### PR TITLE
Fix dependency on Grpc.Tools

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
 ### Bug Fixes
+
+- [sdk] Fix paket referencing Pulumi.
+  [#91](https://github.com/pulumi/pulumi-dotnet/pull/91)

--- a/sdk/Pulumi/Pulumi.csproj
+++ b/sdk/Pulumi/Pulumi.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Include="Grpc.Net.Client" Version="2.43.0" />
-    <PackageReference Include="Grpc.AspNetCore" Version="2.37.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.37.0" />
     <PackageReference Include="Grpc.Tools" Version="2.44.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Pretty much a re-hash of https://github.com/pulumi/pulumi/pull/6793, but for the Pulumi.csproj. Was pointed out in community slack that we'd broken paket again.