### PR TITLE
Use single envvar to specify test org (`PULUMI_TEST_OWNER`)

### DIFF
--- a/sdk/Pulumi.Automation.Tests/Utility.cs
+++ b/sdk/Pulumi.Automation.Tests/Utility.cs
@@ -21,7 +21,9 @@ namespace Pulumi.Automation.Tests
         }
 
         public static string GetTestOrg()
-            => Environment.GetEnvironmentVariable("PULUMI_TEST_ORG") ?? "pulumi-test";
+            => Environment.GetEnvironmentVariable("PULUMI_TEST_OWNER")
+            ?? Environment.GetEnvironmentVariable("PULUMI_TEST_ORG")
+            ?? "pulumi-test";
 
         public static string FullyQualifiedStackName(string org, string project, string stack)
             => $"{org}/{project}/{stack}";


### PR DESCRIPTION
There are currently two envvars that are used to specify an Pulumi Service org for tests:

1. The automation API tests look for the `PULUMI_TEST_ORG` envvar and fallback to using the `pulumi-test` org when the envvar isn't set. We're not currently setting `PULUMI_TEST_ORG` in the GHA workflows like we do in `pulumi/pulumi`, so presumably the automation API tests are using the `pulumi-test` org fallback.
2. There's also a `PULUMI_TEST_OWNER` envvar that some of the integration tests uses. We are currently setting `PULUMI_TEST_OWNER` to `moolumi`.

This change updates the automation API tests to first look for the `PULUMI_TEST_OWNER` envvar, falling back to `PULUMI_TEST_ORG`, and then finally `pulumi-test`. That way, we only need to have a single consistent envvar set in CI (`PULUMI_TEST_OWNER`), [set to `moolumi`](https://github.com/pulumi/pulumi-dotnet/blob/5fd17059c9108f0c356b903f570ba2fd4d3ea19a/.github/workflows/pr.yml#L19), which is the org we want to use for these tests.

`PULUMI_TEST_OWNER` was chosen over `PULUMI_TEST_ORG` because `PULUMI_TEST_OWNER` is also used in the Go integration test framework.