### PR TITLE
[sdk] Delegates alias computation to engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.52.0
+# 3.52.0 (2023-01-17)
 
 ### Improvements
 
@@ -7,3 +7,5 @@
   complete enough to try out, and we hope to get feedback on the interface to refine and stabilize this
   shortly.
   [#76](https://github.com/pulumi/pulumi-dotnet/pull/76)
+
+### Bug Fixes

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,12 +1,14 @@
 ### Improvements
 
+- [sdk] Delegates alias computation to engine [#14](https://github.com/pulumi/pulumi-dotnet/issues/14)
+
+### Bug Fixes
+
 - [sdk] Work around a port parsing bug in the engine when using providers.
   [#82](https://github.com/pulumi/pulumi-dotnet/pull/82)
 
 - [sdk] Rename "ID" properties to "Id" in the provider interfaces.
   [#84](https://github.com/pulumi/pulumi-dotnet/pull/84)
-
-### Bug Fixes
 
 - [sdk] Fix a mixup of Urn and Id in the provider interface.
   [#83](https://github.com/pulumi/pulumi-dotnet/pull/83)

--- a/sdk/Pulumi.Tests/Mocks/Aliases.cs
+++ b/sdk/Pulumi.Tests/Mocks/Aliases.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,7 +13,25 @@ namespace Pulumi.Tests.Mocks.Aliases
     {
         public AliasesStack()
         {
-            var parent1 = new Pulumi.CustomResource("test:resource:type", "myres1", null, new CustomResourceOptions { });
+            // create 1000 aliases
+            var manyAliases = Enumerable.Range(0, 1000).Select(i =>
+            {
+                Input<Alias> alias = new Alias
+                {
+                    Name = $"myres{i}",
+                    Project = "myproject",
+                    Stack = "mystack",
+                    Type = "test:resource:type"
+                };
+
+                return alias;
+            });
+
+            var parent1 = new Pulumi.CustomResource("test:resource:type", "myres1", null, new CustomResourceOptions
+            {
+                Aliases = manyAliases.ToList()
+            });
+
             var child1 = new Pulumi.CustomResource("test:resource:child", "myres1-child", null, new CustomResourceOptions
             {
                 Parent = parent1,

--- a/sdk/Pulumi.Tests/Mocks/MocksTests.cs
+++ b/sdk/Pulumi.Tests/Mocks/MocksTests.cs
@@ -193,6 +193,10 @@ namespace Pulumi.Tests.Mocks
             var resources = await Deployment.TestAsync<Aliases.AliasesStack>(
                 new Aliases.AliasesMocks());
 
+            // simply assert that we have some resources
+            // here we only case about not having an alias computation explosion
+            Assert.NotEmpty(resources);
+
             // TODO[pulumi/pulumi#8637]
             //
             // var parent1Urn = await resources[1].Urn.GetValueAsync("");
@@ -202,47 +206,6 @@ namespace Pulumi.Tests.Mocks
             // `pulumi:pulumi:Stack` as an explicit parent type in the URN. This should not happen, and indicates
             // a bug in the the Pulumi .NET SDK unrelated to Aliases.  It appears this only happens when using the
             // .NET mock testing framework, not when running normal programs.
-            var expected = new Dictionary<string, List<string>>{
-                { "myres1-child", new List<string>{}},
-                { "myres2-child", new List<string>{
-                    "urn:pulumi:stack::project::pulumi:pulumi:Stack$test:resource:type$test:resource:child2::myres2-child"
-                }},
-                { "myres3-child", new List<string>{
-                    "urn:pulumi:stack::project::pulumi:pulumi:Stack$test:resource:type$test:resource:child::child2"
-                }},
-                { "myres4-child", new List<string>{
-                    "urn:pulumi:stack::project::pulumi:pulumi:Stack$test:resource:type$test:resource:child::myres4-child2",
-                    "urn:pulumi:stack::project::test:resource:type3$test:resource:child::myres4-child",
-                    "urn:pulumi:stack::project::test:resource:type3$test:resource:child::myres4-child2",
-                }},
-                { "myres5-child", new List<string>{
-                    "urn:pulumi:stack::project::pulumi:pulumi:Stack$test:resource:type$test:resource:child::myres5-child2",
-                    "urn:pulumi:stack::project::test:resource:type$test:resource:child::myres52-child",
-                    "urn:pulumi:stack::project::test:resource:type$test:resource:child::myres52-child2",
-                }},
-                { "myres6-child", new List<string>{
-                    "urn:pulumi:stack::project::pulumi:pulumi:Stack$test:resource:type$test:resource:child::myres6-child2",
-                    "urn:pulumi:stack::project::pulumi:pulumi:Stack$test:resource:type$test:resource:child2::myres6-child",
-                    "urn:pulumi:stack::project::test:resource:type$test:resource:child::myres62-child",
-                    "urn:pulumi:stack::project::test:resource:type$test:resource:child::myres62-child2",
-                    "urn:pulumi:stack::project::test:resource:type$test:resource:child2::myres62-child",
-                    "urn:pulumi:stack::project::test:resource:type3$test:resource:child::myres6-child",
-                    "urn:pulumi:stack::project::test:resource:type3$test:resource:child::myres6-child2",
-                    "urn:pulumi:stack::project::test:resource:type3$test:resource:child2::myres6-child",
-                    "urn:pulumi:stack::project::test:resource:type$test:resource:child::myres63-child",
-                    "urn:pulumi:stack::project::test:resource:type$test:resource:child::myres63-child2",
-                    "urn:pulumi:stack::project::test:resource:type$test:resource:child2::myres63-child",
-                }},
-
-            };
-            foreach (var resource in resources)
-            {
-                if (resource.GetResourceType() == "test:resource:child")
-                {
-                    var aliases = await Output.All(resource._aliases).GetValueAsync(ImmutableArray.Create<string>());
-                    Assert.Equal<string>(expected[resource.GetResourceName()], aliases);
-                }
-            }
         }
     }
 

--- a/sdk/Pulumi/Deployment/Deployment.cs
+++ b/sdk/Pulumi/Deployment/Deployment.cs
@@ -222,6 +222,15 @@ namespace Pulumi
             return MonitorSupportsFeature("deletedWith");
         }
 
+        /// <summary>
+        /// Returns whether the resource monitor we are connected to supports the "aliasSpec" feature across the RPC interface.
+        /// In which case we no longer compute alias combinations ourselves but instead delegate the work to the engine.
+        /// </summary>
+        internal Task<bool> MonitorSupportsAliasSpec()
+        {
+            return MonitorSupportsFeature("aliasSpec");
+        }
+
         // Because the secrets feature predates the Pulumi .NET SDK, we assume
         // that the monitor supports secrets.
     }

--- a/sdk/Pulumi/Deployment/Deployment_RegisterResource.cs
+++ b/sdk/Pulumi/Deployment/Deployment_RegisterResource.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading.Tasks;
 using Google.Protobuf.WellKnownTypes;
 using Pulumirpc;
@@ -58,7 +59,16 @@ namespace Pulumi
             request.Parent = prepareResult.ParentUrn;
             request.Provider = prepareResult.ProviderRef;
             request.Providers.Add(prepareResult.ProviderRefs);
-            request.AliasURNs.AddRange(prepareResult.AliasURNs);
+            if (prepareResult.SupportsAliasSpec)
+            {
+                request.Aliases.AddRange(prepareResult.Aliases);
+            }
+            else
+            {
+                var aliasUrns = prepareResult.Aliases.Select(a => a.Urn);
+                request.AliasURNs.AddRange(aliasUrns);
+            }
+
             request.Dependencies.AddRange(prepareResult.AllDirectDependencyUrns);
 
             foreach (var (key, resourceUrns) in prepareResult.PropertyToDirectDependencyUrns)

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -858,6 +858,12 @@
             Check if the monitor supports the "outputValues" feature.
             </summary>
         </member>
+        <member name="M:Pulumi.Deployment.MonitorSupportsAliasSpec">
+            <summary>
+            Returns whether the resource monitor we are connected to supports the "aliasSpec" feature across the RPC interface.
+            In which case we no longer compute alias combinations ourselves but instead delegate the work to the engine.
+            </summary>
+        </member>
         <member name="M:Pulumi.Deployment.EngineLogger.Pulumi#IEngineLogger#DebugAsync(System.String,Pulumi.Resource,System.Nullable{System.Int32},System.Nullable{System.Boolean})">
             <summary>
             Logs a debug-level message that is generally hidden from end-users.
@@ -952,6 +958,13 @@
             <summary>
             Recursively walk the resources passed in, returning them and all resources reachable from
             <see cref="P:Pulumi.Resource.ChildResources"/> through any **Component** resources we encounter.
+            </summary>
+        </member>
+        <member name="F:Pulumi.Deployment.PrepareResult.SupportsAliasSpec">
+            <summary>
+            Returns whether the resource monitor we are connected to supports the "aliasSpec" feature across the RPC interface.
+            When that is not the case, use only use the URNs of the aliases to populate the AliasURNs field of RegisterResourceRequest,
+            otherwise we pass the full structure of the Aliases field to the resource monitor.
             </summary>
         </member>
         <member name="M:Pulumi.Deployment.CompleteResourceAsync(Pulumi.Resource,System.Boolean,System.Func{System.String,Pulumi.Resource},Pulumi.ResourceArgs,Pulumi.ResourceOptions,System.Collections.Immutable.ImmutableDictionary{System.String,Pulumi.Serialization.IOutputCompletionSource})">
@@ -1965,11 +1978,6 @@
             A collection of transformations to apply as part of resource registration.
             </summary>
         </member>
-        <member name="F:Pulumi.Resource._aliases">
-            <summary>
-            A list of aliases applied to this resource.
-            </summary>
-        </member>
         <member name="M:Pulumi.Resource.GetResourceType">
             <summary>
             The type assigned to the resource at construction.
@@ -2019,14 +2027,6 @@
         <member name="M:Pulumi.Resource.GetProvider(System.String)">
             <summary>
             Fetches the provider for the given module member, if any.
-            </summary>
-        </member>
-        <member name="M:Pulumi.Resource.AllAliases(System.Collections.Generic.List{Pulumi.Input{Pulumi.Alias}},System.String,System.String,Pulumi.Resource)">
-            <summary>
-            <see cref="M:Pulumi.Resource.AllAliases(System.Collections.Generic.List{Pulumi.Input{Pulumi.Alias}},System.String,System.String,Pulumi.Resource)"/> makes a copy of the aliases array, and add to it any 
-            implicit aliases inherited from its parent. If there are N child aliases, and
-            M parent aliases, there will be (M+1)*(N+1)-1 total aliases, or, as calculated
-            in the logic below, N+(M*(1+N)).
             </summary>
         </member>
         <member name="T:Pulumi.ResourceArgs">

--- a/sdk/Pulumi/Resources/Resource.cs
+++ b/sdk/Pulumi/Resources/Resource.cs
@@ -72,11 +72,6 @@ namespace Pulumi
         private readonly ImmutableArray<ResourceTransformation> _transformations;
 
         /// <summary>
-        /// A list of aliases applied to this resource.
-        /// </summary>
-        internal readonly ImmutableArray<Input<string>> _aliases;
-
-        /// <summary>
         /// The type assigned to the resource at construction.
         /// </summary>
         // This is a method and not a property to not collide with potential subclass property names.
@@ -262,7 +257,6 @@ namespace Pulumi
             this._provider = custom ? options.Provider : null;
             this._version = options.Version;
             this._pluginDownloadURL = options.PluginDownloadURL;
-            this._aliases = AllAliases(options.Aliases.ToList(), name, type, options.Parent);
 
             Deployment.InternalInstance.ReadOrRegisterResource(this, remote, urn => new DependencyResource(urn), args, options);
         }
@@ -280,114 +274,6 @@ namespace Pulumi
 
             this._providers.TryGetValue(memComponents[0], out var result);
             return result;
-        }
-
-        private static Output<string> CollapseAliasToUrn(
-            Input<Alias> alias,
-            string defaultName,
-            string defaultType,
-            Resource? defaultParent)
-        {
-            return alias.ToOutput().Apply(a =>
-            {
-                if (a.Urn != null)
-                {
-                    CheckNull(a.Name, nameof(a.Name));
-                    CheckNull(a.Type, nameof(a.Type));
-                    CheckNull(a.Project, nameof(a.Project));
-                    CheckNull(a.Stack, nameof(a.Stack));
-                    CheckNull(a.Parent, nameof(a.Parent));
-                    CheckNull(a.ParentUrn, nameof(a.ParentUrn));
-                    if (a.NoParent)
-                        ThrowAliasPropertyConflict(nameof(a.NoParent));
-
-                    return Output.Create(a.Urn);
-                }
-
-                var name = a.Name ?? defaultName;
-                var type = a.Type ?? defaultType;
-                var project = a.Project ?? Deployment.Instance.ProjectName;
-                var stack = a.Stack ?? Deployment.Instance.StackName;
-
-                var parentCount =
-                    (a.Parent != null ? 1 : 0) +
-                    (a.ParentUrn != null ? 1 : 0) +
-                    (a.NoParent ? 1 : 0);
-
-                if (parentCount >= 2)
-                {
-                    throw new ArgumentException(
-$"Only specify one of '{nameof(Alias.Parent)}', '{nameof(Alias.ParentUrn)}' or '{nameof(Alias.NoParent)}' in an {nameof(Alias)}");
-                }
-
-                var (parent, parentUrn) = GetParentInfo(defaultParent, a);
-
-                if (name == null)
-                    throw new Exception("No valid 'Name' passed in for alias.");
-
-                if (type == null)
-                    throw new Exception("No valid 'type' passed in for alias.");
-
-                return Pulumi.Urn.Create(name, type, parent, parentUrn, project, stack);
-            });
-        }
-
-        /// <summary>
-        /// <see cref="AllAliases"/> makes a copy of the aliases array, and add to it any 
-        /// implicit aliases inherited from its parent. If there are N child aliases, and
-        /// M parent aliases, there will be (M+1)*(N+1)-1 total aliases, or, as calculated
-        /// in the logic below, N+(M*(1+N)).
-        /// </summary>
-        internal static ImmutableArray<Input<string>> AllAliases(List<Input<Alias>> childAliases, string childName, string childType, Resource? parent)
-        {
-            var aliases = ImmutableArray.CreateBuilder<Input<string>>();
-            foreach (var childAlias in childAliases)
-            {
-                aliases.Add(CollapseAliasToUrn(childAlias, childName, childType, parent));
-            }
-            if (parent != null)
-            {
-                foreach (var parentAlias in parent._aliases)
-                {
-                    aliases.Add(Pulumi.Urn.InheritedChildAlias(childName, parent._name, parentAlias, childType));
-                    foreach (var childAlias in childAliases)
-                    {
-                        var inheritedAlias = CollapseAliasToUrn(childAlias, childName, childType, parent).Apply(childAliasURN =>
-                        {
-                            var aliasedChildName = Pulumi.Urn.Name(childAliasURN);
-                            var aliasedChildType = Pulumi.Urn.Type(childAliasURN);
-                            return Pulumi.Urn.InheritedChildAlias(aliasedChildName, parent._name, parentAlias, aliasedChildType);
-                        });
-                        aliases.Add(inheritedAlias);
-                    }
-                }
-            }
-            return aliases.ToImmutable();
-        }
-
-        private static void CheckNull<T>(T? value, string name) where T : class
-        {
-            if (value != null)
-            {
-                ThrowAliasPropertyConflict(name);
-            }
-        }
-
-        private static void ThrowAliasPropertyConflict(string name)
-            => throw new ArgumentException($"{nameof(Alias)} should not specify both {nameof(Alias.Urn)} and {name}");
-
-        private static (Resource? parent, Input<string>? urn) GetParentInfo(Resource? defaultParent, Alias alias)
-        {
-            if (alias.Parent != null)
-                return (alias.Parent, null);
-
-            if (alias.ParentUrn != null)
-                return (null, alias.ParentUrn);
-
-            if (alias.NoParent)
-                return (null, null);
-
-            return (defaultParent, null);
         }
 
         private static ImmutableDictionary<string, ProviderResource> ConvertToProvidersMap(List<ProviderResource>? providers)


### PR DESCRIPTION
Fixes #14 

Removes `AllAliases` function and instead constructs a`List<Pulumirpc.Alias>` in `PrepareAliases` (linear time) which populates the `RegisterResourceRequest` accordingly:
```csharp
if (prepareResult.SupportsAliasSpec) 
{
    request.Aliases.AddRange(prepareResult.Aliases);
}
else 
{
    var aliasUrns = prepareResult.Aliases.Select(a => a.Urn);
    request.AliasURNs.AddRange(aliasUrns);
}
```
Wasn't exactly sure how to test this other than constructing a lot (=1000) of aliases in `AliasesMocks` and _observe_ that it doesn't just hang for a while. 

All integration tests are succeeding locally except for `TestProvider` but that seems unrelated. Let's see what CI has to say about it. 