### PR TITLE
Make MockMonitor return true for all features except outputValues

### DIFF
--- a/sdk/Pulumi/Testing/MockMonitor.cs
+++ b/sdk/Pulumi/Testing/MockMonitor.cs
@@ -28,7 +28,10 @@ namespace Pulumi.Testing
         {
             // Rather than attempting to keep the list of feature flags up-to date here, we just assume the
             // mock monitor supports any feature requested of it.
-            return Task.FromResult(new SupportsFeatureResponse { HasSupport = true });
+            // However, support for "outputValues" is deliberately disabled for the mock monitor so
+            // instances of `Output` don't show up in `MockResourceArgs` Inputs.
+            var hasSupport = request.Id != "outputValues";
+            return Task.FromResult(new SupportsFeatureResponse { HasSupport = hasSupport });
         }
 
         public async Task<InvokeResponse> InvokeAsync(ResourceInvokeRequest request)


### PR DESCRIPTION
This just makes the return value of `SupportsFeature` behave the same as the Node, Python, and Go SDKs, where all features are supported _except_ output values, so that `Output<T>` values don't show up in `MockResourceArgs` inputs.

Reference: https://github.com/pulumi/pulumi/pull/14118