### PR TITLE
Remove code that prepares the local nuget package for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ And finally, `pulumi preview` and `pulumi up` as you would any other Pulumi proj
 
 ### Prerequisites
 - Dotnet [SDK v6+](https://dotnet.microsoft.com/download/dotnet/6.0) installed on your machine.
-- Go 1.19 or later (for building and testing `pulumi-language-dotnet`)
-- The Pulumi CLI (for running automation tests) 
+- Go 1.19+
+- The Pulumi CLI
 
 Then you can run one of the following commands:
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ dotnet run integration test <testName>
 dotnet run all-integration-tests
 ```
 
+# Running integration tests
+
+When running integration tests via an IDE like Goland or VSCode, you need to have `~/.pulumi-dev/bin` at the start of your `PATH` environment variable and run `dotnet run install-language-plugin` before running the tests so that it uses the local language plugin, not the one that comes bundled with  your Pulumi CLI.
+
+Alternatively, you can run `dotnet run integration test <testName>` or `dotnet run all-integration-tests` which will install the language plugin for you and put it in the right place just before running the test.
+
 ## Public API Changes
 
 When making changes to the code you may get the following compilation

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ And finally, `pulumi preview` and `pulumi up` as you would any other Pulumi proj
 
 ### Prerequisites
 - Dotnet [SDK v6+](https://dotnet.microsoft.com/download/dotnet/6.0) installed on your machine.
-- Go 1.19+
-- The Pulumi CLI
+- Go 1.19+ for building and testing `pulumi-language-dotnet`
+- The Pulumi CLI (used in automation tests and for integration tests)
 
 Then you can run one of the following commands:
 

--- a/README.md
+++ b/README.md
@@ -103,12 +103,6 @@ dotnet run integration test <testName>
 dotnet run all-integration-tests
 ```
 
-# Running integration tests
-
-When running integration tests via an IDE like Goland or VSCode, you need to have `~/.pulumi-dev/bin` at the start of your `PATH` environment variable and run `dotnet run install-language-plugin` before running the tests so that it uses the local language plugin, not the one that comes bundled with  your Pulumi CLI.
-
-Alternatively, you can run `dotnet run integration test <testName>` or `dotnet run all-integration-tests` which will install the language plugin for you and put it in the right place just before running the test.
-
 ## Public API Changes
 
 When making changes to the code you may get the following compilation

--- a/build/Program.fs
+++ b/build/Program.fs
@@ -24,6 +24,7 @@ let pulumiAutomationSdk = Path.Combine(sdk, "Pulumi.Automation")
 let pulumiAutomationSdkTests = Path.Combine(sdk, "Pulumi.Automation.Tests")
 let pulumiFSharp = Path.Combine(sdk, "Pulumi.FSharp")
 let integrationTests = Path.Combine(repositoryRoot, "integration_tests")
+let pulumiLanguageDotnet = Path.Combine(repositoryRoot, "pulumi-language-dotnet")
 
 /// Runs `dotnet clean` command against the solution file,
 /// then proceeds to delete the `bin` and `obj` directory of each project in the solution
@@ -48,7 +49,10 @@ let restoreSdk() =
     printfn "Restoring Pulumi SDK packages"
     if Shell.Exec("dotnet", "restore --no-cache", sdk) <> 0
     then failwith "restore failed"
-    
+
+/// Returns an array of names of go tests inside ./integration_tests
+/// You can use this to see which tests are available,
+/// then run individual tests using `dotnet run integration test <testName>`
 let integrationTestNames() =
     let cmd = Cli.Wrap("go").WithArguments("test -list=.").WithWorkingDirectory(integrationTests)
     let output = cmd.ExecuteBufferedAsync().GetAwaiter().GetResult()
@@ -69,6 +73,10 @@ let buildSdk() =
     if Shell.Exec("dotnet", "build --configuration Release", sdk) <> 0
     then failwith "build failed"
 
+/// Publishes packages for Pulumi, Pulumi.Automation and Pulumi.FSharp to nuget.
+/// Requires NUGET_PUBLISH_KEY and PULUMI_VERSION environment variables.
+/// When publishing, we check whether the package we are about to publish already exists on Nuget
+/// and if that is the case, we skip it.
 let publishSdks() =
     // prepare
     cleanSdk()
@@ -102,15 +110,15 @@ let publishSdks() =
             failwith $"Some nuget packages were not published: {failedProjectsAtPublishing}"
 
 let cleanLanguagePlugin() = 
-    let plugin = Path.Combine(repositoryRoot, "pulumi-language-dotnet", "pulumi-language-dotnet")
+    let plugin = Path.Combine(pulumiLanguageDotnet, "pulumi-language-dotnet")
     if File.Exists plugin then File.Delete plugin
 
 let buildLanguagePlugin() = 
     cleanLanguagePlugin()
     printfn "Building pulumi-language-dotnet Plugin"
-    if Shell.Exec("go", "build", Path.Combine(repositoryRoot, "pulumi-language-dotnet")) <> 0
+    if Shell.Exec("go", "build", pulumiLanguageDotnet) <> 0
     then failwith "Building pulumi-language-dotnet failed"
-    let output = Path.Combine(repositoryRoot, "pulumi-language-dotnet", "pulumi-language-dotnet")
+    let output = Path.Combine(pulumiLanguageDotnet, "pulumi-language-dotnet")
     printfn $"Built binary {output}"
 
 let testLanguagePlugin() = 
@@ -149,25 +157,9 @@ let syncProtoFiles() = GitSync.repository {
     ]
 }
 
-let preparePulumiSdkNugetLocally() =
-    cleanSdk()
-    if Shell.Exec("dotnet",  "build -p:Version=3.50", pulumiSdk) <> 0 then
-        failwith "Failed to build the local nuget package"
-    
-    let releaseDir = Path.Combine(pulumiSdk, "bin", "Debug")
-    let releaseArtifacts = Directory.EnumerateFiles(releaseDir)
-    if not (releaseArtifacts.Any()) then
-        failwith "couldn't the built nuget package"
-    else
-        let nugetPackageFile = releaseArtifacts.First()
-        let homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
-        let pulumiLocalNugetPath = Path.Combine(homeDir, ".pulumi-dev", "nuget")
-        Directory.ensure pulumiLocalNugetPath
-        Shell.copyFile pulumiLocalNugetPath nugetPackageFile
-
 let runSpecificIntegrationTest(testName: string) = 
     cleanSdk()
-    if Shell.Exec("go", $"test -run=^{testName}$", Path.Combine(repositoryRoot, "integration_tests")) <> 0
+    if Shell.Exec("go", $"test -run=^{testName}$", integrationTests) <> 0
     then failwith $"Integration test '{testName}' failed"
 
 let runAllIntegrationTests() =
@@ -187,7 +179,6 @@ let main(args: string[]) : int =
     | [| "test-automation-sdk" |] -> testPulumiAutomationSdk()
     | [| "publish-sdks" |] -> publishSdks()
     | [| "sync-proto-files" |] -> syncProtoFiles()
-    | [| "prepare-pulumi-sdk-nuget-locally" |] -> preparePulumiSdkNugetLocally()
     | [| "list-integration-tests" |] -> listIntegrationTests()
     | [| "integration"; "test"; testName |] -> runSpecificIntegrationTest testName
     | [| "all-integration-tests" |] -> runAllIntegrationTests()


### PR DESCRIPTION
This removes the function `preparePulumiSdkNugetLocally()` which was to build a local nuget package of the Pulumi SDK for testing inside `~/.pulumi-dev/nuget`. This is no longer needed because the integration tests now use a local project reference instead