### PR TITLE
Multi-target netcoreapp3.1 and net6.0

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,6 @@
 ### Improvements
 
-- [revert] Re-introduce support for .NET Core 3.1 via multi-targeting.
-  [#XX](https://github.com/pulumi/pulumi-dotnet/pull/XX)
+- [sdk] Multi-target .NET Core 3.1 and .NET 6.0.
+  [#69](https://github.com/pulumi/pulumi-dotnet/pull/69)
 
 ### Bug Fixes

--- a/integration_tests/integration_util_test.go
+++ b/integration_tests/integration_util_test.go
@@ -92,12 +92,20 @@ func prepareDotnetProject(projInfo *engine.Projinfo) error {
 				continue
 			}
 
+			packageReference := fmt.Sprintf(`<ProjectReference Include="%s" />`, pulumiSdkPath)
+
+			// If we're running edit tests we might have already have added the ProjectReference (edit tests
+			// rerun prepareProject)
+			if strings.Contains(string(projectContent), packageReference) {
+				continue
+			}
+
 			modifiedContent := fmt.Sprintf(`
 	<ItemGroup>
-		<ProjectReference Include="%s" />
+		%s
 	</ItemGroup>
 </Project>
-`, pulumiSdkPath)
+`, packageReference)
 
 			modifiedProjectContent := strings.ReplaceAll(string(projectContent), "</Project>", modifiedContent)
 			err = os.WriteFile(projectPath, []byte(modifiedProjectContent), 0644)

--- a/sdk/Pulumi.Automation/Pulumi.Automation.csproj
+++ b/sdk/Pulumi.Automation/Pulumi.Automation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>

--- a/sdk/Pulumi.FSharp/Pulumi.FSharp.fsproj
+++ b/sdk/Pulumi.FSharp/Pulumi.FSharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>
     <Company>Pulumi Corp.</Company>

--- a/sdk/Pulumi/Pulumi.csproj
+++ b/sdk/Pulumi/Pulumi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>


### PR DESCRIPTION
Update all the SDKs to multi-target netcoreapp3.1 and net6.0. Small change because I had the leftovers of trying to target net6.0 still checked in via `#if` blocks.