### PR TITLE
Sync proto files

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,9 +9,12 @@
   - [sdk/auto] Expose additional Pulumi refresh options to the Automation API.
     [#117](https://github.com/pulumi/pulumi-dotnet/pull/117)
 
+  - [sdk] Updated to the latest pulumi protobuf specification.
+    [#135](https://github.com/pulumi/pulumi-dotnet/pull/135)
+
 ### Bug Fixes
   - [sdk] Fix JSON serialisation of Input<T> types.
     [#112](https://github.com/pulumi/pulumi-dotnet/pull/112)
-	
+
   - [sdk] Improve the error message from not implemented provider methods.
     [#125](https://github.com/pulumi/pulumi-dotnet/pull/125)

--- a/proto/pulumi/codegen/mapper.proto
+++ b/proto/pulumi/codegen/mapper.proto
@@ -1,0 +1,44 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "pulumi/plugin.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
+
+package codegen;
+
+option go_package = "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen";
+
+// Mapper is a service for getting mappings from other ecosystems to Pulumi.
+// This is currently unstable and experimental.
+service Mapper {
+    // GetMapping tries to find a mapping for the given provider.
+    rpc GetMapping(GetMappingRequest) returns (GetMappingResponse) {}
+}
+
+// GetMappingRequest allows the engine to return ecosystem specific information to allow the converter to be
+// convert provider types from a source markup to Pulumi.
+message GetMappingRequest {
+    // the provider name for the mapping being requested.
+    string provider = 1;
+}
+
+// GetMappingResponse returns converter plugin specific data for the requested provider. This will normally be human
+// readable JSON, but the engine doesn't mandate any form.
+message GetMappingResponse {
+    // the conversion plugin specific data (if any)
+    bytes data = 1;
+}

--- a/proto/pulumi/converter.proto
+++ b/proto/pulumi/converter.proto
@@ -1,0 +1,70 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "pulumi/plugin.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
+
+package pulumirpc;
+
+option go_package = "github.com/pulumi/pulumi/sdk/v3/proto/go;pulumirpc";
+
+// Converter is a service for converting between other ecosystems and Pulumi.
+// This is currently unstable and experimental.
+service Converter {
+    // ConvertState converts state from the target ecosystem into a form that can be imported into Pulumi.
+    rpc ConvertState(ConvertStateRequest) returns (ConvertStateResponse) {}
+
+    // ConvertProgram converts a program from the target ecosystem into a form that can be used with Pulumi.
+    rpc ConvertProgram(ConvertProgramRequest) returns (ConvertProgramResponse) {}
+}
+
+message ConvertStateRequest {
+    // the gRPC address of the mapper service.
+    string mapper_target = 1;
+}
+
+// A ResourceImport specifies a resource to import.
+message ResourceImport {
+    // the type token for the resource.
+    string type = 1;
+    // the name of the resource.
+    string name = 2;
+    // the ID of the resource.
+    string id = 3;
+
+    // the provider version to use for the resource, if any.
+    string version = 4;
+    // the provider PluginDownloadURL to use for the resource, if any.
+    string pluginDownloadURL = 5;
+}
+
+message ConvertStateResponse {
+    // a list of resources to import.
+    repeated ResourceImport resources = 1;
+}
+
+message ConvertProgramRequest {
+    // the source directory containing the program to convert from.
+    string source_directory = 1;
+    // a target directory to write the resulting PCL code and project file to.
+    string target_directory = 2;
+    // the gRPC address of the mapper service.
+    string mapper_target = 3;
+}
+
+message ConvertProgramResponse {
+}

--- a/sdk/Pulumi/Deployment/Deployment_Call.cs
+++ b/sdk/Pulumi/Deployment/Deployment_Call.cs
@@ -26,7 +26,7 @@ namespace Pulumi
             var (result, deps) = await CallRawAsync(token, args, self, options).ConfigureAwait(false);
             if (convertResult)
             {
-                var converted = Converter.ConvertValue<T>(err => Log.Warn(err, self), $"{token} result", new Value { StructValue = result });
+                var converted = Pulumi.Serialization.Converter.ConvertValue<T>(err => Log.Warn(err, self), $"{token} result", new Value { StructValue = result });
                 return new OutputData<T>(deps, converted.Value, converted.IsKnown, converted.IsSecret);
             }
 

--- a/sdk/Pulumi/Deployment/Deployment_Invoke.cs
+++ b/sdk/Pulumi/Deployment/Deployment_Invoke.cs
@@ -84,7 +84,7 @@ namespace Pulumi
 
             var protoArgs = serializedArgs.ToSerializationResult();
             var result = await InvokeRawAsync(token, protoArgs, options).ConfigureAwait(false);
-            var data = Converter.ConvertValue<T>(err => Log.Warn(err), $"{token} result",
+            var data = Pulumi.Serialization.Converter.ConvertValue<T>(err => Log.Warn(err), $"{token} result",
                                                  new Value { StructValue = result.Serialized });
             var resources = ImmutableHashSet.CreateRange(
                 result.PropertyToDependentResources.Values.SelectMany(r => r)
@@ -105,7 +105,7 @@ namespace Pulumi
                 return default!;
             }
 
-            var data = Converter.ConvertValue<T>(err => Log.Warn(err), $"{token} result", new Value { StructValue = result.Serialized });
+            var data = Pulumi.Serialization.Converter.ConvertValue<T>(err => Log.Warn(err), $"{token} result", new Value { StructValue = result.Serialized });
             return data.Value;
         }
 

--- a/sdk/Pulumi/Provider/Provider.cs
+++ b/sdk/Pulumi/Provider/Provider.cs
@@ -525,7 +525,7 @@ namespace Pulumi.Experimental.Provider
             {
                 return ImmutableDictionary<string, PropertyValue>.Empty;
             }
-            return PropertyValue.Marshal(properties);
+            return PropertyValue.Unmarshal(properties);
         }
 
         public override async Task<Pulumirpc.CheckResponse> CheckConfig(Pulumirpc.CheckRequest request, ServerCallContext context)
@@ -536,7 +536,7 @@ namespace Pulumi.Experimental.Provider
                 using var cts = GetToken(context);
                 var domResponse = await Implementation.CheckConfig(domRequest, cts.Token);
                 var grpcResponse = new Pulumirpc.CheckResponse();
-                grpcResponse.Inputs = domResponse.Inputs == null ? null : PropertyValue.Unmarshal(domResponse.Inputs);
+                grpcResponse.Inputs = domResponse.Inputs == null ? null : PropertyValue.Marshal(domResponse.Inputs);
                 if (domResponse.Failures != null)
                 {
                     foreach (var domFailure in domResponse.Failures)
@@ -623,7 +623,7 @@ namespace Pulumi.Experimental.Provider
                 using var cts = GetToken(context);
                 var domResponse = await Implementation.Invoke(domRequest, cts.Token);
                 var grpcResponse = new Pulumirpc.InvokeResponse();
-                grpcResponse.Return = domResponse.Return == null ? null : PropertyValue.Unmarshal(domResponse.Return);
+                grpcResponse.Return = domResponse.Return == null ? null : PropertyValue.Marshal(domResponse.Return);
                 if (domResponse.Failures != null)
                 {
                     foreach (var domFailure in domResponse.Failures)
@@ -735,7 +735,7 @@ namespace Pulumi.Experimental.Provider
                 var domResponse = await Implementation.Create(domRequest, cts.Token);
                 var grpcResponse = new Pulumirpc.CreateResponse();
                 grpcResponse.Id = domResponse.Id ?? "";
-                grpcResponse.Properties = domResponse.Properties == null ? null : PropertyValue.Unmarshal(domResponse.Properties);
+                grpcResponse.Properties = domResponse.Properties == null ? null : PropertyValue.Marshal(domResponse.Properties);
                 return grpcResponse;
             }
             catch (NotImplementedException ex)
@@ -761,8 +761,8 @@ namespace Pulumi.Experimental.Provider
                 var domResponse = await Implementation.Read(domRequest, cts.Token);
                 var grpcResponse = new Pulumirpc.ReadResponse();
                 grpcResponse.Id = domResponse.Id ?? "";
-                grpcResponse.Properties = domResponse.Properties == null ? null : PropertyValue.Unmarshal(domResponse.Properties);
-                grpcResponse.Inputs = domResponse.Inputs == null ? null : PropertyValue.Unmarshal(domResponse.Inputs);
+                grpcResponse.Properties = domResponse.Properties == null ? null : PropertyValue.Marshal(domResponse.Properties);
+                grpcResponse.Inputs = domResponse.Inputs == null ? null : PropertyValue.Marshal(domResponse.Inputs);
                 return grpcResponse;
             }
             catch (NotImplementedException ex)
@@ -787,7 +787,7 @@ namespace Pulumi.Experimental.Provider
                 using var cts = GetToken(context);
                 var domResponse = await Implementation.Check(domRequest, cts.Token);
                 var grpcResponse = new Pulumirpc.CheckResponse();
-                grpcResponse.Inputs = domResponse.Inputs == null ? null : PropertyValue.Unmarshal(domResponse.Inputs);
+                grpcResponse.Inputs = domResponse.Inputs == null ? null : PropertyValue.Marshal(domResponse.Inputs);
                 if (domResponse.Failures != null)
                 {
                     foreach (var domFailure in domResponse.Failures)
@@ -874,7 +874,7 @@ namespace Pulumi.Experimental.Provider
                 using var cts = GetToken(context);
                 var domResponse = await Implementation.Update(domRequest, cts.Token);
                 var grpcResponse = new Pulumirpc.UpdateResponse();
-                grpcResponse.Properties = domResponse.Properties == null ? null : PropertyValue.Unmarshal(domResponse.Properties);
+                grpcResponse.Properties = domResponse.Properties == null ? null : PropertyValue.Marshal(domResponse.Properties);
                 return grpcResponse;
             }
             catch (NotImplementedException ex)


### PR DESCRIPTION
Also fix the PropertyValue.Marshal/Unmarshal names to match the Go SDK. Marshal is to go from PropertyValue to Protobuf, but this SDK was using Unmarshal for that operation.