### PR TITLE
Make MockMonitor return true for all features.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
 ### Bug Fixes
+
+- [sdk] Fix MockMonitor reporting DeletedWith wasn't supported.
+  [#93](https://github.com/pulumi/pulumi-dotnet/pull/93)

--- a/sdk/Pulumi/Testing/MockMonitor.cs
+++ b/sdk/Pulumi/Testing/MockMonitor.cs
@@ -26,8 +26,9 @@ namespace Pulumi.Testing
 
         public Task<SupportsFeatureResponse> SupportsFeatureAsync(SupportsFeatureRequest request)
         {
-            var hasSupport = request.Id == "secrets" || request.Id == "resourceReferences";
-            return Task.FromResult(new SupportsFeatureResponse { HasSupport = hasSupport });
+            // Rather than attempting to keep the list of feature flags up-to date here, we just assume the
+            // mock monitor supports any feature requested of it.
+            return Task.FromResult(new SupportsFeatureResponse { HasSupport = true });
         }
 
         public async Task<InvokeResponse> InvokeAsync(ResourceInvokeRequest request)


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-dotnet/issues/92