### PR TITLE
ci: Add coverage tracking

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,9 +36,17 @@ jobs:
       - name: Build Pulumi SDK
         run: dotnet run build-sdk
       - name: Test Pulumi SDK
-        run: dotnet run test-sdk
+        run: dotnet run test-sdk coverage
       - name: Test Pulumi Automation SDK
-        run: dotnet run test-automation-sdk
+        run: dotnet run test-automation-sdk coverage
+      - name: Upload coverage data
+        uses: codecov/codecov-action@v3
+        with:
+          directory: coverage
+          files: "*"
+          fail_ci_if_error: false
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
   IntegrationTests:
     strategy:
         matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,8 @@ _TeamCity*
 .axoCover/*
 !.axoCover/settings.json
 
+/coverage
+
 # Coverlet is a free, cross platform Code Coverage Tool
 coverage*.json
 coverage*.xml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+coverage:
+  status:
+
+    # Project tracks and reports the project-level coverage.
+    project:
+      default:
+        informational: true
+
+    # Patch tracks the coverage of the changes in a single patch.
+    patch:
+      default:
+        informational: true
+
+# Don't comment on PRs.
+comment: false
+
+# Don't post annotations to GitHub.
+github_checks:
+    annotations: false

--- a/sdk/Pulumi.Automation.Tests/Pulumi.Automation.Tests.csproj
+++ b/sdk/Pulumi.Automation.Tests/Pulumi.Automation.Tests.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="2.0.4" />

--- a/sdk/Pulumi.Tests/Pulumi.Tests.csproj
+++ b/sdk/Pulumi.Tests/Pulumi.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This adds unit test coverage of the SDK and uploads to codecov. Will follow-up with lang host coverage in a separate PR.

Part of #162