### PR TITLE
[sdk] Implement Converter abstraction for building converter plugins

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,3 +4,6 @@
 
 - [sdk] Fix the default version for dotnet providers.
   [#148](https://github.com/pulumi/pulumi-dotnet/pull/148)
+
+### Improvements
+- [sdk] - Implements a `Converter` abstraction for building language converter plugins for Pulumi in dotnet. 

--- a/proto/pulumi/codegen/hcl.proto
+++ b/proto/pulumi/codegen/hcl.proto
@@ -1,0 +1,89 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package pulumirpc.codegen;
+
+option go_package = "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen";
+
+// Pos represents a single position in a source file, by addressing the start byte of a unicode character
+// encoded in UTF-8.
+message Pos {
+	// Line is the source code line where this position points. Lines are counted starting at 1 and
+	// incremented for each newline character encountered.
+	int64 line = 1;
+
+	// Column is the source code column where this position points, in unicode characters, with counting
+	// starting at 1.
+	//
+	// Column counts characters as they appear visually, so for example a latin letter with a combining
+	// diacritic mark counts as one character. This is intended for rendering visual markers against source
+	// code in contexts where these diacritics would be rendered in a single character cell. Technically
+	// speaking, Column is counting grapheme clusters as used in unicode normalization.
+	int64 column = 2;
+
+	// Byte is the byte offset into the file where the indicated character begins. This is a zero-based offset
+	// to the first byte of the first UTF-8 codepoint sequence in the character, and thus gives a position
+	// that can be resolved _without_ awareness of Unicode characters.
+	int64 byte = 3;
+}
+
+// Range represents a span of characters between two positions in a source file.
+message Range {
+	// Filename is the name of the file into which this range's positions point.
+	string filename = 1;
+
+	// Start and End represent the bounds of this range. Start is inclusive and End is exclusive.
+	Pos start = 2;
+	Pos end = 3;
+}
+
+// DiagnosticSeverity is the severity level of a diagnostic message.
+enum DiagnosticSeverity {
+	// DIAG_INVALID is the invalid zero value of DiagnosticSeverity
+	DIAG_INVALID = 0;
+	// DIAG_ERROR indicates that the problem reported by a diagnostic prevents
+	// further progress in parsing and/or evaluating the subject.
+	DIAG_ERROR = 1;
+	// DIAG_WARNING indicates that the problem reported by a diagnostic warrants
+	// user attention but does not prevent further progress. It is most
+	// commonly used for showing deprecation notices.
+	DIAG_WARNING = 2;
+}
+
+// Diagnostic represents information to be presented to a user about an error or anomaly in parsing or evaluating configuration.
+message Diagnostic {
+	DiagnosticSeverity severity = 1;
+
+	// Summary and Detail contain the English-language description of the
+	// problem. Summary is a terse description of the general problem and
+	// detail is a more elaborate, often-multi-sentence description of
+	// the problem and what might be done to solve it.
+	string summary = 2;
+	string detail = 3;
+
+	// Subject and Context are both source ranges relating to the diagnostic.
+	//
+	// Subject is a tight range referring to exactly the construct that
+	// is problematic, while Context is an optional broader range (which should
+	// fully contain Subject) that ought to be shown around Subject when
+	// generating isolated source-code snippets in diagnostic messages.
+	// If Context is nil, the Subject is also the Context.
+	//
+	// Some diagnostics have no source ranges at all. If Context is set then
+	// Subject should always also be set.
+	Range subject = 4;
+	Range context = 5;
+}

--- a/proto/pulumi/codegen/loader.proto
+++ b/proto/pulumi/codegen/loader.proto
@@ -1,0 +1,43 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
+
+package codegen;
+
+option go_package = "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen";
+
+// Loader is a service for getting schemas from the Pulumi engine for use in code generators and other tools.
+// This is currently unstable and experimental.
+service Loader {
+    // GetSchema tries to find a schema for the given package and version.
+    rpc GetSchema(GetSchemaRequest) returns (GetSchemaResponse) {}
+}
+
+// GetSchemaRequest allows the engine to return a schema for a given package and version.
+message GetSchemaRequest {
+    // the package name for the schema being requested.
+    string package = 1;
+    // the version for the schema being requested, must be a valid semver or empty.
+    string version = 2;
+}
+
+// GetSchemaResponse returns the schema data for the requested package.
+message GetSchemaResponse {
+    // the JSON encoded schema.
+    bytes schema = 1;
+}

--- a/proto/pulumi/codegen/mapper.proto
+++ b/proto/pulumi/codegen/mapper.proto
@@ -14,7 +14,6 @@
 
 syntax = "proto3";
 
-import "pulumi/plugin.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 
@@ -34,6 +33,8 @@ service Mapper {
 message GetMappingRequest {
     // the provider name for the mapping being requested.
     string provider = 1;
+    // the expected name of the pulumi provider that maps to the requested provider. Defaults to the same as 'provider'.
+    string pulumi_provider = 2;
 }
 
 // GetMappingResponse returns converter plugin specific data for the requested provider. This will normally be human

--- a/proto/pulumi/converter.proto
+++ b/proto/pulumi/converter.proto
@@ -14,6 +14,7 @@
 
 syntax = "proto3";
 
+import "pulumi/codegen/hcl.proto";
 import "pulumi/plugin.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
@@ -33,7 +34,7 @@ service Converter {
 }
 
 message ConvertStateRequest {
-    // the gRPC address of the mapper service.
+    // the gRPC target of the mapper service.
     string mapper_target = 1;
 }
 
@@ -62,9 +63,11 @@ message ConvertProgramRequest {
     string source_directory = 1;
     // a target directory to write the resulting PCL code and project file to.
     string target_directory = 2;
-    // the gRPC address of the mapper service.
+    // the gRPC target of the mapper service.
     string mapper_target = 3;
 }
 
 message ConvertProgramResponse {
+    // any diagnostics from code generation.
+    repeated pulumirpc.codegen.Diagnostic diagnostics = 1;
 }

--- a/proto/pulumi/language.proto
+++ b/proto/pulumi/language.proto
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2023, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 syntax = "proto3";
 
+import "pulumi/codegen/hcl.proto";
 import "pulumi/plugin.proto";
 import "google/protobuf/empty.proto";
 
@@ -32,7 +33,7 @@ service LanguageRuntime {
     rpc GetPluginInfo(google.protobuf.Empty) returns (PluginInfo) {}
 
     // InstallDependencies will install dependencies for the project, e.g. by running `npm install` for nodejs projects.
-    rpc  InstallDependencies(InstallDependenciesRequest) returns (stream  InstallDependenciesResponse) {}
+    rpc InstallDependencies(InstallDependenciesRequest) returns (stream  InstallDependenciesResponse) {}
 
     // About returns information about the runtime for this language.
     rpc About(google.protobuf.Empty) returns (AboutResponse) {}
@@ -42,6 +43,15 @@ service LanguageRuntime {
 
     // RunPlugin executes a plugin program and returns its result asynchronously.
     rpc RunPlugin(RunPluginRequest) returns (stream RunPluginResponse) {}
+
+    // GenerateProgram generates a given PCL program into a program for this language.
+    rpc GenerateProgram(GenerateProgramRequest) returns (GenerateProgramResponse) {}
+
+    // GenerateProject generates a given PCL program into a project for this language.
+    rpc GenerateProject(GenerateProjectRequest) returns (GenerateProjectResponse) {}
+
+    // GeneratePackage generates a given pulumi package into a package for this language.
+    rpc GeneratePackage(GeneratePackageRequest) returns (GeneratePackageResponse) {}
 }
 
 // AboutResponse returns runtime information about the language.
@@ -127,4 +137,50 @@ message RunPluginResponse {
         bytes stderr = 2; // a line of stderr text.
         int32 exitcode = 3; // the exit code of the provider.
     }
+}
+
+message GenerateProgramRequest {
+    // the PCL source of the project.
+    map<string, string> source = 1;
+    // The target of a codegen.LoaderServer to use for loading schemas.
+    string loader_target = 2;
+}
+
+message GenerateProgramResponse {
+    // any diagnostics from code generation.
+    repeated pulumirpc.codegen.Diagnostic diagnostics = 1;
+    // the generated program source code.
+    map<string, bytes> source = 2;
+}
+
+message GenerateProjectRequest {
+    // the directory to generate the project from.
+    string source_directory = 1;
+    // the directory to generate the project in.
+    string target_directory = 2;
+    // the JSON-encoded pulumi project file.
+    string project = 3;
+    // if PCL binding should be strict or not.
+    bool strict = 4;
+    // The target of a codegen.LoaderServer to use for loading schemas.
+    string loader_target = 5;
+}
+
+message GenerateProjectResponse {
+    // any diagnostics from code generation.
+    repeated pulumirpc.codegen.Diagnostic diagnostics = 1;
+}
+
+message GeneratePackageRequest {
+    // the directory to generate the package in.
+    string directory = 1;
+    // the JSON-encoded schema.
+    string schema = 2;
+    // extra files to copy to the package output.
+    map<string, bytes> extra_files = 3;
+    // The target of a codegen.LoaderServer to use for loading schemas.
+    string loader_target = 4;
+}
+
+message GeneratePackageResponse {
 }

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 import "pulumi/plugin.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
+import "pulumi/source.proto";
 
 package pulumirpc;
 
@@ -97,6 +98,7 @@ message ConfigureRequest {
     google.protobuf.Struct args = 2;   // the input properties for the provider. Only filled in for newer providers.
     bool acceptSecrets  = 3;           // when true, operations should return secrets as strongly typed.
     bool acceptResources = 4;          // when true, operations should return resources as strongly typed values to the provider.
+    bool sends_old_inputs = 5;         // when true, diff and update will be called with the old outputs and the old inputs.
 }
 
 message ConfigureResponse {
@@ -153,6 +155,8 @@ message CallRequest {
     int32 parallel = 11;            // the degree of parallelism for resource operations (<=1 for serial).
     string monitorEndpoint = 12;    // the address for communicating back to the resource monitor.
     string organization = 14;       // the organization of the stack being deployed into.
+
+    SourcePosition sourcePosition = 15; // the optional source position of the user code that initiated the call.
 }
 
 message CallResponse {
@@ -191,9 +195,10 @@ message CheckFailure {
 message DiffRequest {
     string id = 1;                     // the ID of the resource to diff.
     string urn = 2;                    // the Pulumi URN for this resource.
-    google.protobuf.Struct olds = 3;   // the old values of provider inputs to diff.
-    google.protobuf.Struct news = 4;   // the new values of provider inputs to diff.
+    google.protobuf.Struct olds = 3;   // the old output values of resource to diff.
+    google.protobuf.Struct news = 4;   // the new input values of resource to diff.
     repeated string ignoreChanges = 5; // a set of property paths that should be treated as unchanged.
+    google.protobuf.Struct old_inputs = 6;   // the old input values of the resource to diff.
 }
 
 message PropertyDiff {
@@ -294,6 +299,7 @@ message UpdateRequest {
     double timeout = 5;                // the update request timeout represented in seconds.
     repeated string ignoreChanges = 6; // a set of property paths that should be treated as unchanged.
     bool preview = 7;                   // true if this is a preview and the provider should not actually create the resource.
+    google.protobuf.Struct old_inputs = 8; // the old input values of the resource to diff.
 }
 
 message UpdateResponse {
@@ -313,6 +319,29 @@ message ConstructRequest {
         repeated string urns = 1; // A list of URNs this property depends on.
     }
 
+    // CustomTimeouts specifies timeouts for resource provisioning operations.
+    // Use it with the [Timeouts] option when creating new resources
+    // to override default timeouts.
+    //
+    // Each timeout is specified as a duration string such as,
+    // "5ms" (5 milliseconds), "40s" (40 seconds),
+    // and "1m30s" (1 minute, 30 seconds).
+    //
+    // The following units are accepted.
+    //
+    //   - ns: nanoseconds
+    //   - us: microseconds
+    //   - µs: microseconds
+    //   - ms: milliseconds
+    //   - s: seconds
+    //   - m: minutes
+    //   - h: hours
+    message CustomTimeouts {
+        string create = 1;
+        string update = 2;
+        string delete = 3;
+    }
+
     string project = 1;             // the project name.
     string stack = 2;               // the name of the stack being deployed into.
     map<string, string> config = 3; // the configuration variables to apply before running.
@@ -325,12 +354,22 @@ message ConstructRequest {
     string parent = 9;                                        // an optional parent URN that this child resource belongs to.
     google.protobuf.Struct inputs = 10;                       // the inputs to the resource constructor.
     map<string, PropertyDependencies> inputDependencies = 11; // a map from property keys to the dependencies of the property.
-    bool protect = 12;                                        // true if the resource should be marked protected.
     map<string, string> providers = 13;                       // the map of providers to use for this resource's children.
-    repeated string aliases = 14;                             // a list of additional URNs that shoud be considered the same.
     repeated string dependencies = 15;                        // a list of URNs that this resource depends on, as observed by the language host.
     repeated string configSecretKeys = 16;                    // the configuration keys that have secret values.
     string organization = 17;                                 // the organization of the stack being deployed into.
+
+    // Resource options:
+    // Do not change field IDs. Add new fields at the end.
+    bool protect                            = 12; // true if the resource should be marked protected.
+    repeated string aliases                 = 14; // a list of additional URNs that shoud be considered the same.
+    repeated string additionalSecretOutputs = 18; // additional output properties that should be treated as secrets.
+    CustomTimeouts customTimeouts           = 19; // default timeouts for CRUD operations on this resource.
+    string deletedWith                      = 20; // URN of a resource that, if deleted, also deletes this resource.
+    bool deleteBeforeReplace                = 21; // whether to delete the resource before replacing it.
+    repeated string ignoreChanges           = 22; // properties that should be ignored during a diff
+    repeated string replaceOnChanges        = 23; // properties that, when changed, trigger a replacement
+    bool retainOnDelete                     = 24; // whether to retain the resource in the cloud provider when it is deleted
 }
 
 message ConstructResponse {

--- a/proto/pulumi/resource.proto
+++ b/proto/pulumi/resource.proto
@@ -18,6 +18,7 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "pulumi/provider.proto";
 import "pulumi/alias.proto";
+import "pulumi/source.proto";
 
 package pulumirpc;
 
@@ -70,13 +71,15 @@ message ReadResourceRequest {
 
     bool acceptResources = 12;             // when true operations should return resource references as strongly typed.
     string pluginDownloadURL = 13;         // the server url of the provider to use when servicing this request.
+
+    SourcePosition sourcePosition = 14;    // the optional source position of the user code that initiated the read.
 }
 
 // ReadResourceResponse contains the result of reading a resource's state.
 message ReadResourceResponse {
     string urn = 1;                        // the URN for this resource.
     google.protobuf.Struct properties = 2; // the state of the resource read from the live environment.
-    }
+}
 
 // RegisterResourceRequest contains information about a resource object that was newly allocated.
 message RegisterResourceRequest {
@@ -118,6 +121,17 @@ message RegisterResourceRequest {
     bool retainOnDelete = 25;                                   // if true the engine will not call the resource providers delete method for this resource.
     repeated Alias aliases = 26;                                // a list of additional aliases that should be considered the same.
     string deletedWith = 27;                                    // if set the engine will not call the resource providers delete method for this resource when specified resource is deleted.
+
+    // Indicates that alias specs are specified correctly according to the spec.
+    // Older versions of the Node.js SDK did not send alias specs correctly.
+    // If this is not set to true and the engine detects the request is from the
+    // Node.js runtime, the engine will transform incorrect alias specs into
+    // correct ones.
+    // Other SDKs that are correctly specifying alias specs could set this to
+    // true, but it's not necessary.
+    bool aliasSpecs = 28;
+
+    SourcePosition sourcePosition = 29;    // the optional source position of the user code that initiated the register.
 }
 
 // RegisterResourceResponse is returned by the engine after a resource has finished being initialized.  It includes the
@@ -149,4 +163,6 @@ message ResourceInvokeRequest {
     string version = 4;              // the version of the provider to use when servicing this request.
     bool acceptResources = 5;        // when true operations should return resource references as strongly typed.
     string pluginDownloadURL = 6;    // an optional reference to the provider url to use for this invoke.
+
+    SourcePosition sourcePosition = 7; // the optional source position of the user code that initiated the invoke.
 }

--- a/proto/pulumi/source.proto
+++ b/proto/pulumi/source.proto
@@ -1,0 +1,26 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package pulumirpc;
+
+option go_package = "github.com/pulumi/pulumi/sdk/v3/proto/go;pulumirpc";
+
+// A SourcePosition represents a position in a source file.
+message SourcePosition {
+    string uri = 1; // The URI of the file. Currently only the file scheme with an absolute path is supported.
+    int32 line = 2; // The line in the file
+    int32 column = 3; // The column in the line
+}

--- a/sdk/Pulumi/Codegen/Diagnostic.cs
+++ b/sdk/Pulumi/Codegen/Diagnostic.cs
@@ -1,0 +1,32 @@
+namespace Pulumi.Codegen
+{
+    public enum DiagnosticSeverity
+    {
+        Invalid,
+        Warning,
+        Error
+    }
+
+    public sealed class Position
+    {
+        public long Line { get; set; }
+        public long Column { get; set; }
+        public long Byte { get; set; }
+    }
+
+    public sealed class Range
+    {
+        public string? Filename { get; set; }
+        public Position? Start { get; set; } = null;
+        public Position? End { get; set; } = null;
+    }
+
+    public sealed class Diagnostic
+    {
+        public string? Summary { get; set; }
+        public string? Detail { get; set; }
+        public Range? Subject { get; set; }
+        public Range? Context { get; set; }
+        public DiagnosticSeverity Severity { get; set; }
+    }
+}

--- a/sdk/Pulumi/Converter/Converter.cs
+++ b/sdk/Pulumi/Converter/Converter.cs
@@ -64,7 +64,6 @@ namespace Pulumi.Experimental.Converter
         }
 
         public static async Task Serve(
-            string[] args,
             Converter converter,
             CancellationToken? cancellationToken = null,
             TextWriter? stdout = null)
@@ -86,14 +85,6 @@ namespace Pulumi.Experimental.Converter
                             // clear so we don't read appsettings.json
                             // note that we also won't read environment variables for config
                             config.Sources.Clear();
-
-                            var memConfig = new Dictionary<string, string>();
-                            if (args.Length > 0)
-                            {
-                                memConfig.Add("Host", args[0]);
-                            }
-
-                            config.AddInMemoryCollection(memConfig);
                         })
                         .ConfigureLogging(loggingBuilder =>
                         {

--- a/sdk/Pulumi/Converter/Converter.cs
+++ b/sdk/Pulumi/Converter/Converter.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Net;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using System.Linq;
+using System.Collections.Generic;
+using Grpc.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Pulumirpc.Codegen;
+using Diagnostic = Pulumi.Codegen.Diagnostic;
+using DiagnosticSeverity = Pulumi.Codegen.DiagnosticSeverity;
+
+namespace Pulumi.Experimental.Converter
+{
+    public sealed class ConvertProgramRequest
+    {
+        public string SourceDirectory { get; set; } = "";
+        public string TargetDirectory { get; set; } = "";
+        public string MapperTarget { get; set; } = "";
+    }
+
+    public sealed class ConvertProgramResponse
+    {
+        public List<Codegen.Diagnostic> Diagnostics { get; set; } = new List<Diagnostic>();
+        public static ConvertProgramResponse Empty => new ConvertProgramResponse();
+    }
+
+    public abstract class Converter
+    {
+        public virtual Task<ConvertProgramResponse> ConvertProgram(ConvertProgramRequest request)
+        {
+            throw new NotImplementedException($"{nameof(ConvertProgram)} is not implemented");
+        }
+
+        public static Converter CreateSimple(Func<ConvertProgramRequest, ConvertProgramResponse> convertProgram)
+        {
+            Task<ConvertProgramResponse> ConvertAsync(ConvertProgramRequest request)
+            {
+                var response = convertProgram(request);
+                return Task.FromResult(response);
+            }
+
+            return new SimpleProgramConverter(ConvertAsync);
+        }
+
+        public static Converter CreateSimpleAsync(Func<ConvertProgramRequest, Task<ConvertProgramResponse>> convertProgramAsync)
+        {
+            return new SimpleProgramConverter(convertProgramAsync);
+        }
+
+        public static async Task Serve(
+            string[] args,
+            Converter converter,
+            CancellationToken? cancellationToken = null,
+            TextWriter? stdout = null)
+        {
+            // maxRpcMessageSize raises the gRPC Max message size from `4194304` (4mb) to `419430400` (400mb)
+            var maxRpcMessageSize = 400 * 1024 * 1024;
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder
+                        .ConfigureKestrel(kestrelOptions =>
+                        {
+                            kestrelOptions.Listen(IPAddress.Loopback, 0,
+                                listenOptions => { listenOptions.Protocols = HttpProtocols.Http2; });
+                        })
+                        .ConfigureAppConfiguration((context, config) =>
+                        {
+                            // clear so we don't read appsettings.json
+                            // note that we also won't read environment variables for config
+                            config.Sources.Clear();
+
+                            var memConfig = new Dictionary<string, string>();
+                            if (args.Length > 0)
+                            {
+                                memConfig.Add("Host", args[0]);
+                            }
+
+                            config.AddInMemoryCollection(memConfig);
+                        })
+                        .ConfigureLogging(loggingBuilder =>
+                        {
+                            // disable default logging
+                            loggingBuilder.ClearProviders();
+                        })
+                        .ConfigureServices(services =>
+                        {
+                            services.AddSingleton(new ConverterService(converter));
+
+                            services.AddGrpc(grpcOptions =>
+                            {
+                                grpcOptions.MaxReceiveMessageSize = maxRpcMessageSize;
+                                grpcOptions.MaxSendMessageSize = maxRpcMessageSize;
+                            });
+
+                            services.AddGrpcReflection();
+                        })
+                        .Configure(app =>
+                        {
+                            app.UseRouting();
+                            app.UseEndpoints(endpoints =>
+                            {
+                                endpoints.MapGrpcService<ConverterService>();
+                                endpoints.MapGrpcReflectionService();
+                            });
+                        });
+                })
+                .Build();
+
+            // before starting the host, set up this callback to tell us what port was selected
+            var portTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            host.Services.GetRequiredService<IHostApplicationLifetime>().ApplicationStarted.Register(() =>
+            {
+                try
+                {
+                    var serverFeatures = host.Services.GetRequiredService<IServer>().Features;
+                    var addressesFeature = serverFeatures.Get<IServerAddressesFeature>();
+                    Debug.Assert(addressesFeature != null, "Server should have an IServerAddressesFeature");
+                    var addresses = addressesFeature.Addresses.ToList();
+                    Debug.Assert(addresses.Count == 1, "Server should only be listening on one address");
+                    var uri = new Uri(addresses[0]);
+                    portTcs.TrySetResult(uri.Port);
+                }
+                catch (Exception ex)
+                {
+                    portTcs.TrySetException(ex);
+                }
+            });
+
+            var ct = cancellationToken ?? CancellationToken.None;
+            stdout ??= System.Console.Out;
+
+            await host.StartAsync(ct);
+
+            var port = await portTcs.Task;
+            // Explicitly write just the number and "\n". WriteLine would write "\r\n" on Windows, and while
+            // the engine has now been fixed to handle that (see https://github.com/pulumi/pulumi/pull/11915)
+            // we work around this here so that old engines can use dotnet providers as well.
+            await stdout.WriteAsync(port.ToString() + "\n");
+
+            await host.WaitForShutdownAsync(ct);
+
+            host.Dispose();
+        }
+    }
+
+    class SimpleProgramConverter : Converter
+    {
+        private readonly Func<ConvertProgramRequest, Task<ConvertProgramResponse>> _convertProgram;
+
+        public SimpleProgramConverter(Func<ConvertProgramRequest, Task<ConvertProgramResponse>> convertProgram)
+        {
+            _convertProgram = convertProgram;
+        }
+        public override async Task<ConvertProgramResponse> ConvertProgram(ConvertProgramRequest request)
+        {
+            return await _convertProgram(request);
+        }
+    }
+
+    class ConverterService : Pulumirpc.Converter.ConverterBase
+    {
+        private readonly Func<ConvertProgramRequest, Task<ConvertProgramResponse>> _convertProgram;
+
+        public ConverterService(Converter implementation)
+        {
+            _convertProgram = implementation.ConvertProgram;
+        }
+
+        private Pulumirpc.Codegen.Range RpcRange(Pulumi.Codegen.Range range)
+        {
+            var rpcRange = new Pulumirpc.Codegen.Range();
+            rpcRange.Filename = range.Filename ?? "";
+            if (range.Start != null)
+            {
+                rpcRange.Start = new Pos
+                {
+                    Line = range.Start.Line,
+                    Column = range.Start.Column,
+                    Byte = range.Start.Byte
+                };
+            }
+
+            if (range.End != null)
+            {
+                rpcRange.End = new Pos
+                {
+                    Line = range.End.Line,
+                    Column = range.End.Column,
+                    Byte = range.End.Byte
+                };
+            }
+
+            return rpcRange;
+        }
+
+        public override async Task<Pulumirpc.ConvertProgramResponse> ConvertProgram(Pulumirpc.ConvertProgramRequest rpcRequest, ServerCallContext context)
+        {
+            var response = await _convertProgram(new ConvertProgramRequest
+            {
+                SourceDirectory = rpcRequest.SourceDirectory,
+                TargetDirectory = rpcRequest.TargetDirectory,
+                MapperTarget = rpcRequest.MapperTarget
+            });
+
+            var rpcResponse = new Pulumirpc.ConvertProgramResponse();
+            foreach (var diagnostic in response.Diagnostics)
+            {
+                var rpcDiagnostic = new Pulumirpc.Codegen.Diagnostic();
+                rpcDiagnostic.Detail = diagnostic.Detail ?? "";
+                rpcDiagnostic.Summary = diagnostic.Summary ?? "";
+                rpcDiagnostic.Severity = diagnostic.Severity switch
+                {
+                    DiagnosticSeverity.Warning => Pulumirpc.Codegen.DiagnosticSeverity.DiagWarning,
+                    DiagnosticSeverity.Error => Pulumirpc.Codegen.DiagnosticSeverity.DiagError,
+                    _ => Pulumirpc.Codegen.DiagnosticSeverity.DiagInvalid
+                };
+                if (diagnostic.Subject != null)
+                {
+                    rpcDiagnostic.Subject = RpcRange(diagnostic.Subject);
+                }
+
+                if (diagnostic.Context != null)
+                {
+                    rpcDiagnostic.Context = RpcRange(diagnostic.Context);
+                }
+
+                rpcResponse.Diagnostics.Add(rpcDiagnostic);
+            }
+
+            return rpcResponse;
+        }
+    }
+}

--- a/sdk/Pulumi/Pulumi.csproj
+++ b/sdk/Pulumi/Pulumi.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Include="Grpc.Net.Client" Version="2.43.0" />
     <PackageReference Include="Grpc.AspNetCore.Server" Version="2.37.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.37.0" />
     <PackageReference Include="Grpc.Tools" Version="2.44.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -170,6 +170,83 @@
             ConfigMissingException is used when a configuration value is completely missing.
             </summary>
         </member>
+        <member name="T:Pulumi.Experimental.Provider.LogSeverity">
+            <summary>
+            LogSeverity is the severity level of a log message.  Errors are fatal; all others are informational.
+            </summary>
+        </member>
+        <member name="F:Pulumi.Experimental.Provider.LogSeverity.Debug">
+            <summary>
+            A debug-level message not displayed to end-users (the default).
+            </summary>
+        </member>
+        <member name="F:Pulumi.Experimental.Provider.LogSeverity.Info">
+            <summary>
+            An informational message printed to output during resource operations.
+            </summary>
+        </member>
+        <member name="F:Pulumi.Experimental.Provider.LogSeverity.Warning">
+            <summary>
+            A warning to indicate that something went wrong.
+            </summary>
+        </member>
+        <member name="F:Pulumi.Experimental.Provider.LogSeverity.Error">
+            <summary>
+            A fatal error indicating that the tool should stop processing subsequent resource operations.
+            </summary>
+        </member>
+        <member name="T:Pulumi.Experimental.Provider.LogMessage">
+            <summary>
+            A log message to be sent to the Pulumi engine.
+            </summary>
+        </member>
+        <member name="F:Pulumi.Experimental.Provider.LogMessage.Severity">
+            <summary>
+            The logging level of this message.
+            </summary>
+        </member>
+        <member name="F:Pulumi.Experimental.Provider.LogMessage.Message">
+            <summary>
+            The contents of the logged message.
+            </summary>
+        </member>
+        <member name="F:Pulumi.Experimental.Provider.LogMessage.Urn">
+            <summary>
+            The (optional) resource urn this log is associated with.
+            </summary>
+        </member>
+        <member name="F:Pulumi.Experimental.Provider.LogMessage.StreamId">
+            <summary>
+            The (optional) stream id that a stream of log messages can be associated with. This allows
+            clients to not have to buffer a large set of log messages that they all want to be
+            conceptually connected.  Instead the messages can be sent as chunks (with the same stream id)
+            and the end display can show the messages as they arrive, while still stitching them together
+            into one total log message.
+            </summary>
+            <remarks>
+            0 means do not associate with any stream.
+            </remarks>
+        </member>
+        <member name="F:Pulumi.Experimental.Provider.LogMessage.Ephemeral">
+            <summary>
+            Optional value indicating whether this is a status message.
+            </summary>
+        </member>
+        <member name="T:Pulumi.Experimental.Provider.IHost">
+            <summary>
+            An interface to the engine host running this plugin.
+            </summary>
+        </member>
+        <member name="M:Pulumi.Experimental.Provider.IHost.LogAsync(Pulumi.Experimental.Provider.LogMessage)">
+            <summary>
+            Send a log message to the host.
+            </summary>
+        </member>
+        <member name="T:Pulumi.Experimental.Provider.PropertyValueType">
+            <summary>
+            Property values will be one of these types.
+            </summary>
+        </member>
         <member name="T:Pulumi.Alias">
             <summary>
             Alias is a description of prior named used for a resource. It can be processed in the
@@ -1552,83 +1629,6 @@
             <summary>
             Logs an exception. Consider raising the exception after
             calling this method to stop the Pulumi program.
-            </summary>
-        </member>
-        <member name="T:Pulumi.Experimental.Provider.LogSeverity">
-            <summary>
-            LogSeverity is the severity level of a log message.  Errors are fatal; all others are informational.
-            </summary>
-        </member>
-        <member name="F:Pulumi.Experimental.Provider.LogSeverity.Debug">
-            <summary>
-            A debug-level message not displayed to end-users (the default).
-            </summary>
-        </member>
-        <member name="F:Pulumi.Experimental.Provider.LogSeverity.Info">
-            <summary>
-            An informational message printed to output during resource operations.
-            </summary>
-        </member>
-        <member name="F:Pulumi.Experimental.Provider.LogSeverity.Warning">
-            <summary>
-            A warning to indicate that something went wrong.
-            </summary>
-        </member>
-        <member name="F:Pulumi.Experimental.Provider.LogSeverity.Error">
-            <summary>
-            A fatal error indicating that the tool should stop processing subsequent resource operations.
-            </summary>
-        </member>
-        <member name="T:Pulumi.Experimental.Provider.LogMessage">
-            <summary>
-            A log message to be sent to the Pulumi engine.
-            </summary>
-        </member>
-        <member name="F:Pulumi.Experimental.Provider.LogMessage.Severity">
-            <summary>
-            The logging level of this message.
-            </summary>
-        </member>
-        <member name="F:Pulumi.Experimental.Provider.LogMessage.Message">
-            <summary>
-            The contents of the logged message.
-            </summary>
-        </member>
-        <member name="F:Pulumi.Experimental.Provider.LogMessage.Urn">
-            <summary>
-            The (optional) resource urn this log is associated with.
-            </summary>
-        </member>
-        <member name="F:Pulumi.Experimental.Provider.LogMessage.StreamId">
-            <summary>
-            The (optional) stream id that a stream of log messages can be associated with. This allows
-            clients to not have to buffer a large set of log messages that they all want to be
-            conceptually connected.  Instead the messages can be sent as chunks (with the same stream id)
-            and the end display can show the messages as they arrive, while still stitching them together
-            into one total log message.
-            </summary>
-            <remarks>
-            0 means do not associate with any stream.
-            </remarks>
-        </member>
-        <member name="F:Pulumi.Experimental.Provider.LogMessage.Ephemeral">
-            <summary>
-            Optional value indicating whether this is a status message.
-            </summary>
-        </member>
-        <member name="T:Pulumi.Experimental.Provider.IHost">
-            <summary>
-            An interface to the engine host running this plugin.
-            </summary>
-        </member>
-        <member name="M:Pulumi.Experimental.Provider.IHost.LogAsync(Pulumi.Experimental.Provider.LogMessage)">
-            <summary>
-            Send a log message to the host.
-            </summary>
-        </member>
-        <member name="T:Pulumi.Experimental.Provider.PropertyValueType">
-            <summary>
-            Property values will be one of these types.
             </summary>
         </member>
         <member name="T:Pulumi.CallArgs">
@@ -3629,6 +3629,140 @@
             <param name="serviceBinder">Service methods will be bound by calling <c>AddMethod</c> on this object.</param>
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
         </member>
+        <member name="T:Pulumirpc.Codegen.HclReflection">
+            <summary>Holder for reflection information generated from pulumi/codegen/hcl.proto</summary>
+        </member>
+        <member name="P:Pulumirpc.Codegen.HclReflection.Descriptor">
+            <summary>File descriptor for pulumi/codegen/hcl.proto</summary>
+        </member>
+        <member name="T:Pulumirpc.Codegen.DiagnosticSeverity">
+            <summary>
+            DiagnosticSeverity is the severity level of a diagnostic message.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.Codegen.DiagnosticSeverity.DiagInvalid">
+            <summary>
+            DIAG_INVALID is the invalid zero value of DiagnosticSeverity
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.Codegen.DiagnosticSeverity.DiagError">
+            <summary>
+            DIAG_ERROR indicates that the problem reported by a diagnostic prevents
+            further progress in parsing and/or evaluating the subject.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.Codegen.DiagnosticSeverity.DiagWarning">
+            <summary>
+            DIAG_WARNING indicates that the problem reported by a diagnostic warrants
+            user attention but does not prevent further progress. It is most
+            commonly used for showing deprecation notices.
+            </summary>
+        </member>
+        <member name="T:Pulumirpc.Codegen.Pos">
+            <summary>
+            Pos represents a single position in a source file, by addressing the start byte of a unicode character
+            encoded in UTF-8.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.Codegen.Pos.LineFieldNumber">
+            <summary>Field number for the "line" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.Codegen.Pos.Line">
+            <summary>
+            Line is the source code line where this position points. Lines are counted starting at 1 and
+            incremented for each newline character encountered.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.Codegen.Pos.ColumnFieldNumber">
+            <summary>Field number for the "column" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.Codegen.Pos.Column">
+             <summary>
+             Column is the source code column where this position points, in unicode characters, with counting
+             starting at 1.
+            
+             Column counts characters as they appear visually, so for example a latin letter with a combining
+             diacritic mark counts as one character. This is intended for rendering visual markers against source
+             code in contexts where these diacritics would be rendered in a single character cell. Technically
+             speaking, Column is counting grapheme clusters as used in unicode normalization.
+             </summary>
+        </member>
+        <member name="F:Pulumirpc.Codegen.Pos.ByteFieldNumber">
+            <summary>Field number for the "byte" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.Codegen.Pos.Byte">
+            <summary>
+            Byte is the byte offset into the file where the indicated character begins. This is a zero-based offset
+            to the first byte of the first UTF-8 codepoint sequence in the character, and thus gives a position
+            that can be resolved _without_ awareness of Unicode characters.
+            </summary>
+        </member>
+        <member name="T:Pulumirpc.Codegen.Range">
+            <summary>
+            Range represents a span of characters between two positions in a source file.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.Codegen.Range.FilenameFieldNumber">
+            <summary>Field number for the "filename" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.Codegen.Range.Filename">
+            <summary>
+            Filename is the name of the file into which this range's positions point.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.Codegen.Range.StartFieldNumber">
+            <summary>Field number for the "start" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.Codegen.Range.Start">
+            <summary>
+            Start and End represent the bounds of this range. Start is inclusive and End is exclusive.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.Codegen.Range.EndFieldNumber">
+            <summary>Field number for the "end" field.</summary>
+        </member>
+        <member name="T:Pulumirpc.Codegen.Diagnostic">
+            <summary>
+            Diagnostic represents information to be presented to a user about an error or anomaly in parsing or evaluating configuration.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.Codegen.Diagnostic.SeverityFieldNumber">
+            <summary>Field number for the "severity" field.</summary>
+        </member>
+        <member name="F:Pulumirpc.Codegen.Diagnostic.SummaryFieldNumber">
+            <summary>Field number for the "summary" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.Codegen.Diagnostic.Summary">
+            <summary>
+            Summary and Detail contain the English-language description of the
+            problem. Summary is a terse description of the general problem and
+            detail is a more elaborate, often-multi-sentence description of
+            the problem and what might be done to solve it.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.Codegen.Diagnostic.DetailFieldNumber">
+            <summary>Field number for the "detail" field.</summary>
+        </member>
+        <member name="F:Pulumirpc.Codegen.Diagnostic.SubjectFieldNumber">
+            <summary>Field number for the "subject" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.Codegen.Diagnostic.Subject">
+             <summary>
+             Subject and Context are both source ranges relating to the diagnostic.
+            
+             Subject is a tight range referring to exactly the construct that
+             is problematic, while Context is an optional broader range (which should
+             fully contain Subject) that ought to be shown around Subject when
+             generating isolated source-code snippets in diagnostic messages.
+             If Context is nil, the Subject is also the Context.
+            
+             Some diagnostics have no source ranges at all. If Context is set then
+             Subject should always also be set.
+             </summary>
+        </member>
+        <member name="F:Pulumirpc.Codegen.Diagnostic.ContextFieldNumber">
+            <summary>Field number for the "context" field.</summary>
+        </member>
         <member name="T:Pulumirpc.ConverterReflection">
             <summary>Holder for reflection information generated from pulumi/converter.proto</summary>
         </member>
@@ -3640,7 +3774,7 @@
         </member>
         <member name="P:Pulumirpc.ConvertStateRequest.MapperTarget">
             <summary>
-            the gRPC address of the mapper service.
+            the gRPC target of the mapper service.
             </summary>
         </member>
         <member name="T:Pulumirpc.ResourceImport">
@@ -3717,7 +3851,15 @@
         </member>
         <member name="P:Pulumirpc.ConvertProgramRequest.MapperTarget">
             <summary>
-            the gRPC address of the mapper service.
+            the gRPC target of the mapper service.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.ConvertProgramResponse.DiagnosticsFieldNumber">
+            <summary>Field number for the "diagnostics" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ConvertProgramResponse.Diagnostics">
+            <summary>
+            any diagnostics from code generation.
             </summary>
         </member>
         <member name="T:Pulumirpc.Converter">
@@ -4485,6 +4627,118 @@
         <member name="T:Pulumirpc.RunPluginResponse.OutputOneofCase">
             <summary>Enum of possible cases for the "output" oneof.</summary>
         </member>
+        <member name="F:Pulumirpc.GenerateProgramRequest.SourceFieldNumber">
+            <summary>Field number for the "source" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.GenerateProgramRequest.Source">
+            <summary>
+            the PCL source of the project.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.GenerateProgramRequest.LoaderTargetFieldNumber">
+            <summary>Field number for the "loader_target" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.GenerateProgramRequest.LoaderTarget">
+            <summary>
+            The target of a codegen.LoaderServer to use for loading schemas.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.GenerateProgramResponse.DiagnosticsFieldNumber">
+            <summary>Field number for the "diagnostics" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.GenerateProgramResponse.Diagnostics">
+            <summary>
+            any diagnostics from code generation.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.GenerateProgramResponse.SourceFieldNumber">
+            <summary>Field number for the "source" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.GenerateProgramResponse.Source">
+            <summary>
+            the generated program source code.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.GenerateProjectRequest.SourceDirectoryFieldNumber">
+            <summary>Field number for the "source_directory" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.GenerateProjectRequest.SourceDirectory">
+            <summary>
+            the directory to generate the project from.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.GenerateProjectRequest.TargetDirectoryFieldNumber">
+            <summary>Field number for the "target_directory" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.GenerateProjectRequest.TargetDirectory">
+            <summary>
+            the directory to generate the project in.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.GenerateProjectRequest.ProjectFieldNumber">
+            <summary>Field number for the "project" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.GenerateProjectRequest.Project">
+            <summary>
+            the JSON-encoded pulumi project file.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.GenerateProjectRequest.StrictFieldNumber">
+            <summary>Field number for the "strict" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.GenerateProjectRequest.Strict">
+            <summary>
+            if PCL binding should be strict or not.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.GenerateProjectRequest.LoaderTargetFieldNumber">
+            <summary>Field number for the "loader_target" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.GenerateProjectRequest.LoaderTarget">
+            <summary>
+            The target of a codegen.LoaderServer to use for loading schemas.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.GenerateProjectResponse.DiagnosticsFieldNumber">
+            <summary>Field number for the "diagnostics" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.GenerateProjectResponse.Diagnostics">
+            <summary>
+            any diagnostics from code generation.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.GeneratePackageRequest.DirectoryFieldNumber">
+            <summary>Field number for the "directory" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.GeneratePackageRequest.Directory">
+            <summary>
+            the directory to generate the package in.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.GeneratePackageRequest.SchemaFieldNumber">
+            <summary>Field number for the "schema" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.GeneratePackageRequest.Schema">
+            <summary>
+            the JSON-encoded schema.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.GeneratePackageRequest.ExtraFilesFieldNumber">
+            <summary>Field number for the "extra_files" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.GeneratePackageRequest.ExtraFiles">
+            <summary>
+            extra files to copy to the package output.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.GeneratePackageRequest.LoaderTargetFieldNumber">
+            <summary>Field number for the "loader_target" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.GeneratePackageRequest.LoaderTarget">
+            <summary>
+            The target of a codegen.LoaderServer to use for loading schemas.
+            </summary>
+        </member>
         <member name="T:Pulumirpc.LanguageRuntime">
             <summary>
             LanguageRuntime is the interface that the planning monitor uses to drive execution of an interpreter responsible
@@ -4554,6 +4808,30 @@
             <param name="responseStream">Used for sending responses back to the client.</param>
             <param name="context">The context of the server-side call handler being invoked.</param>
             <returns>A task indicating completion of the handler.</returns>
+        </member>
+        <member name="M:Pulumirpc.LanguageRuntime.LanguageRuntimeBase.GenerateProgram(Pulumirpc.GenerateProgramRequest,Grpc.Core.ServerCallContext)">
+            <summary>
+            GenerateProgram generates a given PCL program into a program for this language.
+            </summary>
+            <param name="request">The request received from the client.</param>
+            <param name="context">The context of the server-side call handler being invoked.</param>
+            <returns>The response to send back to the client (wrapped by a task).</returns>
+        </member>
+        <member name="M:Pulumirpc.LanguageRuntime.LanguageRuntimeBase.GenerateProject(Pulumirpc.GenerateProjectRequest,Grpc.Core.ServerCallContext)">
+            <summary>
+            GenerateProject generates a given PCL program into a project for this language.
+            </summary>
+            <param name="request">The request received from the client.</param>
+            <param name="context">The context of the server-side call handler being invoked.</param>
+            <returns>The response to send back to the client (wrapped by a task).</returns>
+        </member>
+        <member name="M:Pulumirpc.LanguageRuntime.LanguageRuntimeBase.GeneratePackage(Pulumirpc.GeneratePackageRequest,Grpc.Core.ServerCallContext)">
+            <summary>
+            GeneratePackage generates a given pulumi package into a package for this language.
+            </summary>
+            <param name="request">The request received from the client.</param>
+            <param name="context">The context of the server-side call handler being invoked.</param>
+            <returns>The response to send back to the client (wrapped by a task).</returns>
         </member>
         <member name="T:Pulumirpc.LanguageRuntime.LanguageRuntimeClient">
             <summary>Client for LanguageRuntime</summary>
@@ -4789,6 +5067,114 @@
             <param name="options">The options for the call.</param>
             <returns>The call object.</returns>
         </member>
+        <member name="M:Pulumirpc.LanguageRuntime.LanguageRuntimeClient.GenerateProgram(Pulumirpc.GenerateProgramRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
+            <summary>
+            GenerateProgram generates a given PCL program into a program for this language.
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+            <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+            <param name="cancellationToken">An optional token for canceling the call.</param>
+            <returns>The response received from the server.</returns>
+        </member>
+        <member name="M:Pulumirpc.LanguageRuntime.LanguageRuntimeClient.GenerateProgram(Pulumirpc.GenerateProgramRequest,Grpc.Core.CallOptions)">
+            <summary>
+            GenerateProgram generates a given PCL program into a program for this language.
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="options">The options for the call.</param>
+            <returns>The response received from the server.</returns>
+        </member>
+        <member name="M:Pulumirpc.LanguageRuntime.LanguageRuntimeClient.GenerateProgramAsync(Pulumirpc.GenerateProgramRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
+            <summary>
+            GenerateProgram generates a given PCL program into a program for this language.
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+            <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+            <param name="cancellationToken">An optional token for canceling the call.</param>
+            <returns>The call object.</returns>
+        </member>
+        <member name="M:Pulumirpc.LanguageRuntime.LanguageRuntimeClient.GenerateProgramAsync(Pulumirpc.GenerateProgramRequest,Grpc.Core.CallOptions)">
+            <summary>
+            GenerateProgram generates a given PCL program into a program for this language.
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="options">The options for the call.</param>
+            <returns>The call object.</returns>
+        </member>
+        <member name="M:Pulumirpc.LanguageRuntime.LanguageRuntimeClient.GenerateProject(Pulumirpc.GenerateProjectRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
+            <summary>
+            GenerateProject generates a given PCL program into a project for this language.
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+            <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+            <param name="cancellationToken">An optional token for canceling the call.</param>
+            <returns>The response received from the server.</returns>
+        </member>
+        <member name="M:Pulumirpc.LanguageRuntime.LanguageRuntimeClient.GenerateProject(Pulumirpc.GenerateProjectRequest,Grpc.Core.CallOptions)">
+            <summary>
+            GenerateProject generates a given PCL program into a project for this language.
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="options">The options for the call.</param>
+            <returns>The response received from the server.</returns>
+        </member>
+        <member name="M:Pulumirpc.LanguageRuntime.LanguageRuntimeClient.GenerateProjectAsync(Pulumirpc.GenerateProjectRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
+            <summary>
+            GenerateProject generates a given PCL program into a project for this language.
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+            <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+            <param name="cancellationToken">An optional token for canceling the call.</param>
+            <returns>The call object.</returns>
+        </member>
+        <member name="M:Pulumirpc.LanguageRuntime.LanguageRuntimeClient.GenerateProjectAsync(Pulumirpc.GenerateProjectRequest,Grpc.Core.CallOptions)">
+            <summary>
+            GenerateProject generates a given PCL program into a project for this language.
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="options">The options for the call.</param>
+            <returns>The call object.</returns>
+        </member>
+        <member name="M:Pulumirpc.LanguageRuntime.LanguageRuntimeClient.GeneratePackage(Pulumirpc.GeneratePackageRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
+            <summary>
+            GeneratePackage generates a given pulumi package into a package for this language.
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+            <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+            <param name="cancellationToken">An optional token for canceling the call.</param>
+            <returns>The response received from the server.</returns>
+        </member>
+        <member name="M:Pulumirpc.LanguageRuntime.LanguageRuntimeClient.GeneratePackage(Pulumirpc.GeneratePackageRequest,Grpc.Core.CallOptions)">
+            <summary>
+            GeneratePackage generates a given pulumi package into a package for this language.
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="options">The options for the call.</param>
+            <returns>The response received from the server.</returns>
+        </member>
+        <member name="M:Pulumirpc.LanguageRuntime.LanguageRuntimeClient.GeneratePackageAsync(Pulumirpc.GeneratePackageRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
+            <summary>
+            GeneratePackage generates a given pulumi package into a package for this language.
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+            <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+            <param name="cancellationToken">An optional token for canceling the call.</param>
+            <returns>The call object.</returns>
+        </member>
+        <member name="M:Pulumirpc.LanguageRuntime.LanguageRuntimeClient.GeneratePackageAsync(Pulumirpc.GeneratePackageRequest,Grpc.Core.CallOptions)">
+            <summary>
+            GeneratePackage generates a given pulumi package into a package for this language.
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="options">The options for the call.</param>
+            <returns>The call object.</returns>
+        </member>
         <member name="M:Pulumirpc.LanguageRuntime.LanguageRuntimeClient.NewInstance(Grpc.Core.ClientBase.ClientBaseConfiguration)">
             <summary>Creates a new instance of client from given <c>ClientBaseConfiguration</c>.</summary>
         </member>
@@ -4927,6 +5313,14 @@
         <member name="P:Pulumirpc.ConfigureRequest.AcceptResources">
             <summary>
             when true, operations should return resources as strongly typed values to the provider.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.ConfigureRequest.SendsOldInputsFieldNumber">
+            <summary>Field number for the "sends_old_inputs" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ConfigureRequest.SendsOldInputs">
+            <summary>
+            when true, diff and update will be called with the old outputs and the old inputs.
             </summary>
         </member>
         <member name="F:Pulumirpc.ConfigureResponse.AcceptSecretsFieldNumber">
@@ -5137,6 +5531,14 @@
             the organization of the stack being deployed into.
             </summary>
         </member>
+        <member name="F:Pulumirpc.CallRequest.SourcePositionFieldNumber">
+            <summary>Field number for the "sourcePosition" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.CallRequest.SourcePosition">
+            <summary>
+            the optional source position of the user code that initiated the call.
+            </summary>
+        </member>
         <member name="T:Pulumirpc.CallRequest.Types">
             <summary>Container for nested types declared in the CallRequest message type.</summary>
         </member>
@@ -5278,7 +5680,7 @@
         </member>
         <member name="P:Pulumirpc.DiffRequest.Olds">
             <summary>
-            the old values of provider inputs to diff.
+            the old output values of resource to diff.
             </summary>
         </member>
         <member name="F:Pulumirpc.DiffRequest.NewsFieldNumber">
@@ -5286,7 +5688,7 @@
         </member>
         <member name="P:Pulumirpc.DiffRequest.News">
             <summary>
-            the new values of provider inputs to diff.
+            the new input values of resource to diff.
             </summary>
         </member>
         <member name="F:Pulumirpc.DiffRequest.IgnoreChangesFieldNumber">
@@ -5295,6 +5697,14 @@
         <member name="P:Pulumirpc.DiffRequest.IgnoreChanges">
             <summary>
             a set of property paths that should be treated as unchanged.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.DiffRequest.OldInputsFieldNumber">
+            <summary>Field number for the "old_inputs" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.DiffRequest.OldInputs">
+            <summary>
+            the old input values of the resource to diff.
             </summary>
         </member>
         <member name="F:Pulumirpc.PropertyDiff.KindFieldNumber">
@@ -5619,6 +6029,14 @@
             true if this is a preview and the provider should not actually create the resource.
             </summary>
         </member>
+        <member name="F:Pulumirpc.UpdateRequest.OldInputsFieldNumber">
+            <summary>Field number for the "old_inputs" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.UpdateRequest.OldInputs">
+            <summary>
+            the old input values of the resource to diff.
+            </summary>
+        </member>
         <member name="F:Pulumirpc.UpdateResponse.PropertiesFieldNumber">
             <summary>Field number for the "properties" field.</summary>
         </member>
@@ -5747,28 +6165,12 @@
             a map from property keys to the dependencies of the property.
             </summary>
         </member>
-        <member name="F:Pulumirpc.ConstructRequest.ProtectFieldNumber">
-            <summary>Field number for the "protect" field.</summary>
-        </member>
-        <member name="P:Pulumirpc.ConstructRequest.Protect">
-            <summary>
-            true if the resource should be marked protected.
-            </summary>
-        </member>
         <member name="F:Pulumirpc.ConstructRequest.ProvidersFieldNumber">
             <summary>Field number for the "providers" field.</summary>
         </member>
         <member name="P:Pulumirpc.ConstructRequest.Providers">
             <summary>
             the map of providers to use for this resource's children.
-            </summary>
-        </member>
-        <member name="F:Pulumirpc.ConstructRequest.AliasesFieldNumber">
-            <summary>Field number for the "aliases" field.</summary>
-        </member>
-        <member name="P:Pulumirpc.ConstructRequest.Aliases">
-            <summary>
-            a list of additional URNs that shoud be considered the same.
             </summary>
         </member>
         <member name="F:Pulumirpc.ConstructRequest.DependenciesFieldNumber">
@@ -5795,6 +6197,79 @@
             the organization of the stack being deployed into.
             </summary>
         </member>
+        <member name="F:Pulumirpc.ConstructRequest.ProtectFieldNumber">
+            <summary>Field number for the "protect" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ConstructRequest.Protect">
+            <summary>
+            Resource options:
+            Do not change field IDs. Add new fields at the end.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.ConstructRequest.AliasesFieldNumber">
+            <summary>Field number for the "aliases" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ConstructRequest.Aliases">
+            <summary>
+            a list of additional URNs that shoud be considered the same.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.ConstructRequest.AdditionalSecretOutputsFieldNumber">
+            <summary>Field number for the "additionalSecretOutputs" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ConstructRequest.AdditionalSecretOutputs">
+            <summary>
+            additional output properties that should be treated as secrets.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.ConstructRequest.CustomTimeoutsFieldNumber">
+            <summary>Field number for the "customTimeouts" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ConstructRequest.CustomTimeouts">
+            <summary>
+            default timeouts for CRUD operations on this resource.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.ConstructRequest.DeletedWithFieldNumber">
+            <summary>Field number for the "deletedWith" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ConstructRequest.DeletedWith">
+            <summary>
+            URN of a resource that, if deleted, also deletes this resource.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.ConstructRequest.DeleteBeforeReplaceFieldNumber">
+            <summary>Field number for the "deleteBeforeReplace" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ConstructRequest.DeleteBeforeReplace">
+            <summary>
+            whether to delete the resource before replacing it.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.ConstructRequest.IgnoreChangesFieldNumber">
+            <summary>Field number for the "ignoreChanges" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ConstructRequest.IgnoreChanges">
+            <summary>
+            properties that should be ignored during a diff
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.ConstructRequest.ReplaceOnChangesFieldNumber">
+            <summary>Field number for the "replaceOnChanges" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ConstructRequest.ReplaceOnChanges">
+            <summary>
+            properties that, when changed, trigger a replacement
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.ConstructRequest.RetainOnDeleteFieldNumber">
+            <summary>Field number for the "retainOnDelete" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ConstructRequest.RetainOnDelete">
+            <summary>
+            whether to retain the resource in the cloud provider when it is deleted
+            </summary>
+        </member>
         <member name="T:Pulumirpc.ConstructRequest.Types">
             <summary>Container for nested types declared in the ConstructRequest message type.</summary>
         </member>
@@ -5810,6 +6285,36 @@
             <summary>
             A list of URNs this property depends on.
             </summary>
+        </member>
+        <member name="T:Pulumirpc.ConstructRequest.Types.CustomTimeouts">
+             <summary>
+             CustomTimeouts specifies timeouts for resource provisioning operations.
+             Use it with the [Timeouts] option when creating new resources
+             to override default timeouts.
+            
+             Each timeout is specified as a duration string such as,
+             "5ms" (5 milliseconds), "40s" (40 seconds),
+             and "1m30s" (1 minute, 30 seconds).
+            
+             The following units are accepted.
+            
+               - ns: nanoseconds
+               - us: microseconds
+               - µs: microseconds
+               - ms: milliseconds
+               - s: seconds
+               - m: minutes
+               - h: hours
+             </summary>
+        </member>
+        <member name="F:Pulumirpc.ConstructRequest.Types.CustomTimeouts.CreateFieldNumber">
+            <summary>Field number for the "create" field.</summary>
+        </member>
+        <member name="F:Pulumirpc.ConstructRequest.Types.CustomTimeouts.UpdateFieldNumber">
+            <summary>Field number for the "update" field.</summary>
+        </member>
+        <member name="F:Pulumirpc.ConstructRequest.Types.CustomTimeouts.DeleteFieldNumber">
+            <summary>Field number for the "delete" field.</summary>
         </member>
         <member name="F:Pulumirpc.ConstructResponse.UrnFieldNumber">
             <summary>Field number for the "urn" field.</summary>
@@ -6932,6 +7437,14 @@
             the server url of the provider to use when servicing this request.
             </summary>
         </member>
+        <member name="F:Pulumirpc.ReadResourceRequest.SourcePositionFieldNumber">
+            <summary>Field number for the "sourcePosition" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ReadResourceRequest.SourcePosition">
+            <summary>
+            the optional source position of the user code that initiated the read.
+            </summary>
+        </member>
         <member name="T:Pulumirpc.ReadResourceResponse">
             <summary>
             ReadResourceResponse contains the result of reading a resource's state.
@@ -7174,6 +7687,28 @@
             if set the engine will not call the resource providers delete method for this resource when specified resource is deleted.
             </summary>
         </member>
+        <member name="F:Pulumirpc.RegisterResourceRequest.AliasSpecsFieldNumber">
+            <summary>Field number for the "aliasSpecs" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.RegisterResourceRequest.AliasSpecs">
+            <summary>
+            Indicates that alias specs are specified correctly according to the spec.
+            Older versions of the Node.js SDK did not send alias specs correctly.
+            If this is not set to true and the engine detects the request is from the
+            Node.js runtime, the engine will transform incorrect alias specs into
+            correct ones.
+            Other SDKs that are correctly specifying alias specs could set this to
+            true, but it's not necessary.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.RegisterResourceRequest.SourcePositionFieldNumber">
+            <summary>Field number for the "sourcePosition" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.RegisterResourceRequest.SourcePosition">
+            <summary>
+            the optional source position of the user code that initiated the register.
+            </summary>
+        </member>
         <member name="T:Pulumirpc.RegisterResourceRequest.Types">
             <summary>Container for nested types declared in the RegisterResourceRequest message type.</summary>
         </member>
@@ -7358,6 +7893,14 @@
             an optional reference to the provider url to use for this invoke.
             </summary>
         </member>
+        <member name="F:Pulumirpc.ResourceInvokeRequest.SourcePositionFieldNumber">
+            <summary>Field number for the "sourcePosition" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ResourceInvokeRequest.SourcePosition">
+            <summary>
+            the optional source position of the user code that initiated the invoke.
+            </summary>
+        </member>
         <member name="T:Pulumirpc.ResourceMonitor">
             <summary>
             ResourceMonitor is the interface a source uses to talk back to the planning monitor orchestrating the execution.
@@ -7400,6 +7943,168 @@
             <param name="serviceBinder">Service methods will be bound by calling <c>AddMethod</c> on this object.</param>
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
         </member>
+        <member name="T:Pulumirpc.SourceReflection">
+            <summary>Holder for reflection information generated from pulumi/source.proto</summary>
+        </member>
+        <member name="P:Pulumirpc.SourceReflection.Descriptor">
+            <summary>File descriptor for pulumi/source.proto</summary>
+        </member>
+        <member name="T:Pulumirpc.SourcePosition">
+            <summary>
+            A SourcePosition represents a position in a source file.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.SourcePosition.UriFieldNumber">
+            <summary>Field number for the "uri" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.SourcePosition.Uri">
+            <summary>
+            The URI of the file. Currently only the file scheme with an absolute path is supported.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.SourcePosition.LineFieldNumber">
+            <summary>Field number for the "line" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.SourcePosition.Line">
+            <summary>
+            The line in the file
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.SourcePosition.ColumnFieldNumber">
+            <summary>Field number for the "column" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.SourcePosition.Column">
+            <summary>
+            The column in the line
+            </summary>
+        </member>
+        <member name="T:Codegen.LoaderReflection">
+            <summary>Holder for reflection information generated from pulumi/codegen/loader.proto</summary>
+        </member>
+        <member name="P:Codegen.LoaderReflection.Descriptor">
+            <summary>File descriptor for pulumi/codegen/loader.proto</summary>
+        </member>
+        <member name="T:Codegen.GetSchemaRequest">
+            <summary>
+            GetSchemaRequest allows the engine to return a schema for a given package and version.
+            </summary>
+        </member>
+        <member name="F:Codegen.GetSchemaRequest.PackageFieldNumber">
+            <summary>Field number for the "package" field.</summary>
+        </member>
+        <member name="P:Codegen.GetSchemaRequest.Package">
+            <summary>
+            the package name for the schema being requested.
+            </summary>
+        </member>
+        <member name="F:Codegen.GetSchemaRequest.VersionFieldNumber">
+            <summary>Field number for the "version" field.</summary>
+        </member>
+        <member name="P:Codegen.GetSchemaRequest.Version">
+            <summary>
+            the version for the schema being requested, must be a valid semver or empty.
+            </summary>
+        </member>
+        <member name="T:Codegen.GetSchemaResponse">
+            <summary>
+            GetSchemaResponse returns the schema data for the requested package.
+            </summary>
+        </member>
+        <member name="F:Codegen.GetSchemaResponse.SchemaFieldNumber">
+            <summary>Field number for the "schema" field.</summary>
+        </member>
+        <member name="P:Codegen.GetSchemaResponse.Schema">
+            <summary>
+            the JSON encoded schema.
+            </summary>
+        </member>
+        <member name="T:Codegen.Loader">
+            <summary>
+            Loader is a service for getting schemas from the Pulumi engine for use in code generators and other tools.
+            This is currently unstable and experimental.
+            </summary>
+        </member>
+        <member name="P:Codegen.Loader.Descriptor">
+            <summary>Service descriptor</summary>
+        </member>
+        <member name="T:Codegen.Loader.LoaderBase">
+            <summary>Base class for server-side implementations of Loader</summary>
+        </member>
+        <member name="M:Codegen.Loader.LoaderBase.GetSchema(Codegen.GetSchemaRequest,Grpc.Core.ServerCallContext)">
+            <summary>
+            GetSchema tries to find a schema for the given package and version.
+            </summary>
+            <param name="request">The request received from the client.</param>
+            <param name="context">The context of the server-side call handler being invoked.</param>
+            <returns>The response to send back to the client (wrapped by a task).</returns>
+        </member>
+        <member name="T:Codegen.Loader.LoaderClient">
+            <summary>Client for Loader</summary>
+        </member>
+        <member name="M:Codegen.Loader.LoaderClient.#ctor(Grpc.Core.ChannelBase)">
+            <summary>Creates a new client for Loader</summary>
+            <param name="channel">The channel to use to make remote calls.</param>
+        </member>
+        <member name="M:Codegen.Loader.LoaderClient.#ctor(Grpc.Core.CallInvoker)">
+            <summary>Creates a new client for Loader that uses a custom <c>CallInvoker</c>.</summary>
+            <param name="callInvoker">The callInvoker to use to make remote calls.</param>
+        </member>
+        <member name="M:Codegen.Loader.LoaderClient.#ctor">
+            <summary>Protected parameterless constructor to allow creation of test doubles.</summary>
+        </member>
+        <member name="M:Codegen.Loader.LoaderClient.#ctor(Grpc.Core.ClientBase.ClientBaseConfiguration)">
+            <summary>Protected constructor to allow creation of configured clients.</summary>
+            <param name="configuration">The client configuration.</param>
+        </member>
+        <member name="M:Codegen.Loader.LoaderClient.GetSchema(Codegen.GetSchemaRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
+            <summary>
+            GetSchema tries to find a schema for the given package and version.
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+            <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+            <param name="cancellationToken">An optional token for canceling the call.</param>
+            <returns>The response received from the server.</returns>
+        </member>
+        <member name="M:Codegen.Loader.LoaderClient.GetSchema(Codegen.GetSchemaRequest,Grpc.Core.CallOptions)">
+            <summary>
+            GetSchema tries to find a schema for the given package and version.
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="options">The options for the call.</param>
+            <returns>The response received from the server.</returns>
+        </member>
+        <member name="M:Codegen.Loader.LoaderClient.GetSchemaAsync(Codegen.GetSchemaRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
+            <summary>
+            GetSchema tries to find a schema for the given package and version.
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+            <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+            <param name="cancellationToken">An optional token for canceling the call.</param>
+            <returns>The call object.</returns>
+        </member>
+        <member name="M:Codegen.Loader.LoaderClient.GetSchemaAsync(Codegen.GetSchemaRequest,Grpc.Core.CallOptions)">
+            <summary>
+            GetSchema tries to find a schema for the given package and version.
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="options">The options for the call.</param>
+            <returns>The call object.</returns>
+        </member>
+        <member name="M:Codegen.Loader.LoaderClient.NewInstance(Grpc.Core.ClientBase.ClientBaseConfiguration)">
+            <summary>Creates a new instance of client from given <c>ClientBaseConfiguration</c>.</summary>
+        </member>
+        <member name="M:Codegen.Loader.BindService(Codegen.Loader.LoaderBase)">
+            <summary>Creates service definition that can be registered with a server</summary>
+            <param name="serviceImpl">An object implementing the server-side handling logic.</param>
+        </member>
+        <member name="M:Codegen.Loader.BindService(Grpc.Core.ServiceBinderBase,Codegen.Loader.LoaderBase)">
+            <summary>Register service method with a service binder with or without implementation. Useful when customizing the  service binding logic.
+            Note: this method is part of an experimental API that can change or be removed without any prior notice.</summary>
+            <param name="serviceBinder">Service methods will be bound by calling <c>AddMethod</c> on this object.</param>
+            <param name="serviceImpl">An object implementing the server-side handling logic.</param>
+        </member>
         <member name="T:Codegen.MapperReflection">
             <summary>Holder for reflection information generated from pulumi/codegen/mapper.proto</summary>
         </member>
@@ -7418,6 +8123,14 @@
         <member name="P:Codegen.GetMappingRequest.Provider">
             <summary>
             the provider name for the mapping being requested.
+            </summary>
+        </member>
+        <member name="F:Codegen.GetMappingRequest.PulumiProviderFieldNumber">
+            <summary>Field number for the "pulumi_provider" field.</summary>
+        </member>
+        <member name="P:Codegen.GetMappingRequest.PulumiProvider">
+            <summary>
+            the expected name of the pulumi provider that maps to the requested provider. Defaults to the same as 'provider'.
             </summary>
         </member>
         <member name="T:Codegen.GetMappingResponse">


### PR DESCRIPTION
This PR implements a `Converter` abstraction under the `Pulumi.Experimental.Converter` namespace which allows easily building and serving converter plugins from dotnet.

Minimal example:
```cs
using Pulumi.Experimental.Converter;

var converter = Converter.CreateSimple(request =>
{
    return ConvertProgramResponse.Empty;
});

await Converter.Serve(converter);
```
In F#:
```fs
open Pulumi.Experimental.Converter

let converter = Converter.CreateSimple (fun request -> ConvertProgramResponse.Empty)

converter
|> Converter.Serve
|> Async.AwaitTask
|> Async.RunSynchronously
```
Here, you give the converter implementation to `Converter.CreateSimple`, this gives you an instance of `SimpleProgramConverter` which implements `Converter`. Then you use that instance as an argument for `Converter.Serve`

Additionally, users can inherit `Converter` in a dedicated class and override the `ConvertProgram` function. 

The `ConvertState` function is not added yet, that can be done in a separate PR when necessary. 

Note that I executed `dotnet run sync-proto-files` to get latest additions from Pulumi (including the converter definitions)