### PR TITLE
Consistently case Id in provider interface

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,8 +1,10 @@
 ### Improvements
 
-
 - [sdk] Work around a port parsing bug in the engine when using providers.
   [#82](https://github.com/pulumi/pulumi-dotnet/pull/82)
+
+- [sdk] Rename "ID" properties to "Id" in the provider interfaces.
+  [#84](https://github.com/pulumi/pulumi-dotnet/pull/84)
 
 ### Bug Fixes
 

--- a/integration_tests/testprovider/TestProvider.cs
+++ b/integration_tests/testprovider/TestProvider.cs
@@ -90,7 +90,7 @@ public class TestProvider : Provider {
 
             ++this.id;
             return Task.FromResult(new CreateResponse() {
-                ID = this.id.ToString(),
+                Id = this.id.ToString(),
                 Properties = outputs,
             });
         }
@@ -110,7 +110,7 @@ public class TestProvider : Provider {
             outputs.Add("result", new PropertyValue(result));
 
             return Task.FromResult(new CreateResponse() {
-                ID = result,
+                Id = result,
                 Properties = outputs,
             });
         }
@@ -126,7 +126,7 @@ public class TestProvider : Provider {
     public override Task<ReadResponse> Read(ReadRequest request, CancellationToken ct)
     {
         var response = new ReadResponse() {
-            ID = request.ID,
+            Id = request.Id,
             Properties = request.Properties,
         };
         return Task.FromResult(response);

--- a/sdk/Pulumi/Provider/PropertyValue.cs
+++ b/sdk/Pulumi/Provider/PropertyValue.cs
@@ -28,19 +28,19 @@ namespace Pulumi.Experimental.Provider
     public readonly struct ResourceReference : IEquatable<ResourceReference>
     {
         public readonly string URN;
-        public readonly PropertyValue ID;
+        public readonly PropertyValue Id;
         public readonly string PackageVersion;
 
         public ResourceReference(string urn, PropertyValue id, string version)
         {
             URN = urn;
-            ID = id;
+            Id = id;
             PackageVersion = version;
         }
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(URN, ID, PackageVersion);
+            return HashCode.Combine(URN, Id, PackageVersion);
         }
 
         public override bool Equals(object? obj)
@@ -54,7 +54,7 @@ namespace Pulumi.Experimental.Provider
 
         public bool Equals(ResourceReference other)
         {
-            return URN == other.URN && ID.Equals(other.ID) && PackageVersion == other.PackageVersion;
+            return URN == other.URN && Id.Equals(other.Id) && PackageVersion == other.PackageVersion;
         }
     }
 
@@ -872,7 +872,7 @@ namespace Pulumi.Experimental.Provider
                     var result = new Struct();
                     result.Fields[Constants.SpecialSigKey] = Value.ForString(Constants.SpecialResourceSig);
                     result.Fields[Constants.UrnPropertyName] = Value.ForString(resource.URN);
-                    result.Fields[Constants.IdPropertyName] = Unmarshal(resource.ID);
+                    result.Fields[Constants.IdPropertyName] = Unmarshal(resource.Id);
                     if (resource.PackageVersion != "")
                     {
                         result.Fields[Constants.ResourceVersionName] = Value.ForString(resource.PackageVersion);

--- a/sdk/Pulumi/Provider/Provider.cs
+++ b/sdk/Pulumi/Provider/Provider.cs
@@ -69,7 +69,7 @@ namespace Pulumi.Experimental.Provider
         public readonly string Urn;
         public string Type => Pulumi.Urn.Type(Urn);
         public string Name => Pulumi.Urn.Name(Urn);
-        public readonly string ID;
+        public readonly string Id;
         public readonly ImmutableDictionary<string, PropertyValue> Olds;
         public readonly ImmutableDictionary<string, PropertyValue> News;
         public readonly ImmutableArray<string> IgnoreChanges;
@@ -77,7 +77,7 @@ namespace Pulumi.Experimental.Provider
         public DiffRequest(string urn, string id, ImmutableDictionary<string, PropertyValue> olds, ImmutableDictionary<string, PropertyValue> news, ImmutableArray<string> ignoreChanges)
         {
             Urn = urn;
-            ID = id;
+            Id = id;
             Olds = olds;
             News = news;
             IgnoreChanges = ignoreChanges;
@@ -197,14 +197,14 @@ namespace Pulumi.Experimental.Provider
 
     public sealed class CreateResponse
     {
-        public string? ID { get; set; }
+        public string? Id { get; set; }
         public IDictionary<string, PropertyValue>? Properties { get; set; }
     }
 
     public sealed class ReadRequest
     {
         public readonly string Urn;
-        public readonly string ID;
+        public readonly string Id;
         public string Type => Pulumi.Urn.Type(Urn);
         public string Name => Pulumi.Urn.Name(Urn);
         public readonly ImmutableDictionary<string, PropertyValue> Properties;
@@ -213,7 +213,7 @@ namespace Pulumi.Experimental.Provider
         public ReadRequest(string urn, string id, ImmutableDictionary<string, PropertyValue> properties, ImmutableDictionary<string, PropertyValue> inputs)
         {
             Urn = urn;
-            ID = id;
+            Id = id;
             Properties = properties;
             Inputs = inputs;
         }
@@ -221,7 +221,7 @@ namespace Pulumi.Experimental.Provider
 
     public sealed class ReadResponse
     {
-        public string? ID { get; set; }
+        public string? Id { get; set; }
         public IDictionary<string, PropertyValue>? Properties { get; set; }
         public IDictionary<string, PropertyValue>? Inputs { get; set; }
     }
@@ -229,7 +229,7 @@ namespace Pulumi.Experimental.Provider
     public sealed class UpdateRequest
     {
         public readonly string Urn;
-        public readonly string ID;
+        public readonly string Id;
         public string Type => Pulumi.Urn.Type(Urn);
         public string Name => Pulumi.Urn.Name(Urn);
         public readonly ImmutableDictionary<string, PropertyValue> Olds;
@@ -241,7 +241,7 @@ namespace Pulumi.Experimental.Provider
         public UpdateRequest(string urn, string id, ImmutableDictionary<string, PropertyValue> olds, ImmutableDictionary<string, PropertyValue> news, TimeSpan timeout, ImmutableArray<string> ignoreChanges, bool preview)
         {
             Urn = urn;
-            ID = id;
+            Id = id;
             Olds = olds;
             News = news;
             Timeout = timeout;
@@ -258,7 +258,7 @@ namespace Pulumi.Experimental.Provider
     public sealed class DeleteRequest
     {
         public readonly string Urn;
-        public readonly string ID;
+        public readonly string Id;
         public string Type => Pulumi.Urn.Type(Urn);
         public string Name => Pulumi.Urn.Name(Urn);
         public readonly ImmutableDictionary<string, PropertyValue> Properties;
@@ -267,7 +267,7 @@ namespace Pulumi.Experimental.Provider
         public DeleteRequest(string urn, string id, ImmutableDictionary<string, PropertyValue> properties, TimeSpan timeout)
         {
             Urn = urn;
-            ID = id;
+            Id = id;
             Properties = properties;
             Timeout = timeout;
         }
@@ -705,7 +705,7 @@ namespace Pulumi.Experimental.Provider
                 using var cts = GetToken(context);
                 var domResponse = await Implementation.Create(domRequest, cts.Token);
                 var grpcResponse = new Pulumirpc.CreateResponse();
-                grpcResponse.Id = domResponse.ID ?? "";
+                grpcResponse.Id = domResponse.Id ?? "";
                 grpcResponse.Properties = domResponse.Properties == null ? null : PropertyValue.Unmarshal(domResponse.Properties);
                 return grpcResponse;
             }
@@ -731,7 +731,7 @@ namespace Pulumi.Experimental.Provider
                 using var cts = GetToken(context);
                 var domResponse = await Implementation.Read(domRequest, cts.Token);
                 var grpcResponse = new Pulumirpc.ReadResponse();
-                grpcResponse.Id = domResponse.ID ?? "";
+                grpcResponse.Id = domResponse.Id ?? "";
                 grpcResponse.Properties = domResponse.Properties == null ? null : PropertyValue.Unmarshal(domResponse.Properties);
                 grpcResponse.Inputs = domResponse.Inputs == null ? null : PropertyValue.Unmarshal(domResponse.Inputs);
                 return grpcResponse;


### PR DESCRIPTION
Other places in the Pulumi SDK use "Id" not "ID". That is also inline with Microsoft naming guidance.