### PR TITLE
[sdk] Bring back the correct fallback behavior for calculating aliases for older Pulumi engines

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -13,3 +13,5 @@
   
 - [sdk] Correctly check for alias support in the engine and map fully specified alias urns.
   [#88](https://github.com/pulumi/pulumi-dotnet/pull/88)
+
+- [sdk] Bring back the correct fallback behavior for calculating aliases for older Pulumi engines.

--- a/sdk/Pulumi/Deployment/Deployment_RegisterResource.cs
+++ b/sdk/Pulumi/Deployment/Deployment_RegisterResource.cs
@@ -79,7 +79,7 @@ namespace Pulumi
             }
         }
 
-        private async static Task<RegisterResourceRequest> CreateRegisterResourceRequest(
+        private static async Task<RegisterResourceRequest> CreateRegisterResourceRequest(
             string type, string name, bool custom, bool remote, ResourceOptions options)
         {
             var customOpts = options as CustomResourceOptions;
@@ -137,7 +137,7 @@ namespace Pulumi
             // https://golang.org/pkg/time/#ParseDuration.
             //
             // Simply put, we simply convert our ticks to the integral number of nanoseconds
-            // corresponding to it.  Since each tick is 100ns, this can trivialy be done just by
+            // corresponding to it.  Since each tick is 100ns, this can trivially be done just by
             // appending "00" to it.
             return timeSpan.Value.Ticks + "00ns";
         }

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -858,7 +858,7 @@
             Check if the monitor supports the "outputValues" feature.
             </summary>
         </member>
-        <member name="M:Pulumi.Deployment.MonitorSupportsAliasSpec">
+        <member name="M:Pulumi.Deployment.MonitorSupportsAliasSpecs">
             <summary>
             Returns whether the resource monitor we are connected to supports the "aliasSpec" feature across the RPC interface.
             In which case we no longer compute alias combinations ourselves but instead delegate the work to the engine.
@@ -1978,6 +1978,11 @@
             A collection of transformations to apply as part of resource registration.
             </summary>
         </member>
+        <member name="F:Pulumi.Resource._aliases">
+            <summary>
+            A list of aliases applied to this resource.
+            </summary>
+        </member>
         <member name="M:Pulumi.Resource.GetResourceType">
             <summary>
             The type assigned to the resource at construction.
@@ -2027,6 +2032,14 @@
         <member name="M:Pulumi.Resource.GetProvider(System.String)">
             <summary>
             Fetches the provider for the given module member, if any.
+            </summary>
+        </member>
+        <member name="M:Pulumi.Resource.AllAliases(System.Collections.Generic.List{Pulumi.Input{Pulumi.Alias}},System.String,System.String,Pulumi.Resource)">
+            <summary>
+            <see cref="M:Pulumi.Resource.AllAliases(System.Collections.Generic.List{Pulumi.Input{Pulumi.Alias}},System.String,System.String,Pulumi.Resource)"/> makes a copy of the aliases array, and add to it any
+            implicit aliases inherited from its parent. If there are N child aliases, and
+            M parent aliases, there will be (M+1)*(N+1)-1 total aliases, or, as calculated
+            in the logic below, N+(M*(1+N)).
             </summary>
         </member>
         <member name="T:Pulumi.ResourceArgs">

--- a/sdk/Pulumi/Resources/Resource.cs
+++ b/sdk/Pulumi/Resources/Resource.cs
@@ -72,6 +72,11 @@ namespace Pulumi
         private readonly ImmutableArray<ResourceTransformation> _transformations;
 
         /// <summary>
+        /// A list of aliases applied to this resource.
+        /// </summary>
+        internal readonly ImmutableArray<Input<string>> _aliases;
+
+        /// <summary>
         /// The type assigned to the resource at construction.
         /// </summary>
         // This is a method and not a property to not collide with potential subclass property names.
@@ -257,7 +262,7 @@ namespace Pulumi
             this._provider = custom ? options.Provider : null;
             this._version = options.Version;
             this._pluginDownloadURL = options.PluginDownloadURL;
-
+            this._aliases = AllAliases(options.Aliases.ToList(), name, type, options.Parent);
             Deployment.InternalInstance.ReadOrRegisterResource(this, remote, urn => new DependencyResource(urn), args, options);
         }
 
@@ -274,6 +279,115 @@ namespace Pulumi
 
             this._providers.TryGetValue(memComponents[0], out var result);
             return result;
