### PR TITLE
Run tests on the production service

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,8 +13,7 @@ on:
       - 'CHANGELOG_PENDING.md'
 
 env:
-  PULUMI_API: https://api.pulumi-staging.io
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN_PRODUCTION }}
   AWS_REGION: us-west-2
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PULUMI_TEST_OWNER: "moolumi"

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -29,8 +29,7 @@ env:
   PULUMI_VERSION: ${{ inputs.version }}
   GITHUB_REF: ${{ inputs.ref }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
-  PULUMI_API: https://api.pulumi-staging.io
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN_PRODUCTION }}
   AWS_REGION: us-west-2
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The Pulumi Staging GitHub App is configured for all repos in the `pulumi` org. Any pulumi updates from staging will result in preview/update comments added on PRs. This adds a lot of unnecessary noise when running automation API tests in this repo.

This PR switches to using the production service like what is used in `pulumi/pulumi`, which avoids these comments since the production Pulumi GitHub App isn't configured for `pulumi` repos.

## Before

We'd get a bunch of comments like:

<img width="935" alt="Screen Shot 2023-01-20 at 12 17 08 PM" src="https://user-images.githubusercontent.com/710598/213797782-ff9a2ad2-b392-4f24-a555-a09db8bd04f3.png">


## After

No more comment noise