### PR TITLE
plugin: Shut down gracefully on SIGINT

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,5 @@
 ### Improvements
 
+- Plugin: clean up resources and exit cleanly on receiving SIGINT or CTRL_BREAK.
+
 ### Bug Fixes


### PR DESCRIPTION
Shut the plugin down gracefully
when a SIGINT or CTRL_BREAK signal is received.

Related:

- https://github.com/pulumi/pulumi/pull/13809
- https://github.com/pulumi/pulumi-yaml/pull/501

Refs https://github.com/pulumi/pulumi/issues/9780