+        }
+
+        private static Output<string> CollapseAliasToUrn(
+            Input<Alias> alias,
+            string defaultName,
+            string defaultType,
+            Resource? defaultParent)
+        {
+            return alias.ToOutput().Apply(a =>
+            {
+                if (a.Urn != null)
+                {
+                    CheckNull(a.Name, nameof(a.Name));
+                    CheckNull(a.Type, nameof(a.Type));
+                    CheckNull(a.Project, nameof(a.Project));
+                    CheckNull(a.Stack, nameof(a.Stack));
+                    CheckNull(a.Parent, nameof(a.Parent));
+                    CheckNull(a.ParentUrn, nameof(a.ParentUrn));
+                    if (a.NoParent)
+                        ThrowAliasPropertyConflict(nameof(a.NoParent));
+
+                    return Output.Create(a.Urn);
+                }
+
+                var name = a.Name ?? defaultName;
+                var type = a.Type ?? defaultType;
+                var project = a.Project ?? Deployment.Instance.ProjectName;
+                var stack = a.Stack ?? Deployment.Instance.StackName;
+
+                var parentCount =
+                    (a.Parent != null ? 1 : 0) +
+                    (a.ParentUrn != null ? 1 : 0) +
+                    (a.NoParent ? 1 : 0);
+
+                if (parentCount >= 2)
+                {
+                    throw new ArgumentException(
+$"Only specify one of '{nameof(Alias.Parent)}', '{nameof(Alias.ParentUrn)}' or '{nameof(Alias.NoParent)}' in an {nameof(Alias)}");
+                }
+
+                var (parent, parentUrn) = GetParentInfo(defaultParent, a);
+
+                if (name == null)
+                    throw new ArgumentNullException("No valid 'Name' passed in for alias.");
+
+                if (type == null)
+                    throw new ArgumentNullException("No valid 'type' passed in for alias.");
+
+                return Pulumi.Urn.Create(name, type, parent, parentUrn, project, stack);
+            });
+        }
+
+
+        private static void CheckNull<T>(T? value, string name) where T : class
+        {
+            if (value != null)
+            {
+                ThrowAliasPropertyConflict(name);
+            }
+        }
+
+        private static void ThrowAliasPropertyConflict(string name)
+            => throw new ArgumentException($"{nameof(Alias)} should not specify both {nameof(Alias.Urn)} and {name}");
+
+        private static (Resource? parent, Input<string>? urn) GetParentInfo(Resource? defaultParent, Alias alias)
+        {
+            if (alias.Parent != null)
+                return (alias.Parent, null);
+
+            if (alias.ParentUrn != null)
+                return (null, alias.ParentUrn);
+
+            if (alias.NoParent)
+                return (null, null);
+
+            return (defaultParent, null);
+        }
+
+        /// <summary>
+        /// <see cref="AllAliases"/> makes a copy of the aliases array, and add to it any
+        /// implicit aliases inherited from its parent. If there are N child aliases, and
+        /// M parent aliases, there will be (M+1)*(N+1)-1 total aliases, or, as calculated
+        /// in the logic below, N+(M*(1+N)).
+        /// </summary>
+        internal static ImmutableArray<Input<string>> AllAliases(List<Input<Alias>> childAliases, string childName, string childType, Resource? parent)
+        {
+            var aliases = ImmutableArray.CreateBuilder<Input<string>>();
+            foreach (var childAlias in childAliases)
+            {
+                aliases.Add(CollapseAliasToUrn(childAlias, childName, childType, parent));
+            }
+            if (parent != null)
+            {
+                foreach (var parentAlias in parent._aliases)
+                {
+                    aliases.Add(Pulumi.Urn.InheritedChildAlias(childName, parent._name, parentAlias, childType));
+                    foreach (var childAlias in childAliases)
+                    {
+                        var inheritedAlias = CollapseAliasToUrn(childAlias, childName, childType, parent).Apply(childAliasURN =>
+                        {
+                            var aliasedChildName = Pulumi.Urn.Name(childAliasURN);
+                            var aliasedChildType = Pulumi.Urn.Type(childAliasURN);
+                            return Pulumi.Urn.InheritedChildAlias(aliasedChildName, parent._name, parentAlias, aliasedChildType);
+                        });
+                        aliases.Add(inheritedAlias);
+                    }
+                }
+            }
+            return aliases.ToImmutable();
         }
 
         private static ImmutableDictionary<string, ProviderResource> ConvertToProvidersMap(List<ProviderResource>? providers)


### PR DESCRIPTION
Fixes #90 

In order to also bring back the unit tests for `AllAliases`, we need a new feature in `IMocks` that allows us to override the supported features by the resource monitor. Specifically, we need `aliasSpecs` to _not_ be supported in order to test the fallback branch. I will add that in a separate PR