### PR TITLE
When instantiating Stack objects, do not wrap exceptions.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,4 +7,7 @@
   - [sdk] Added `StackReference.GetOutputDetailsAsync` to retrieve output values from stack references directly.
     [#103](https://github.com/pulumi/pulumi-dotnet/pull/103)
 
+  - [sdk] When an exception is thrown from the constructor of a `Stack` subclass, prevent `TargetInvocationException` from obscuring the error message.
+    [#106](https://github.com/pulumi/pulumi-dotnet/pull/106)
+
 ### Bug Fixes

--- a/sdk/Pulumi.Tests/Deployment/DeploymentRunnerTests.cs
+++ b/sdk/Pulumi.Tests/Deployment/DeploymentRunnerTests.cs
@@ -38,6 +38,26 @@ namespace Pulumi.Tests
         }
 
         [Fact]
+        public async Task DisplaysExceptionFromStack()
+        {
+            var deployResult = await Deployment.TryTestAsync<ThrowsExceptionStack>(new EmptyMocks());
+            Assert.NotNull(deployResult.Exception);
+            Assert.IsType<RunException>(deployResult.Exception!);
+            Assert.Contains(ThrowsExceptionStack.EXPECTED_MESSAGE, deployResult.Exception!.Message);
+            Assert.DoesNotContain(nameof(System.Reflection.TargetInvocationException), deployResult.Exception!.Message);
+        }
+
+        class ThrowsExceptionStack : Stack
+        {
+            public const string EXPECTED_MESSAGE = "My exception message.";
+
+            public ThrowsExceptionStack()
+            {
+                throw new Exception(EXPECTED_MESSAGE);
+            }
+        }
+
+        [Fact]
         public async Task LogsTaskDescriptions()
         {
             var resources = await Deployment.TestAsync<LogsTaskDescriptionsStack>(new EmptyMocks());

--- a/sdk/Pulumi/Deployment/Deployment.Runner.cs
+++ b/sdk/Pulumi/Deployment/Deployment.Runner.cs
@@ -69,7 +69,7 @@ namespace Pulumi
                     ?? throw new ApplicationException($"Failed to resolve instance of type {typeof(TStack)} from service provider. Register the type with the service provider before calling {nameof(RunAsync)}."));
             }
 
-            Task<int> IRunner.RunAsync<TStack>() => RunAsync(() => new TStack());
+            Task<int> IRunner.RunAsync<TStack>() => RunAsync(() => (TStack)Activator.CreateInstance(typeof(TStack), BindingFlags.DoNotWrapExceptions, binder: null, args: null, culture: null)!);
 
             public Task<int> RunAsync<TStack>(Func<TStack> stackFactory) where TStack : Stack
             {


### PR DESCRIPTION
# Summary

Slightly nicer error message when is called `Deployment.RunAsync<TStack>` where `TStack`'s constructor throws.

# Details

Let's say you have this stack:

```csharp
using Pulumi;
using System;

internal class ThrowStack : Stack
{
    public ThrowStack()
    {
        throw new Exception("turtles");
    }
}
```

And your main method tries to use it:

```csharp
await Deployment.RunAsync<ThrowStack>();
```

When run with `pulumi up`, the actual error is burried in the center of the call stack, obscured by the `TargetInvocationException`:


```
C:\src\MastodonPulumi>pulumi up
Previewing update (dev)

View Live: https://app.pulumi.com/AustinWise/MastodonPulumi/dev/previews/89b8b54a-ff04-479a-a08a-709fe8fb72f4

     Type                 Name                Plan     Info
     pulumi:pulumi:Stack  MastodonPulumi-dev           2 errors

Diagnostics:
  pulumi:pulumi:Stack (MastodonPulumi-dev):
    error: Running program 'C:\src\MastodonPulumi\bin\Debug\net6.0\MastodonPulumi.dll' failed with an unhandled exception:
    System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
       at object RuntimeType.CreateInstanceOfT()
       at T Activator.CreateInstance<T>()
       at Task<int> Pulumi.Deployment+Runner.Pulumi.IRunner.RunAsync<TStack>(IServiceProvider serviceProvider)+() => { }
       at Task<int> Pulumi.Deployment+Runner.RunAsync<TStack>(Func<TStack> stackFactory) ---> System.Exception: turtles
       at new MastodonPulumi.ThrowStack() in C:/src/MastodonPulumi/ThrowStack.cs:line 14
       at object RuntimeType.CreateInstanceOfT()
       --- End of inner exception stack trace ---
```

This PR prevents the exception from being wrapped in an `TargetInvocationException` by using the `BindingFlags.DoNotWrapExceptions` flag. This should result in the actual error appearing at the top of the call stack.


After this PR is applied, the relevant error message appears at the top of the stack trace:

```
C:\src\MastodonPulumi>pulumi up
Previewing update (dev)

View Live: https://app.pulumi.com/AustinWise/MastodonPulumi/dev/previews/5b6f033b-28ce-4437-8553-ee8fb8ac6c40

     Type                 Name                Plan     Info
     pulumi:pulumi:Stack  MastodonPulumi-dev           2 errors

Diagnostics:
  pulumi:pulumi:Stack (MastodonPulumi-dev):
    error: Running program 'C:\src\MastodonPulumi\bin\Debug\net6.0\MastodonPulumi.dll' failed with an unhandled exception:
    System.Exception: turtles
       at new MastodonPulumi.ThrowStack() in C:/src/MastodonPulumi/ThrowStack.cs:line 10
       at object RuntimeType.CreateInstanceDefaultCtor(bool publicOnly, bool wrapExceptions)
       at object Activator.CreateInstance(Type type, bool nonPublic, bool wrapExceptions)
       at object RuntimeType.CreateInstanceImpl(BindingFlags bindingAttr, Binder binder, object[] args, CultureInfo culture)
       at object Activator.CreateInstance(Type type, BindingFlags bindingAttr, Binder binder, object[] args, CultureInfo culture, object[] activationAttributes) x 2
       at Task<int> Pulumi.Deployment+Runner.Pulumi.IRunner.RunAsync<TStack>(IServiceProvider serviceProvider)+() => { }
       at Task<int> Pulumi.Deployment+Runner.RunAsync<TStack>(Func<TStack> stackFactory)
```