### PR TITLE
Revert "Update Pulumi projects to net6.0 (#10)"

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,12 +1,6 @@
 ### Improvements
 
-- [auto] Adds SkipInstallDependencies option for Remote Workspaces
-  [#64](https://github.com/pulumi/pulumi-dotnet/pull/64)
-
-- [sdk] Drop support for .NET Core 3.1.
-  [#10](https://github.com/pulumi/pulumi-dotnet/pull/10)
-
-- [sdk] Add Output.JsonDeserialize.
-  [#65](https://github.com/pulumi/pulumi-dotnet/pull/65)
+- [revert] Re-introduce support for .NET Core 3.1 via multi-targeting.
+  [#XX](https://github.com/pulumi/pulumi-dotnet/pull/XX)
 
 ### Bug Fixes

--- a/sdk/Pulumi.Automation/Pulumi.Automation.csproj
+++ b/sdk/Pulumi.Automation/Pulumi.Automation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>

--- a/sdk/Pulumi.Automation/Serialization/LocalSerializer.cs
+++ b/sdk/Pulumi.Automation/Serialization/LocalSerializer.cs
@@ -45,7 +45,11 @@ namespace Pulumi.Automation.Serialization
             var options = new JsonSerializerOptions
             {
                 AllowTrailingCommas = true,
+#if NETCOREAPP3_1
+                IgnoreNullValues = true,
+#else
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+#endif
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             };
 

--- a/sdk/Pulumi.FSharp/Pulumi.FSharp.fsproj
+++ b/sdk/Pulumi.FSharp/Pulumi.FSharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>
     <Company>Pulumi Corp.</Company>

--- a/sdk/Pulumi/Core/Output.cs
+++ b/sdk/Pulumi/Core/Output.cs
@@ -217,9 +217,32 @@ namespace Pulumi
                 // This needs to handle nested potentially secret and unknown Output values, we do this by
                 // hooking options to handle any seen Output<T> values.
 
+                // TODO: This can be simplified in net6.0 to just new System.Text.Json.JsonSerializerOptions(options);
+#if NETCOREAPP3_1
+                var internalOptions = new System.Text.Json.JsonSerializerOptions();
+                internalOptions.AllowTrailingCommas = options?.AllowTrailingCommas ?? internalOptions.AllowTrailingCommas;
+                if (options != null)
+                {
+                    foreach (var converter in options.Converters)
+                    {
+                        internalOptions.Converters.Add(converter);
+                    }
+                }
+                internalOptions.DefaultBufferSize = options?.DefaultBufferSize ?? internalOptions.DefaultBufferSize;
+                internalOptions.DictionaryKeyPolicy = options?.DictionaryKeyPolicy ?? internalOptions.DictionaryKeyPolicy;
+                internalOptions.Encoder = options?.Encoder ?? internalOptions.Encoder;
+                internalOptions.IgnoreNullValues = options?.IgnoreNullValues ?? internalOptions.IgnoreNullValues;
+                internalOptions.IgnoreReadOnlyProperties = options?.IgnoreReadOnlyProperties ?? internalOptions.IgnoreReadOnlyProperties;
+                internalOptions.MaxDepth = options?.MaxDepth ?? internalOptions.MaxDepth;
+                internalOptions.PropertyNameCaseInsensitive = options?.PropertyNameCaseInsensitive ?? internalOptions.PropertyNameCaseInsensitive;
+                internalOptions.PropertyNamingPolicy = options?.PropertyNamingPolicy ?? internalOptions.PropertyNamingPolicy;
+                internalOptions.ReadCommentHandling = options?.ReadCommentHandling ?? internalOptions.ReadCommentHandling;
+                internalOptions.WriteIndented = options?.WriteIndented ?? internalOptions.WriteIndented;
+#else
                 var internalOptions = options == null ?
                     new System.Text.Json.JsonSerializerOptions() :
                     new System.Text.Json.JsonSerializerOptions(options);
+#endif
 
                 // Add the magic converter to allow us to do nested outputs
                 var outputConverter = new OutputJsonConverter(result.Resources, result.IsSecret);
@@ -264,9 +287,31 @@ namespace Pulumi
                     return new OutputData<T>(result.Resources, default!, false, result.IsSecret);
                 }
 
+#if NETCOREAPP3_1
+                var internalOptions = new System.Text.Json.JsonSerializerOptions();
+                internalOptions.AllowTrailingCommas = options?.AllowTrailingCommas ?? internalOptions.AllowTrailingCommas;
+                if (options != null)
+                {
+                    foreach (var converter in options.Converters)
+                    {
+                        internalOptions.Converters.Add(converter);
+                    }
+                }
+                internalOptions.DefaultBufferSize = options?.DefaultBufferSize ?? internalOptions.DefaultBufferSize;
+                internalOptions.DictionaryKeyPolicy = options?.DictionaryKeyPolicy ?? internalOptions.DictionaryKeyPolicy;
+                internalOptions.Encoder = options?.Encoder ?? internalOptions.Encoder;
+                internalOptions.IgnoreNullValues = options?.IgnoreNullValues ?? internalOptions.IgnoreNullValues;
+                internalOptions.IgnoreReadOnlyProperties = options?.IgnoreReadOnlyProperties ?? internalOptions.IgnoreReadOnlyProperties;
+                internalOptions.MaxDepth = options?.MaxDepth ?? internalOptions.MaxDepth;
+                internalOptions.PropertyNameCaseInsensitive = options?.PropertyNameCaseInsensitive ?? internalOptions.PropertyNameCaseInsensitive;
+                internalOptions.PropertyNamingPolicy = options?.PropertyNamingPolicy ?? internalOptions.PropertyNamingPolicy;
+                internalOptions.ReadCommentHandling = options?.ReadCommentHandling ?? internalOptions.ReadCommentHandling;
+                internalOptions.WriteIndented = options?.WriteIndented ?? internalOptions.WriteIndented;
+#else
                 var internalOptions = options == null ?
                     new System.Text.Json.JsonSerializerOptions() :
                     new System.Text.Json.JsonSerializerOptions(options);
+#endif
 
                 // Add the magic converter to allow us to do nested outputs
                 var outputConverter = new OutputJsonConverter(result.Resources, result.IsSecret);

--- a/sdk/Pulumi/Pulumi.csproj
+++ b/sdk/Pulumi/Pulumi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>


### PR DESCRIPTION
This reverts commit e06f542aac0535c85e260d291d0d5df8e496ab83.

This is needed to give providers time to upgrade codegen. We messed up the ordering here thinking we needed to release a 6.0 library, but we can update the provider libraries to 6.0 and have them consume Pulumi.nuget at 3.1.