### PR TITLE
Update Pulumi projects to net6.0

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,4 +3,7 @@
 - [auto] Adds SkipInstallDependencies option for Remote Workspaces
   [#64](https://github.com/pulumi/pulumi-dotnet/pull/64)
 
+- [sdk] Drop support for .NET Core 3.1.
+  [#10](https://github.com/pulumi/pulumi-dotnet/pull/10)
+
 ### Bug Fixes

--- a/sdk/Pulumi.Automation/Commands/LocalPulumiCmd.cs
+++ b/sdk/Pulumi.Automation/Commands/LocalPulumiCmd.cs
@@ -143,6 +143,7 @@ namespace Pulumi.Automation.Commands
             public void Dispose()
             {
                 var dir = Path.GetDirectoryName(this.FilePath);
+                System.Diagnostics.Debug.Assert(dir != null, "FilePath had no directory name");
                 try
                 {
                     Directory.Delete(dir, recursive: true);

--- a/sdk/Pulumi.Automation/Pulumi.Automation.csproj
+++ b/sdk/Pulumi.Automation/Pulumi.Automation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>

--- a/sdk/Pulumi.Automation/Serialization/Json/StackSettingsConfigValueJsonConverter.cs
+++ b/sdk/Pulumi.Automation/Serialization/Json/StackSettingsConfigValueJsonConverter.cs
@@ -15,7 +15,7 @@ namespace Pulumi.Automation.Serialization.Json
             // check if plain string
             if (element.ValueKind == JsonValueKind.String)
             {
-                var value = element.GetString();
+                var value = element.GetString()!;
                 return new StackSettingsConfigValue(value, false);
             }
 
@@ -33,8 +33,8 @@ namespace Pulumi.Automation.Serialization.Json
                         {
                             throw new JsonException($"Unable to deserialize [{typeToConvert.FullName}] as a secure string. Expecting a string secret.");
                         }
-                        
-                        return new StackSettingsConfigValue(secureValue.GetString(), true);
+
+                        return new StackSettingsConfigValue(secureValue.GetString()!, true);
                     }
                 }
             }

--- a/sdk/Pulumi.Automation/Serialization/Json/StringToEnumJsonConverter.cs
+++ b/sdk/Pulumi.Automation/Serialization/Json/StringToEnumJsonConverter.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Automation.Serialization.Json
 
         public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return _converter.Convert(reader.GetString());
+            return _converter.Convert(reader.GetString()!);
         }
 
         public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)

--- a/sdk/Pulumi.Automation/Serialization/Json/SystemObjectJsonConverter.cs
+++ b/sdk/Pulumi.Automation/Serialization/Json/SystemObjectJsonConverter.cs
@@ -38,12 +38,12 @@ namespace Pulumi.Automation.Serialization.Json
                     return datetime;
                 }
 
-                return reader.GetString();
+                return reader.GetString()!;
             }
 
             if (reader.TokenType == JsonTokenType.StartArray)
             {
-                return JsonSerializer.Deserialize<object[]>(ref reader, options);
+                return JsonSerializer.Deserialize<object[]>(ref reader, options)!;
             }
 
             if (reader.TokenType == JsonTokenType.StartObject)
@@ -61,7 +61,7 @@ namespace Pulumi.Automation.Serialization.Json
                         throw new JsonException("Unable to retrieve property name.");
 
                     reader.Read();
-                    dictionary[propertyName] = JsonSerializer.Deserialize<object>(ref reader, options);
+                    dictionary[propertyName] = JsonSerializer.Deserialize<object>(ref reader, options)!;
 
                     reader.Read();
                 }

--- a/sdk/Pulumi.Automation/Serialization/LocalSerializer.cs
+++ b/sdk/Pulumi.Automation/Serialization/LocalSerializer.cs
@@ -27,7 +27,7 @@ namespace Pulumi.Automation.Serialization
         }
 
         public T DeserializeJson<T>(string content)
-            => JsonSerializer.Deserialize<T>(content, this._jsonOptions);
+            => JsonSerializer.Deserialize<T>(content, this._jsonOptions)!;
 
         public T DeserializeYaml<T>(string content)
             where T : class
@@ -45,7 +45,7 @@ namespace Pulumi.Automation.Serialization
             var options = new JsonSerializerOptions
             {
                 AllowTrailingCommas = true,
-                IgnoreNullValues = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             };
 

--- a/sdk/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/Pulumi.Automation/WorkspaceStack.cs
@@ -563,7 +563,7 @@ namespace Pulumi.Automation
                 return ImmutableList<UpdateSummary>.Empty;
 
             var jsonOptions = LocalSerializer.BuildJsonSerializerOptions();
-            var list = JsonSerializer.Deserialize<List<UpdateSummary>>(result.StandardOutput, jsonOptions);
+            var list = JsonSerializer.Deserialize<List<UpdateSummary>>(result.StandardOutput, jsonOptions)!;
             return list.ToImmutableList();
         }
 
@@ -705,7 +705,7 @@ namespace Pulumi.Automation
                     try
                     {
                         var serverFeatures = this._host.Services.GetRequiredService<IServer>().Features;
-                        var addresses = serverFeatures.Get<IServerAddressesFeature>().Addresses.ToList();
+                        var addresses = serverFeatures.Get<IServerAddressesFeature>()!.Addresses.ToList();
                         Debug.Assert(addresses.Count == 1, "Server should only be listening on one address");
                         var uri = new Uri(addresses[0]);
                         this._portTcs.TrySetResult(uri.Port);

--- a/sdk/Pulumi.FSharp/Pulumi.FSharp.fsproj
+++ b/sdk/Pulumi.FSharp/Pulumi.FSharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>
     <Company>Pulumi Corp.</Company>

--- a/sdk/Pulumi/Deployment/Deployment_Config.cs
+++ b/sdk/Pulumi/Deployment/Deployment_Config.cs
@@ -86,7 +86,7 @@ namespace Pulumi
                 var envObject = JsonDocument.Parse(envConfigSecretKeys);
                 foreach (var element in envObject.RootElement.EnumerateArray())
                 {
-                    parsedConfigSecretKeys.Add(element.GetString());
+                    parsedConfigSecretKeys.Add(element.ToString());
                 }
             }
 

--- a/sdk/Pulumi/Pulumi.csproj
+++ b/sdk/Pulumi/Pulumi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>


### PR DESCRIPTION
.NET Core 3.1 is out of support on December 13th:
https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core

We've already stopped testing on .NET Core 3.1, and program gen has been targeting only 6.0 for a while now as well.

This updates the core porjects to only 6.0 as well.

We'll still want to do https://github.com/pulumi/pulumi/pull/11543 in pu/pu to update sdkgen.