### PR TITLE
[sdk] Correctly check for alias support in the engine and map fully specified alias urns

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,4 @@
 ### Improvements
 
 ### Bug Fixes
+ - [sdk] Correctly check for alias support in the engine and map fully specified alias urns [#88](https://github.com/pulumi/pulumi-dotnet/pull/88)

--- a/sdk/Pulumi/Deployment/Deployment.cs
+++ b/sdk/Pulumi/Deployment/Deployment.cs
@@ -226,9 +226,9 @@ namespace Pulumi
         /// Returns whether the resource monitor we are connected to supports the "aliasSpec" feature across the RPC interface.
         /// In which case we no longer compute alias combinations ourselves but instead delegate the work to the engine.
         /// </summary>
-        internal Task<bool> MonitorSupportsAliasSpec()
+        internal Task<bool> MonitorSupportsAliasSpecs()
         {
-            return MonitorSupportsFeature("aliasSpec");
+            return MonitorSupportsFeature("aliasSpecs");
         }
 
         // Because the secrets feature predates the Pulumi .NET SDK, we assume

--- a/sdk/Pulumi/Deployment/Deployment_Prepare.cs
+++ b/sdk/Pulumi/Deployment/Deployment_Prepare.cs
@@ -116,8 +116,8 @@ namespace Pulumi
                 propertyToDirectDependencyUrns[propertyName] = urns;
             }
 
-            var resourceMonitorSupportsAliasSpec = await MonitorSupportsAliasSpec().ConfigureAwait(false);
-            var aliases = await PrepareAliases(res, options, resourceMonitorSupportsAliasSpec).ConfigureAwait(false);
+            var resourceMonitorSupportsAliasSpecs = await MonitorSupportsAliasSpecs().ConfigureAwait(false);
+            var aliases = await PrepareAliases(res, options, resourceMonitorSupportsAliasSpecs).ConfigureAwait(false);
 
             return new PrepareResult(
                 serializedProps,
@@ -127,7 +127,7 @@ namespace Pulumi
                 allDirectDependencyUrns,
                 propertyToDirectDependencyUrns,
                 aliases,
-                resourceMonitorSupportsAliasSpec);
+                resourceMonitorSupportsAliasSpecs);
 
             void LogExcessive(string message)
             {
@@ -158,6 +158,17 @@ namespace Pulumi
                     if (resolvedAlias == null)
                     {
                         // alias contains unknowns, skip it.
+                        continue;
+                    }
+
+                    if (resolvedAlias.Urn != null)
+                    {
+                        // Alias URN fully provided, use it as is
+                        aliases.Add(new Pulumirpc.Alias
+                        {
+                            Urn = resolvedAlias.Urn
+                        });
+
                         continue;
                     }
 


### PR DESCRIPTION
Learnings from implementing go alias delegation to the engine:
 - the flag is called "aliasSpecs" not "aliasSpec"
 - aliases can also provide a fully qualified URN which can be passed as is to the engine