### PR TITLE
Use local language plugin for integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ dotnet run build-language-plugin
 # Testing the language plugin
 dotnet run test-language-plugin
 
+# Install the language plugin into ~/.pulumi-dev/bin and prepend it to your PATH (for testing)
+dotnet run install-language-plugin
+
 # Sync proto files from pulumi/pulumi
 dotnet run sync-proto-files
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ dotnet run build-language-plugin
 dotnet run test-language-plugin
 
 # Install the language plugin into ~/.pulumi-dev/bin and prepend it to your PATH (for testing)
+# Not needed when running tests via `dotnet run all-integration-tests` or `dotnet run integration test <testName>`
+# as it will automatically install the language plugin before running the tests.
 dotnet run install-language-plugin
 
 # Sync proto files from pulumi/pulumi

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ dotnet run integration test <testName>
 # Run all integration tests
 dotnet run all-integration-tests
 ```
+# Running integration tests
+
+When running integration tests via an IDE like Goland or VSCode, you need to have `~/.pulumi-dev/bin` at the start of your `PATH` environment variable and run `dotnet run install-language-plugin` before running the tests so that it uses the local language plugin, not the one that comes bundled with  your Pulumi CLI.
+
+Alternatively, you can run `dotnet run integration test <testName>` or `dotnet run all-integration-tests` which will install the language plugin for you and put it in the right place just before running the test.
+
 
 ## Public API Changes
 


### PR DESCRIPTION
Implements `installLanguagePluginLocally()` function which builds `pulumi-language-dotnet` plugin and copies it to `~/.pulumi-dev/bin`. Then prepends the `PATH` with `~/.pulumi-dev/bin` during the process run. 

Used implicitly by:
 - dotnet run integration test <testName> (runs in CI)
 - dotnet run all-integration-tests
