### PR TITLE
Defend against invalid event data being parsed as json

### DIFF
--- a/sdk/Pulumi.Automation.Tests/EventLogWatcherTests.cs
+++ b/sdk/Pulumi.Automation.Tests/EventLogWatcherTests.cs
@@ -23,6 +23,15 @@ namespace Pulumi.Automation.Tests
         }
 
         [Fact]
+        public async Task ReceivesInvalidEventAndSkipsOver()
+        {
+            using var fx = new Fixture();
+            await fx.Write("notJson");
+            await fx.Watcher.Stop();
+            Assert.Equal(0, fx.EventCounter);
+        }
+
+        [Fact]
         public async Task ReceivesManyBasicEvents()
         {
             using var fx = new Fixture();

--- a/sdk/Pulumi.Automation.Tests/Serialization/GeneralJsonConverterTests.cs
+++ b/sdk/Pulumi.Automation.Tests/Serialization/GeneralJsonConverterTests.cs
@@ -140,5 +140,31 @@ namespace Pulumi.Automation.Tests.Serialization
             Assert.True(update.ResourceChanges.TryGetValue(OperationType.Create, out var createdCount));
             Assert.Equal(3, createdCount);
         }
+
+        [Fact]
+        public void CanValidateJson()
+        {
+            var json = @"
+[
+    {
+    ""isJson"": true
+    }
+]
+";
+
+            var isValid = _serializer.IsValidJson(json);
+
+            Assert.True(isValid);
+        }
+
+        [Fact]
+        public void DetectsInvalidJson()
+        {
+            var json = @"notValidJson";
+
+            var isValid = _serializer.IsValidJson(json);
+
+            Assert.False(isValid);
+        }
     }
 }

--- a/sdk/Pulumi.Automation/Events/EventLogWatcher.cs
+++ b/sdk/Pulumi.Automation/Events/EventLogWatcher.cs
@@ -98,7 +98,7 @@ namespace Pulumi.Automation.Events
             {
                 var line = await reader.ReadLineAsync().ConfigureAwait(false);
                 this._position = fs.Position;
-                if (!string.IsNullOrWhiteSpace(line))
+                if (!string.IsNullOrWhiteSpace(line) && _localSerializer.IsValidJson(line))
                 {
                     line = line.Trim();
                     var @event = _localSerializer.DeserializeJson<EngineEvent>(line);

--- a/sdk/Pulumi.Automation/Serialization/LocalSerializer.cs
+++ b/sdk/Pulumi.Automation/Serialization/LocalSerializer.cs
@@ -1,5 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation
 
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Pulumi.Automation.Events;
@@ -24,6 +25,21 @@ namespace Pulumi.Automation.Serialization
             // configure yaml
             this._yamlDeserializer = BuildYamlDeserializer();
             this._yamlSerializer = BuildYamlSerializer();
+        }
+
+        public bool IsValidJson(string content)
+        {
+            try
+            {
+                var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(content));
+                reader.Read();
+                reader.Skip();
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
         }
 
         public T DeserializeJson<T>(string content)


### PR DESCRIPTION
Adds some guards in a non-destructive way against invalid event data.

Will hopefully resolve: https://github.com/pulumi/pulumi-dotnet/issues/166

