### PR TITLE
dependabot: Auto-update actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Sets up dependabot to automatically create PRs
to update versions of GitHub Actions used by the repository.

Refs #113
