### PR TITLE
[sdk] Implement reflection-based RegisterOutputs for component resources

### DIFF
--- a/.changes/unreleased/Improvements-200.yaml
+++ b/.changes/unreleased/Improvements-200.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Implement reflection-based RegisterOutputs() for component resources
+time: 2023-10-31T16:37:00.164865+01:00
+custom:
+  PR: "200"

--- a/sdk/Pulumi.Tests/Resources/ComponentResourceTests.cs
+++ b/sdk/Pulumi.Tests/Resources/ComponentResourceTests.cs
@@ -98,6 +98,58 @@ namespace Pulumi.Tests.Resources
                 Assert.Equal(provider, custom._provider);
             });
         }
+
+        class BasicComponent : ComponentResource
+        {
+            public Output<string> First { get; set; }
+            [Output]
+            public Output<string> Second { get; set; }
+            [Output("myThird")]
+            public Output<string> Third { get; set; }
+            public BasicComponent(string name) : base("token:token:token", name, ResourceArgs.Empty)
+            {
+                First = Output.Create("first");
+                Second = Output.Create("second");
+                Third = Output.Create("third");
+                RegisterOutputs();
+            }
+        }
+
+        [Fact]
+        public async Task RegisterOutputsCorrectlyUsesReflectionToRegisterOutputProperties()
+        {
+            var mocks = new MinimalMocks();
+            var options = new TestOptions();
+            var (resources, outputs) = await Deployment.TestAsync(mocks, options, () =>
+            {
+                var basic = new BasicComponent("basic");
+                // use the logic that collects output properties here to return the outputs as stack outputs
+                // so we can assert their keys and values
+                return ComponentResource.CollectOutputProperties(basic);
+            });
+
+            Assert.Contains("First", outputs);
+            Assert.Contains("Second", outputs);
+            Assert.Contains("myThird", outputs);
+
+            if (outputs["First"] is Output<string> first)
+            {
+                var value = await first.GetValueAsync("<unknwon>");
+                Assert.Equal("first", value);
+            }
+
+            if (outputs["Second"] is Output<string> second)
+            {
+                var value = await second.GetValueAsync("<unknwon>");
+                Assert.Equal("second", value);
+            }
+
+            if (outputs["myThird"] is Output<string> third)
+            {
+                var value = await third.GetValueAsync("<unknwon>");
+                Assert.Equal("third", value);
+            }
+        }
     }
 
     class MinimalMocks : IMocks

--- a/sdk/Pulumi/Resources/ComponentResource.cs
+++ b/sdk/Pulumi/Resources/ComponentResource.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Pulumi
@@ -52,6 +53,49 @@ namespace Pulumi
             this.remote = remote;
         }
 
+        internal static Dictionary<string, object?> CollectOutputProperties(ComponentResource instance)
+        {
+            var outputs = new Dictionary<string, object?>();
+            var currentType = instance.GetType();
+            foreach (var prop in currentType.GetProperties())
+            {
+                if (prop.Name == nameof(Urn))
+                {
+                    continue;
+                }
+
+                var outputAttribute =
+                    prop.GetCustomAttributes(typeof(OutputAttribute), false)
+                        .FirstOrDefault();
+                if (outputAttribute is OutputAttribute attr && attr.Name != null)
+                {
+                    // when using [Output("<name>")] we will export the value of this property
+                    // named as the provided <name>
+                    var value = prop.GetValue(instance);
+                    outputs.Add(attr.Name, value);
+                }
+                else if (outputAttribute is OutputAttribute)
+                {
+                    // otherwise of we only have [Output] we will simply use the name of the property itself
+                    // when exporting the value
+                    var value = prop.GetValue(instance);
+                    outputs.Add(prop.Name, value);
+                }
+                else
+                {
+                    var propertyType = prop.PropertyType;
+                    // only if the type is Output<T> then we will consider it an output property
+                    if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(Output<>))
+                    {
+                        var value = prop.GetValue(instance);
+                        outputs.Add(prop.Name, value);
+                    }
+                }
+            }
+
+            return outputs;
+        }
+
         /// <summary>
         /// RegisterOutputs registers synthetic outputs that a component has initialized, usually by
         /// allocating other child sub-resources and propagating their resulting property values.
@@ -61,7 +105,10 @@ namespace Pulumi
         /// state as quickly as possible (instead of waiting until the entire application completes).
         /// </summary>
         protected void RegisterOutputs()
-            => RegisterOutputs(ImmutableDictionary<string, object?>.Empty);
+        {
+            var outputs = CollectOutputProperties(this);
+            RegisterOutputs(outputs);
+        }
 
         protected void RegisterOutputs(IDictionary<string, object?> outputs)
             => RegisterOutputs(Task.FromResult(outputs ?? throw new ArgumentNullException(nameof(outputs))));

--- a/sdk/Pulumi/Resources/ComponentResource.cs
+++ b/sdk/Pulumi/Resources/ComponentResource.cs
@@ -76,19 +76,19 @@ namespace Pulumi
                     prop.GetCustomAttributes(typeof(OutputAttribute), false)
                         .FirstOrDefault();
 
-                if (outputAttribute is OutputAttribute attr && attr.Name != null)
+                if (outputAttribute is OutputAttribute attr)
                 {
-                    // when using [Output("<name>")] we will export the value of this property
-                    // named as the provided <name>
+                    var registerdOutputKey = prop.Name;
+                    if (!string.IsNullOrWhiteSpace(attr.Name))
+                    {
+                        // when using [Output("<name>")] we will export the value of this property
+                        // with its key equal to the provided <name>
+                        registerdOutputKey = attr.Name;
+                    }
+
+                    // otherwise if we only have [Output] we will simply use the name of the property itself
                     var value = prop.GetValue(this);
-                    outputs.Add(attr.Name, value);
-                }
-                else if (outputAttribute is OutputAttribute)
-                {
-                    // otherwise of we only have [Output] we will simply use the name of the property itself
-                    // when exporting the value
-                    var value = prop.GetValue(this);
-                    outputs.Add(prop.Name, value);
+                    outputs.Add(registerdOutputKey, value);
                 }
             }
 

