### PR TITLE
Add `RemoteWorkspaceOptions.SkipInstallDependencies`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
+- [auto] Adds SkipInstallDependencies option for Remote Workspaces
+  [#64](https://github.com/pulumi/pulumi-dotnet/pull/64)
+
 ### Bug Fixes

--- a/sdk/Pulumi.Automation.Tests/RemoteWorkspaceTests.cs
+++ b/sdk/Pulumi.Automation.Tests/RemoteWorkspaceTests.cs
@@ -158,6 +158,7 @@ namespace Pulumi.Automation.Tests
                     $"pulumi config set bar abc --stack {stackName}",
                     $"pulumi config set --secret buzz secret --stack {stackName}",
                 },
+                SkipInstallDependencies = true,
             });
 
             try

--- a/sdk/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/Pulumi.Automation/LocalWorkspace.cs
@@ -40,6 +40,7 @@ namespace Pulumi.Automation
         private readonly RemoteGitProgramArgs? _remoteGitProgramArgs;
         private readonly IDictionary<string, EnvironmentVariableValue>? _remoteEnvironmentVariables;
         private readonly IList<string>? _remotePreRunCommands;
+        private readonly bool _remoteSkipInstallDependencies;
 
         internal Task ReadyTask { get; }
 
@@ -327,6 +328,7 @@ namespace Pulumi.Automation
                 this.SecretsProvider = options.SecretsProvider;
                 this.Remote = options.Remote;
                 this._remoteGitProgramArgs = options.RemoteGitProgramArgs;
+                this._remoteSkipInstallDependencies = options.RemoteSkipInstallDependencies;
 
                 if (options.EnvironmentVariables != null)
                     this.EnvironmentVariables = new Dictionary<string, string?>(options.EnvironmentVariables);
@@ -861,6 +863,11 @@ namespace Pulumi.Automation
                     args.Add("--remote-pre-run-command");
                     args.Add(command);
                 }
+            }
+
+            if (_remoteSkipInstallDependencies)
+            {
+                args.Add("--remote-skip-install-dependencies");
             }
 
             return args;

--- a/sdk/Pulumi.Automation/LocalWorkspaceOptions.cs
+++ b/sdk/Pulumi.Automation/LocalWorkspaceOptions.cs
@@ -84,5 +84,10 @@ namespace Pulumi.Automation
         /// An optional list of arbitrary commands to run before a remote Pulumi operation is invoked.
         /// </summary>
         internal IList<string>? RemotePreRunCommands { get; set; }
+
+        /// <summary>
+        /// Whether to skip the default dependency installation step.
+        /// </summary>
+        internal bool RemoteSkipInstallDependencies { get; set; }
     }
 }

--- a/sdk/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/Pulumi.Automation/Pulumi.Automation.xml
@@ -700,6 +700,11 @@
             An optional list of arbitrary commands to run before a remote Pulumi operation is invoked.
             </summary>
         </member>
+        <member name="P:Pulumi.Automation.LocalWorkspaceOptions.RemoteSkipInstallDependencies">
+            <summary>
+            Whether to skip the default dependency installation step.
+            </summary>
+        </member>
         <member name="P:Pulumi.Automation.PluginInstallOptions.ExactVersion">
             <summary>
             If <c>true</c>, force installation of an exact version match (usually >= is accepted).
@@ -1065,6 +1070,11 @@
         <member name="P:Pulumi.Automation.RemoteWorkspaceOptions.PreRunCommands">
             <summary>
             An optional list of arbitrary commands to run before a remote Pulumi operation is invoked.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteWorkspaceOptions.SkipInstallDependencies">
+            <summary>
+            Whether to skip the default dependency installation step.
             </summary>
         </member>
         <member name="P:Pulumi.Automation.RemoteWorkspaceStack.Name">

--- a/sdk/Pulumi.Automation/RemoteWorkspace.cs
+++ b/sdk/Pulumi.Automation/RemoteWorkspace.cs
@@ -108,6 +108,7 @@ namespace Pulumi.Automation
                 RemoteGitProgramArgs = args,
                 RemoteEnvironmentVariables = args.EnvironmentVariables,
                 RemotePreRunCommands = args.PreRunCommands,
+                RemoteSkipInstallDependencies = args.SkipInstallDependencies,
             };
 
             var ws = new LocalWorkspace(

--- a/sdk/Pulumi.Automation/RemoteWorkspaceOptions.cs
+++ b/sdk/Pulumi.Automation/RemoteWorkspaceOptions.cs
@@ -29,5 +29,10 @@ namespace Pulumi.Automation
             get => _preRunCommands ??= new List<string>();
             set => _preRunCommands = value;
         }
+
+        /// <summary>
+        /// Whether to skip the default dependency installation step.
+        /// </summary>
+        public bool SkipInstallDependencies { get; set; }
     }
 }


### PR DESCRIPTION
Automation API support for the `skipInstallDependencies` Deployments API option.

Depends on https://github.com/pulumi/pulumi/pull/11674

Part of https://github.com/pulumi/pulumi/issues/11357