### PR TITLE
[sdk] Register and await tasks created from `Apply` that don't return anything.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,5 @@
 ### Improvements
 
 ### Bug Fixes
+ 
+ - [sdk] Register and await tasks created from `Apply` that don't return anything.

--- a/sdk/Pulumi.Tests/Deployment/DeploymentRunnerTests.cs
+++ b/sdk/Pulumi.Tests/Deployment/DeploymentRunnerTests.cs
@@ -38,6 +38,38 @@ namespace Pulumi.Tests
         }
 
         [Fact]
+        public async Task NonGenericTaskIsAwaitedFromApply()
+        {
+            var deployResult = await Deployment.TryTestAsync<UsingNonGenericTaskInApplyStack>(
+                new EmptyMocks());
+            var stack = deployResult.Resources[0] as UsingNonGenericTaskInApplyStack;
+            var resultMessage = await stack.ResultMessage.GetValueAsync("");
+            Assert.Equal("After", resultMessage);
+        }
+
+        class UsingNonGenericTaskInApplyStack : Stack
+        {
+            [Output]
+            public Output<string> ResultMessage { get; set; }
+
+            public UsingNonGenericTaskInApplyStack()
+            {
+                ResultMessage = Output.Create("Before");
+
+                Output.Create(0).Apply(async _ =>
+                {
+                    await Work();
+                });
+            }
+
+            async Task Work()
+            {
+                await Task.Delay(5000);
+                this.ResultMessage = Output.Create("After");
+            }
+        }
+
+        [Fact]
         public async Task DisplaysExceptionFromStack()
         {
             var deployResult = await Deployment.TryTestAsync<ThrowsExceptionStack>(new EmptyMocks());

--- a/sdk/Pulumi/Core/Output.cs
+++ b/sdk/Pulumi/Core/Output.cs
@@ -502,15 +502,15 @@ namespace Pulumi
         /// <summary>
         /// <see cref="Output{T}.Apply{U}(Func{T, Output{U}})"/> for more details.
         /// </summary>
-        public Output<Task> Apply(Func<T, Task> func)
+        public Output<ValueTuple> Apply(Func<T, Task> func)
         {
             return Apply(t =>
             {
-                async Task<Task> WrapperTask()
+                async Task<ValueTuple> WrapperTask()
                 {
                     var underlyingTask = func(t);
                     await underlyingTask.ConfigureAwait(false);
-                    return underlyingTask;
+                    return ValueTuple.Create();
                 }
 
                 return Output.Create(WrapperTask());

--- a/sdk/Pulumi/Core/Output.cs
+++ b/sdk/Pulumi/Core/Output.cs
@@ -519,16 +519,9 @@ namespace Pulumi
                         }
 
                         // return an empty task of type U to satisfy the runtime
-                        // using reflection to create new Task(() => { })
                         // which doesn't have to be awaited because we awaited the original task
-                        Action emptyAction = () => { };
-                        var emptyTask = Activator.CreateInstance(typeof(Task), emptyAction);
-                        if (emptyTask != null)
-                        {
-                            return (U)emptyTask;
-                        }
-
-                        throw new InvalidOperationException("Unable to create empty task");
+                        var emptyTask = new Task(() => { }) as object;
+                        return (U)emptyTask;
                     }
 
                     return Output.Create(WrapperTask());

--- a/sdk/Pulumi/Core/Output.cs
+++ b/sdk/Pulumi/Core/Output.cs
@@ -510,9 +510,7 @@ namespace Pulumi
                 {
                     var underlyingTask = func(t);
                     await underlyingTask.ConfigureAwait(false);
-                    // return a completed task to satisfy the runtime
-                    // which doesn't need to be awaited because we awaited the original task
-                    return Task.CompletedTask;
+                    return underlyingTask;
                 }
 
                 return Output.Create(WrapperTask());

--- a/sdk/Pulumi/Serialization/Serializer.cs
+++ b/sdk/Pulumi/Serialization/Serializer.cs
@@ -284,6 +284,11 @@ $"Tasks are not allowed inside ResourceArgs. Please wrap your Task in an Output:
                 return (int)prop;
             }
 
+            if (prop is ValueTuple)
+            {
+                return null;
+            }
+
             var propType = prop.GetType();
             if (propType.IsValueType && propType.GetCustomAttribute<EnumTypeAttribute>() != null)
             {


### PR DESCRIPTION
Fixes #139 

When using an `async` lambda inside `Apply` where we `await` asynchronous functions that don't return anything, the lambda gets the signature `Func<T, Task>`. Giving that to `Apply` the returned `Task` is not awaited because the overload chosen for the `Apply` is the one accepting `Func<T, U>` and this overload doesn't know how to await and register `U` where `typeof(U) == typeof(Task)`

Because we are not registering the task, it is not awaited properly and the Pulumi program runs to completion before the task is resolved. 

We can easily repro this behavior as follows:
```cs
using System.Threading.Tasks;
using System;
using Pulumi;

await Deployment.RunAsync(() => 
{
    Output.Create(0).Apply(async _ => 
    {
        await LongFailingTask();
    });
});

async Task LongFailingTask()
{
    Pulumi.Log.Info("LongFailingTask before waiting");
    await Task.Delay(5000);
    Pulumi.Log.Info("LongFailingTask after waiting");
    throw new Exception("Boom!");
}
```
Running `pulumi up` on the code above will run the program but will never reach the exception after the delay:
```
Diagnostics:
  pulumi:pulumi:Stack (project-dev):
    LongFailingTask before waiting
```

The fix is to handle `typeof(U) == typeof(Task)` in a special way inside `Apply` where we create a wrapper task-returning function which _awaits_ the task provided by the user and returns a dummy empty task so that the signature `Func<T, Task>` still holds