--- a/sdk/Pulumi/Testing/IMocks.cs
+++ b/sdk/Pulumi/Testing/IMocks.cs
@@ -25,6 +25,12 @@ namespace Pulumi.Testing
         /// <param name="args">MockCallArgs</param>
         /// <returns>Invocation result, can be either a POCO or a dictionary bag.</returns>
         Task<object> CallAsync(MockCallArgs args);
+
+        /// <summary>
+        /// Invoked when component resources (including instances of Stack) register their outputs
+        /// </summary>
+        /// <param name="args">MockRegisterResourceOutputsRequest</param>
+        Task RegisterResourceOutputs(MockRegisterResourceOutputsRequest args) => Task.CompletedTask;
     }
 
     /// <summary>
@@ -77,5 +83,20 @@ namespace Pulumi.Testing
         /// Provider.
         /// </summary>
         public string? Provider { get; set; }
+    }
+
+    /// <summary>
+    /// MockRegisterResourceOutputsRequest for use in RegisterOutputRequest
+    /// </summary>
+    public class MockRegisterResourceOutputsRequest
+    {
+        /// <summary>
+        /// The URN of the resource of which the outputs are being registered
+        /// </summary>
+        public string? Urn { get; set; }
+        /// <summary>
+        /// The outputs which have been registered by the resource
+        /// </summary>
+        public ImmutableDictionary<string, object> Outputs { get; set; } = null!;
     }
 }

--- a/sdk/Pulumi/Testing/IMocks.cs
+++ b/sdk/Pulumi/Testing/IMocks.cs
@@ -93,10 +93,19 @@ namespace Pulumi.Testing
         /// <summary>
         /// The URN of the resource of which the outputs are being registered
         /// </summary>
-        public string? Urn { get; set; }
+        public readonly string Urn;
+
         /// <summary>
         /// The outputs which have been registered by the resource
         /// </summary>
-        public ImmutableDictionary<string, object> Outputs { get; set; } = null!;
+        public readonly ImmutableDictionary<string, Output<object?>> Outputs;
+
+        public MockRegisterResourceOutputsRequest(
+            string urn,
+            ImmutableDictionary<string, Output<object?>> outputs)
+        {
+            Urn = urn;
+            Outputs = outputs;
+        }
     }
 }

--- a/sdk/Pulumi/Testing/MockMonitor.cs
+++ b/sdk/Pulumi/Testing/MockMonitor.cs
@@ -162,11 +162,18 @@ namespace Pulumi.Testing
 
         public async Task RegisterResourceOutputsAsync(RegisterResourceOutputsRequest request)
         {
-            await _mocks.RegisterResourceOutputs(new MockRegisterResourceOutputsRequest
+            var outputs = ImmutableDictionary.CreateBuilder<string, Output<object?>>();
+            foreach (var (key, value) in request.Outputs.Fields)
             {
-                Urn = request.Urn,
-                Outputs = ToDictionary(request.Outputs)
-            });
+                var data = Deserializer.Deserialize(value);
+                outputs.Add(key, new Output<object?>(Task.FromResult(data)));
+            }
+
+            var mockRequest = new MockRegisterResourceOutputsRequest(
+                urn: request.Urn,
+                outputs: outputs.ToImmutable());
+
+            await _mocks.RegisterResourceOutputs(mockRequest);
         }
 
         private static string NewUrn(string parent, string type, string name)

--- a/sdk/Pulumi/Testing/MockMonitor.cs
+++ b/sdk/Pulumi/Testing/MockMonitor.cs
@@ -160,7 +160,14 @@ namespace Pulumi.Testing
             };
         }
 
-        public Task RegisterResourceOutputsAsync(RegisterResourceOutputsRequest request) => Task.CompletedTask;
+        public async Task RegisterResourceOutputsAsync(RegisterResourceOutputsRequest request)
+        {
+            await _mocks.RegisterResourceOutputs(new MockRegisterResourceOutputsRequest
+            {
+                Urn = request.Urn,
+                Outputs = ToDictionary(request.Outputs)
+            });
+        }
 
         private static string NewUrn(string parent, string type, string name)
         {


### PR DESCRIPTION
When writing component resources, at the very end of the constructor logic, developers have to make a call to `RegisterOutputs(...)` and provide a bag of outputs from the instance properties declared with `[Output]` property. 

This PR makes it such that developers can use `RegisterOutputs()` without providing anything and it will use reflection to deduce the keys and values of the outputs from the properties of the component resource. It works as follows:
 - ~Any property of type `Output<T>` is considered an output with the key equal to the name of the property~
 - Any property marked with attribute `[Output]` is considered an output the key equal to the name of the property
 - Any property marked with attribute `[Output(name: "<overriddenPropertyName>")]` is considered an output the key equal to `<overriddenPropertyName>`

~Since we don't have a good way to test `RegisterOutputs`, I moved the logic to an internal, static function called `CollectOutputProperties` which is unit testable on its own. Then in a test stack, made it return the stack outputs from the collected output properties of a test component (`BasicComponent`) so we can assert the resulting keys and values~

The PR extends `IMocks` with support for `RegisterResourceOutputs` such that we can unit test the registered outputs by component resources or stacks
