### PR TITLE
[sdk] Initial implementation of a reflection-based PropertyValue deserializer

### DIFF
--- a/.changes/unreleased/Improvements-201.yaml
+++ b/.changes/unreleased/Improvements-201.yaml
@@ -1,0 +1,6 @@
+component: sdk/provider
+kind: Improvements
+body: Initial implementation of a reflection-based PropertyValue deserializer
+time: 2023-11-18T14:22:27.456364+01:00
+custom:
+  PR: "201"

--- a/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
+++ b/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
@@ -1,0 +1,515 @@
+namespace Pulumi.Tests.Provider;
+
+using Pulumi.Experimental.Provider;
+using Pulumi.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+public class PropertyValueTests
+{
+#pragma warning disable CS0618
+    PropertyValueSerializer CreateSerializer() => new();
+#pragma warning restore CS0618
+
+    PropertyValue Object(params KeyValuePair<string, PropertyValue>[] pairs)
+    {
+        var builder = ImmutableDictionary.CreateBuilder<string, PropertyValue>();
+        foreach (var pair in pairs)
+        {
+            builder.Add(pair.Key, pair.Value);
+        }
+
+        return new PropertyValue(builder.ToImmutable());
+    }
+
+    KeyValuePair<string, PropertyValue> Pair(string key, PropertyValue value) => new(key, value);
+    PropertyValue Array(params PropertyValue[] values) => new(values.ToImmutableArray());
+
+    class BasicArgs : ResourceArgs
+    {
+        public int PasswordLength { get; set; }
+    }
+
+    [Fact]
+    public async Task DeserializingBasicArgsWorks()
+    {
+        var serializer = CreateSerializer();
+        var data = Object(
+            Pair("PasswordLength", new PropertyValue(10)));
+
+        var basicArgs = await serializer.Deserialize<BasicArgs>(data);
+        Assert.Equal(10, basicArgs.PasswordLength);
+    }
+
+    class UsingNullableArgs : ResourceArgs
+    {
+        public int? Length { get; set; }
+    }
+
+    [Fact]
+    public async Task DeserializingNullableArgsWorks()
+    {
+        var serializer = CreateSerializer();
+        var emptyData = Object();
+        var withoutData = await serializer.Deserialize<UsingNullableArgs>(emptyData);
+        Assert.False(withoutData.Length.HasValue, "Nullable value is null");
+
+        var data = Object(Pair("Length", new PropertyValue(10)));
+        var withData = await serializer.Deserialize<UsingNullableArgs>(data);
+        Assert.True(withData.Length.HasValue, "Nullable field has a value");
+        Assert.Equal(10, withData.Length.Value);
+    }
+
+    class UsingListArgs : ResourceArgs
+    {
+        public string[] First { get; set; }
+        public List<string> Second { get; set; }
+        public ImmutableArray<string> Third { get; set; }
+    }
+
+    [Fact]
+    public async Task DeserializingListTypesWorks()
+    {
+        var serializer = CreateSerializer();
+        var array = Array(
+            new PropertyValue("one"),
+            new PropertyValue("two"),
+            new PropertyValue("three"));
+
+        var data = Object(
+            Pair("First", array),
+            Pair("Second", array),
+            Pair("Third", array));
+
+        var args = await serializer.Deserialize<UsingListArgs>(data);
+
+        var elements = new string[] { "one", "two", "three" };
+        Assert.Equal(elements, args.First);
+        Assert.Equal(elements, args.Second.ToArray());
+        Assert.Equal(elements, args.Third.ToArray());
+    }
+
+    class StringFromNullBecomesEmpty : ResourceArgs
+    {
+        public string Data { get; set; }
+    }
+
+    [Fact]
+    public async Task DeserializingStringFromNullValueWorks()
+    {
+        var serializer = CreateSerializer();
+        var data = Object(Pair("Data", PropertyValue.Null));
+        var argsWithNullString = await serializer.Deserialize<StringFromNullBecomesEmpty>(data);
+        Assert.True(String.IsNullOrEmpty(argsWithNullString.Data));
+    }
+
+    class UsingDictionaryArgs : ResourceArgs
+    {
+        public Dictionary<string, string> First { get; set; }
+        public ImmutableDictionary<string, string> Second { get; set; }
+    }
+
+    [Fact]
+    public async Task DeserializingDictionaryPropertiesWork()
+    {
+        var serializer = CreateSerializer();
+        var simpleDictionary = Object(Pair("Uno", new PropertyValue("One")));
+        var data = Object(
+            Pair("First", simpleDictionary),
+            Pair("Second", simpleDictionary));
+
+        var args = await serializer.Deserialize<UsingDictionaryArgs>(data);
+
+        var expected = new Dictionary<string, string>
+        {
+            ["Uno"] = "One"
+        };
+
+        Assert.Equal(expected, args.First);
+        Assert.Equal(expected, args.Second.ToDictionary(x => x.Key, y => y.Value));
+
+        var emptyObject = Object();
+        var emptyArgs = await serializer.Deserialize<UsingDictionaryArgs>(emptyObject);
+        Assert.Null(emptyArgs.First);
+        Assert.Null(emptyArgs.Second);
+    }
+
+    class UsingInputArgs : ResourceArgs
+    {
+        public Input<string> Name { get; set; }
+        public InputList<string> Subnets { get; set; }
+        public InputMap<string> Tags { get; set; }
+    }
+
+    [Fact]
+    public async Task DeserializingInputTypesWorks()
+    {
+        var serializer = CreateSerializer();
+        var data = Object(
+            Pair("Name", new PropertyValue("test")),
+            Pair("Subnets", Array(
+    new PropertyValue("one"),
+                new PropertyValue("two"),
+                new PropertyValue("three"))),
+            Pair("Tags", Object(
+                Pair("one", new PropertyValue("one")),
+                Pair("two", new PropertyValue("two")),
+                Pair("three", new PropertyValue("three"))))
+            );
+
+        var args = await serializer.Deserialize<UsingInputArgs>(data);
+
+        var name = await args.Name.ToOutput().GetValueAsync("");
+        Assert.Equal("test", name);
+
+        var subnets = await args.Subnets.ToOutput().GetValueAsync(ImmutableArray<string>.Empty);
+        Assert.Equal(new[] { "one", "two", "three" }, subnets.ToArray());
+
+        var tags = await args.Tags.ToOutput().GetValueAsync(ImmutableDictionary<string, string>.Empty);
+        Assert.Equal(new Dictionary<string, string>
+        {
+            ["one"] = "one",
+            ["two"] = "two",
+            ["three"] = "three"
+        }, tags);
+    }
+
+    class RequireIntArgs : ResourceArgs
+    {
+        public int Property { get; set; }
+    }
+
+    [Fact]
+    public async Task DeserializingEmptyValuesIntoRequiredPropertyShouldFail()
+    {
+        try
+        {
+            var serializer = CreateSerializer();
+            var emptyObject = Object();
+            await serializer.Deserialize<RequireIntArgs>(emptyObject);
+        }
+        catch (Exception e)
+        {
+            var errorMessage =
+                "Error while deserializing value of type Int32 from property value of type Null. Expected Number instead at path [$, Property].";
+            Assert.Contains(errorMessage, e.Message);
+        }
+    }
+
+    class OptionalIntInputArgs : ResourceArgs
+    {
+        public Input<int?> OptionalInteger { get; set; }
+    }
+
+    [Fact]
+    public async Task DeserializingOptionalInputWorks()
+    {
+        var serializer = CreateSerializer();
+        var emptyData = Object();
+        var args = await serializer.Deserialize<OptionalIntInputArgs>(emptyData);
+        var optionalInteger = await args.OptionalInteger.ToOutput().GetValueAsync(0);
+        Assert.False(optionalInteger.HasValue);
+    }
+
+    enum TestEnum { Allow, Default }
+    class EnumArgs : ResourceArgs
+    {
+        public TestEnum EnumInput { get; set; }
+    }
+
+    [Fact]
+    public async Task DeserializingEnumWorks()
+    {
+        var serializer = CreateSerializer();
+        var data = Object(Pair("EnumInput", new PropertyValue(1)));
+        var args = await serializer.Deserialize<EnumArgs>(data);
+        Assert.Equal(TestEnum.Default, args.EnumInput);
+    }
+
+    [Fact]
+    public async Task DeserializingUnknownInputsWorks()
+    {
+        var serializer = CreateSerializer();
+        var x = Output.Create("");
+        var deserialized = await serializer.Deserialize<Input<string>>(PropertyValue.Computed);
+        var output = deserialized.ToOutput();
+        var known = await OutputUtilities.GetIsKnownAsync(output);
+        Assert.False(known);
+    }
+
+    [Fact]
+    public async Task DeserializingSecretInputsWorks()
+    {
+        var serializer = CreateSerializer();
+        var secretValue = new PropertyValue(new PropertyValue("Hello"));
+        var deserialized = await serializer.Deserialize<Input<string>>(secretValue);
+        var output = deserialized.ToOutput();
+        var data = await output.DataTask;
+        Assert.Equal("Hello", data.Value);
+        Assert.True(data.IsSecret);
+        Assert.True(data.IsKnown);
+    }
+
+    [Fact]
+    public async Task DeserializingBasicInputsWorks()
+    {
+        var serializer = CreateSerializer();
+        var resources = ImmutableArray.Create("pulumi:pulumi:Stack");
+        var output = new PropertyValue(new OutputReference(
+            value: new PropertyValue("Hello"),
+            dependencies: resources));
+
+        var deserialized = await serializer.Deserialize<Input<string>>(output);
+        var deserializedOutput = deserialized.ToOutput();
+        var data = await deserializedOutput.DataTask;
+        Assert.Equal("Hello", data.Value);
+        Assert.False(data.IsSecret);
+        Assert.True(data.IsKnown);
+        Assert.Single(data.Resources);
+        if (data.Resources.First() is DependencyResource dependencyResource)
+        {
+            var resolvedUrn = await dependencyResource.Urn.GetValueAsync("");
+            Assert.Equal("pulumi:pulumi:Stack", resolvedUrn);
+        }
+        else
+        {
+            throw new Exception("Expected deserialized resource to be a dependency resource");
+        }
+    }
+
+    [Fact]
+    public async Task DeserializingWrappedOutputSecretWorks()
+    {
+        var serializer = CreateSerializer();
+        // secretOutput = Secret(Output("Hello"))
+        var secretOutput = new PropertyValue(
+            new PropertyValue(new OutputReference(
+                value: new PropertyValue("Hello"),
+                dependencies: ImmutableArray<string>.Empty)));
+
+        var deserialized = await serializer.Deserialize<Input<string>>(secretOutput);
+        var deserializedOutput = deserialized.ToOutput();
+        var data = await deserializedOutput.DataTask;
+        Assert.Equal("Hello", data.Value);
+        Assert.True(data.IsSecret);
+        Assert.True(data.IsKnown);
+    }
+
+    [Fact]
+    public async Task DeserializingWrappedSecretInOutputWorks()
+    {
+        var serializer = CreateSerializer();
+        // secretOutput = Output(Secret("Hello"))
+        var secretOutput = new PropertyValue(
+            new OutputReference(
+                value: new PropertyValue(new PropertyValue("Hello")),
+                dependencies: ImmutableArray<string>.Empty));
+
+        var deserialized = await serializer.Deserialize<Input<string>>(secretOutput);
+        var deserializedOutput = deserialized.ToOutput();
+        var data = await deserializedOutput.DataTask;
+        Assert.Equal("Hello", data.Value);
+        Assert.True(data.IsSecret);
+        Assert.True(data.IsKnown);
+    }
+
+    [Fact]
+    public async Task SerializingPrimtivesWorks()
+    {
+        var serializer = CreateSerializer();
+        Assert.Equal(new PropertyValue("Hello"), await serializer.Serialize("Hello"));
+        Assert.Equal(new PropertyValue(10), await serializer.Serialize(10));
+        Assert.Equal(new PropertyValue(10.5), await serializer.Serialize(10.5));
+        Assert.Equal(new PropertyValue(true), await serializer.Serialize(true));
+        Assert.Equal(new PropertyValue(false), await serializer.Serialize(false));
+        Assert.Equal(PropertyValue.Null, await serializer.Serialize<object?>(null));
+    }
+
+    [Fact]
+    public async Task SerializingPropertyValueReturnsItself()
+    {
+        var serializer = CreateSerializer();
+        var value = new PropertyValue("Hello");
+        Assert.Equal(value, await serializer.Serialize(value));
+    }
+
+    [Fact]
+    public async Task SerializingCollectionsWorks()
+    {
+        var serializer = CreateSerializer();
+
+        var expected = Array(
+            new PropertyValue("one"),
+            new PropertyValue("two"),
+            new PropertyValue("three"));
+
+        // array
+        Assert.Equal(expected, await serializer.Serialize(new[] { "one", "two", "three" }));
+
+        // list
+        Assert.Equal(expected, await serializer.Serialize(new List<string> { "one", "two", "three" }));
+
+        // immutable array
+        Assert.Equal(expected, await serializer.Serialize(ImmutableArray.Create("one", "two", "three")));
+
+        IEnumerable<string> Seq()
+        {
+            yield return "one";
+            yield return "two";
+            yield return "three";
+        }
+
+        // generic sequences
+        Assert.Equal(expected, await serializer.Serialize(Seq()));
+
+        // default immutable array serializes to empty array
+        // a special case since default(ImmutableArray<T>) is not null but cannot be enumerated directly
+        Assert.Equal(Array(), await serializer.Serialize(default(ImmutableArray<string>)));
+
+        // sets
+        Assert.Equal(expected, await serializer.Serialize(new HashSet<string> { "one", "two", "three" }));
+
+        // dictionaries
+        var expectedDict = Object(
+            Pair("one", new PropertyValue("one")),
+            Pair("two", new PropertyValue("two")),
+            Pair("three", new PropertyValue("three")));
+
+        Assert.Equal(expectedDict, await serializer.Serialize(new Dictionary<string, string>
+        {
+            ["one"] = "one",
+            ["two"] = "two",
+            ["three"] = "three"
+        }));
+
+        // immutable dictionaries
+        Assert.Equal(expectedDict, await serializer.Serialize(ImmutableDictionary.CreateRange(new Dictionary<string, string>
+        {
+            ["one"] = "one",
+            ["two"] = "two",
+            ["three"] = "three"
+        })));
+    }
+
+    [Fact]
+    public async Task SerializingEnumWorks()
+    {
+        var serializer = CreateSerializer();
+        Assert.Equal(new PropertyValue(0), await serializer.Serialize(TestEnum.Allow));
+        Assert.Equal(new PropertyValue(1), await serializer.Serialize(TestEnum.Default));
+    }
+
+    class CustomArgs
+    {
+        [Input("value_field")]
+        public string Value { get; set; }
+        [Output("name_field")]
+        public string Name { get; set; }
+    }
+
+    [Fact]
+    public async Task SerializingClassWherePropertiesHaveOverriddenNamesWorks()
+    {
+        var serializer = CreateSerializer();
+        var args = new CustomArgs
+        {
+            Value = "value",
+            Name = "name"
+        };
+
+        var expected = Object(
+            Pair("value_field", new PropertyValue("value")),
+            Pair("name_field", new PropertyValue("name")));
+
+        Assert.Equal(expected, await serializer.Serialize(args));
+    }
+
+    [Fact]
+    public async Task DeserializingClassWherePropertiesHaveOverriddenNamesWorks()
+    {
+        var serializer = CreateSerializer();
+        var data = Object(
+            Pair("value_field", new PropertyValue("value")),
+            Pair("name_field", new PropertyValue("name")));
+
+        var args = await serializer.Deserialize<CustomArgs>(data);
+        Assert.Equal("value", args.Value);
+        Assert.Equal("name", args.Name);
+    }
+
+    class TypeWithConstructors
+    {
+        public int First { get; set; }
+        public int? Second { get; set; }
+
+        public TypeWithConstructors()
+        {
+
+        }
+
+        public TypeWithConstructors(int first)
+        {
+            First = first * 10;
+            Second = first;
+        }
+
+        public TypeWithConstructors(int first, int? second)
+        {
+            First = first;
+            Second = second;
+        }
+    }
+
+    class TypeWithOptionalConstructorParameter
+    {
+        public int First { get; set; }
+        public int? Second { get; set; }
+        public TypeWithOptionalConstructorParameter(int first)
+        {
+            First = first * 5;
+            Second = first;
+        }
+    }
+
+    [Fact]
+    public async Task DeserializingClassWithMultipleConstructorsWorks()
+    {
+        var serializer = CreateSerializer();
+        var dataFirstConstructor = Object(
+            Pair("first", new PropertyValue(1)));
+
+        // should choose the constructor matching (int first)
+        var firstConstructor = await serializer.Deserialize<TypeWithConstructors>(dataFirstConstructor);
+        Assert.Equal(10, firstConstructor.First);
+        Assert.Equal(1, firstConstructor.Second);
+
+        // should choose the constructor matching (int first, int? second)
+        var dataSecondConstructor = Object(
+            Pair("first", new PropertyValue(1)),
+            Pair("second", new PropertyValue(2)));
+
+        var secondConstructor = await serializer.Deserialize<TypeWithConstructors>(dataSecondConstructor);
+        Assert.Equal(1, secondConstructor.First);
+        Assert.Equal(2, secondConstructor.Second);
+
+        // should choose the default parameterless constructor
+        // then follow deserialization logic by matching property names
+        var objectShapeData = Object(
+            Pair("First", new PropertyValue(42)),
+            Pair("Second", new PropertyValue(420)));
+
+        var objectShape = await serializer.Deserialize<TypeWithConstructors>(objectShapeData);
+        Assert.Equal(42, objectShape.First);
+        Assert.Equal(420, objectShape.Second);
+
+        var typeWithOptionalParameterCtor = await serializer.Deserialize<TypeWithOptionalConstructorParameter>(
+            Object(Pair("first", new PropertyValue(1))));
+
+        Assert.Equal(5, typeWithOptionalParameterCtor.First);
+        Assert.Equal(1, typeWithOptionalParameterCtor.Second);
+    }
+}

--- a/sdk/Pulumi/Provider/PropertyValue.cs
+++ b/sdk/Pulumi/Provider/PropertyValue.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Pulumi.Experimental.Provider
 {
@@ -156,7 +157,7 @@ namespace Pulumi.Experimental.Provider
         }
 
         // Unwraps any outer secret or output values.
-        public bool TryUnwrap([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out PropertyValue? value)
+        public bool TryUnwrap([NotNullWhen(true)] out PropertyValue? value)
         {
             if (SecretValue != null)
             {
@@ -193,6 +194,7 @@ namespace Pulumi.Experimental.Provider
                     ArchiveValue == null &&
                     SecretValue == null &&
                     ResourceValue == null &&
+                    OutputValue == null &&
                     !IsComputed;
             }
         }
@@ -401,7 +403,7 @@ namespace Pulumi.Experimental.Provider
             return false;
         }
 
-        public bool TryGetObject(out ImmutableDictionary<string, PropertyValue>? value)
+        public bool TryGetObject([NotNullWhen(true)] out ImmutableDictionary<string, PropertyValue>? value)
         {
             if (ObjectValue != null)
             {
@@ -434,7 +436,7 @@ namespace Pulumi.Experimental.Provider
             return false;
         }
 
-        public bool TryGetSecret(out PropertyValue? value)
+        public bool TryGetSecret([NotNullWhen(true)] out PropertyValue? value)
         {
             if (SecretValue != null)
             {

--- a/sdk/Pulumi/Provider/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Provider/PropertyValueSerializer.cs
@@ -1,0 +1,926 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Pulumi.Serialization;
+
+namespace Pulumi.Experimental.Provider
+{
+    [Obsolete("PropertyValueSerializer is highly experimental, and the shape of the API may be removed or changed at any time. Use at your own risk")]
+    public class PropertyValueSerializer
+    {
+        string CamelCase(string input) =>
+            input.Length > 1
+                ? input.Substring(0, 1).ToLowerInvariant() + input.Substring(1)
+                : input.ToLowerInvariant();
+
+        private object? DeserializeObject(ImmutableDictionary<string, PropertyValue> inputs, Type targetType, string[] path)
+        {
+            var properties = targetType.GetProperties();
+
+            var objectShape =
+                properties.Select(property => new
+                {
+                    propertyName = PropertyName(property),
+                    propertyType = property.PropertyType
+                }).ToArray();
+
+            var candidateConstructors = new List<ConstructorInfo>();
+            ConstructorInfo? parameterlessConstructor = null;
+            foreach (var constructor in targetType.GetConstructors())
+            {
+                var parameters = constructor.GetParameters();
+                if (parameters.Length == 0)
+                {
+                    parameterlessConstructor = constructor;
+                    continue;
+                }
+
+                // parameters match the shape of the type when all the parameters
+                // have a corresponding property with the same name and type
+                var parametersMatchShape = parameters.All(param =>
+                {
+                    return objectShape.Any(property =>
+                        param.Name == CamelCase(property.propertyName)
+                        && param.ParameterType == property.propertyType);
+                });
+
+                // the shape of the type matches the parameters of the constructor
+                // when all the properties either have a corresponding parameter
+                // or doesn't have a corresponding parameter but is nullable
+                var shapeMatchesParameters = objectShape.All(property =>
+                {
+                    foreach (var param in parameters)
+                    {
+                        if (param.Name == CamelCase(property.propertyName) && param.ParameterType == property.propertyType)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return IsNullable(property.propertyType);
+                });
+
+                if (parametersMatchShape && shapeMatchesParameters)
+                {
+                    candidateConstructors.Add(constructor);
+                }
+            }
+
+            var constructorWithMatchingParameters =
+                candidateConstructors
+                    .FirstOrDefault(ctor =>
+                    {
+                        var parameters = ctor.GetParameters();
+                        var parameterCountMatches = parameters.Length == inputs.Count;
+                        var parameterNamesMatch = parameters.All(param =>
+                        {
+                            var parameterName = param.Name ?? "";
+                            return inputs.ContainsKey(parameterName);
+                        });
+
+                        return parameterCountMatches && parameterNamesMatch;
+                    });
+
+            if (constructorWithMatchingParameters != null)
+            {
+                var parameters = constructorWithMatchingParameters.GetParameters();
+                var deserializedParameters = parameters.Select(parameter =>
+                {
+                    var parameterName = parameter.Name ?? "";
+                    var parameterValue = inputs.GetValueOrDefault(parameterName, PropertyValue.Null);
+                    var parameterPath = path.Append($"param({parameterName})").ToArray();
+                    var value = DeserializeValue(parameterValue, parameter.ParameterType, parameterPath);
+                    if (value == null && !IsNullable(parameter.ParameterType))
+                    {
+                        throw new InvalidOperationException(
+                            $"Could not deserialize parameter {parameterName} of type {parameter.ParameterType.Name} " +
+                            $"at path [{string.Join(", ", parameterPath)}]");
+                    }
+
+                    return value;
+                });
+
+                return constructorWithMatchingParameters.Invoke(deserializedParameters.ToArray());
+            }
+
+            object? instance =
+                parameterlessConstructor != null
+                    ? parameterlessConstructor.Invoke(Array.Empty<object>())
+                    : Activator.CreateInstance(targetType);
+
+            foreach (var property in properties)
+            {
+                var propertyName = PropertyName(property);
+                var propertyPath = path.Append(propertyName).ToArray();
+                if (inputs.TryGetValue(propertyName, out var value))
+                {
+                    var deserializedValue = DeserializeValue(value, property.PropertyType, propertyPath);
+                    property.SetValue(instance, deserializedValue);
+                }
+                else
+                {
+                    var maybeDeserializedEmptyValue = DeserializeValue(PropertyValue.Null, property.PropertyType, propertyPath);
+                    // we couldn't find the corresponding property value in the inputs given
+                    // that is alright if the property is optional (i.e. the type is nullable)
+                    // otherwise we throw an error
+                    if (!IsNullable(property.PropertyType) && maybeDeserializedEmptyValue == null)
+                    {
+                        // TODO: implement a proper exception type that includes the type info, errors and property value
+                        var errorPath = "[" + string.Join(", ", propertyPath) + "]";
+                        throw new InvalidOperationException(
+                            $"Could not deserialize object of type {targetType.Name}, missing required property {propertyName} at {errorPath}");
+                    }
+
+                    property.SetValue(instance, maybeDeserializedEmptyValue);
+                }
+            }
+
+            return instance;
+        }
+
+        private bool IsNullable(Type type)
+        {
+            return !type.IsValueType || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
+        }
+
+        private string PropertyName(PropertyInfo property)
+        {
+            var propertyName = property.Name;
+            var inputAttribute =
+                property
+                    .GetCustomAttributes(typeof(InputAttribute))
+                    .FirstOrDefault();
+
+            if (inputAttribute is InputAttribute input && !string.IsNullOrWhiteSpace(input.Name))
+            {
+                propertyName = input.Name;
+            }
+
+            var outputAttribute =
+                property
+                    .GetCustomAttributes(typeof(OutputAttribute))
+                    .FirstOrDefault();
+
+            if (outputAttribute is OutputAttribute output && !string.IsNullOrWhiteSpace(output.Name))
+            {
+                propertyName = output.Name;
+            }
+
+            return propertyName;
+        }
+
+        public async Task<PropertyValue> Serialize<T>(T value)
+        {
+            if (value == null)
+            {
+                return PropertyValue.Null;
+            }
+
+            var targetType = value.GetType();
+            switch (value)
+            {
+                case string stringValue:
+                    return new PropertyValue(stringValue);
+                case int integer:
+                    return new PropertyValue(integer);
+                case bool boolean:
+                    return new PropertyValue(boolean);
+                case double number:
+                    return new PropertyValue(number);
+                case float number:
+                    return new PropertyValue(number);
+                case decimal number:
+                    return new PropertyValue(Convert.ToDouble(number));
+                case byte number:
+                    return new PropertyValue(number);
+                case uint number:
+                    return new PropertyValue(number);
+                case short number:
+                    return new PropertyValue(number);
+                case ushort number:
+                    return new PropertyValue(number);
+                case long number:
+                    return new PropertyValue(number);
+                case ulong number:
+                    return new PropertyValue(number);
+                case Asset asset:
+                    return new PropertyValue(asset);
+                case Archive archive:
+                    return new PropertyValue(archive);
+                case PropertyValue propertyValue:
+                    return propertyValue;
+            }
+
+            if (targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                var valueField = targetType.GetField("Value")?.GetValue(value);
+                return await Serialize(valueField);
+            }
+
+            if (value is IDictionary dictionary)
+            {
+                var propertyObject = ImmutableDictionary.CreateBuilder<string, PropertyValue>();
+                foreach (var pair in dictionary)
+                {
+                    if (pair is DictionaryEntry keyValuePair && keyValuePair.Key is string key)
+                    {
+                        var serializedValue = await Serialize(keyValuePair.Value);
+                        propertyObject.Add(key, serializedValue);
+                    }
+                }
+
+                return new PropertyValue(propertyObject.ToImmutableDictionary());
+            }
+
+            if (value is IEnumerable enumerable)
+            {
+                var elements = ImmutableArray.CreateBuilder<PropertyValue>();
+
+                if (value is IList list && Serializer.InitializedByDefault(list))
+                {
+                    return new PropertyValue(elements.ToImmutableArray());
+                }
+
+                foreach (var element in enumerable)
+                {
+                    var item = await Serialize(element);
+                    elements.Add(item);
+                }
+
+                return new PropertyValue(elements.ToImmutableArray());
+            }
+
+            if (targetType.IsEnum)
+            {
+                var enumValue = Convert.ToInt32(value);
+                return new PropertyValue(enumValue);
+            }
+
+            if (value is IOutput output)
+            {
+                var data = await output.GetDataAsync().ConfigureAwait(false);
+                if (!data.IsKnown)
+                {
+                    return PropertyValue.Computed;
+                }
+
+                var outputValue = await Serialize(data.Value);
+                var dependantResources = ImmutableArray.CreateBuilder<string>();
+                foreach (var resource in data.Resources)
+                {
+                    var urn = await resource.Urn.GetValueAsync("").ConfigureAwait(false);
+                    dependantResources.Add(urn);
+                }
+
+                var outputProperty = new PropertyValue(new OutputReference(
+                    value: outputValue,
+                    dependencies: dependantResources.ToImmutableArray()));
+
+                if (data.IsSecret)
+                {
+                    return new PropertyValue(outputProperty);
+                }
+
+                return outputProperty;
+            }
+
+            if (value is InputArgs inputArgs)
+            {
+                var inputsMap = await inputArgs.ToDictionaryAsync().ConfigureAwait(false);
+                return await Serialize(inputsMap);
+            }
+
+            if (targetType.IsClass || targetType.IsValueType)
+            {
+                var propertyObject = ImmutableDictionary.CreateBuilder<string, PropertyValue>();
+                foreach (var property in targetType.GetProperties())
+                {
+                    var propertyName = PropertyName(property);
+                    var propertyValue = property.GetValue(value);
+                    var serializedProperty = await Serialize(propertyValue);
+                    propertyObject.Add(propertyName, serializedProperty);
+                }
+
+                return new PropertyValue(propertyObject.ToImmutableDictionary());
+            }
+
+            return PropertyValue.Null;
+        }
+
+        private string DeserializationError(
+            PropertyValueType expected,
+            PropertyValueType actual,
+            Type targetType,
+            string[] path)
+        {
+            if (path.Length == 1 && path[0] == "$")
+            {
+                return $"Error while deserializing value of type {targetType.Name} from property value of type {actual}. "
+                       + $"Expected {expected} instead.";
+            }
+
+            var propertyPath = $"[" + string.Join(", ", path) + "]";
+            return $"Error while deserializing value of type {targetType.Name} from property value of type {actual}. "
+                   + $"Expected {expected} instead at path {propertyPath}.";
+        }
+
+        public Task<T> Deserialize<T>(PropertyValue value)
+        {
+            var rootPath = new[] { "$" };
+            var deserialized = DeserializeValue(value, typeof(T), rootPath);
+            if (deserialized is T deserializedValue)
+            {
+                return Task.FromResult(deserializedValue);
+            }
+
+            throw new InvalidOperationException($"Could not deserialize value of type {typeof(T).Name}");
+        }
+
+        private object? DeserializeValue(PropertyValue value, Type targetType, string[] path)
+        {
+            void ThrowTypeMismatchError(PropertyValueType expectedType)
+            {
+                var error = DeserializationError(
+                    expected: expectedType,
+                    actual: value.Type,
+                    targetType: targetType,
+                    path: path);
+
+                throw new InvalidOperationException(error);
+            }
+
+            if (targetType == typeof(PropertyValue))
+            {
+                return value;
+            }
+
+            if (IsNullable(targetType))
+            {
+                if (value.IsNull)
+                {
+                    return null;
+                }
+
+                if (targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                {
+                    var elementType = targetType.GetGenericArguments()[0];
+                    return Activator.CreateInstance(
+                        type: targetType,
+                        args: new[] { DeserializeValue(value, elementType, path) });
+                }
+            }
+
+            if (targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(InputList<>))
+            {
+                // change InputList<T> to Output<ImmutableArray<T>> and deserialize
+                var elementType = targetType.GetGenericArguments()[0];
+                var listType = typeof(ImmutableArray<>).MakeGenericType(elementType);
+                var outputListType = typeof(Output<>).MakeGenericType(listType);
+                var outputList = DeserializeValue(value, outputListType, path);
+                var fromOutputList = targetType.GetMethod(
+                    "op_Implicit",
+                    types: new[] { outputListType })!;
+
+                return fromOutputList.Invoke(null, new[] { outputList });
+            }
+
+            if (targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(InputMap<>))
+            {
+                // change InputMap<T> to Output<ImmutableDictionary<string, T>> and deserialize
+                var valueType = targetType.GetGenericArguments()[0];
+                var dictionaryType = typeof(ImmutableDictionary<,>).MakeGenericType(typeof(string), valueType);
+                var outputMapType = typeof(Output<>).MakeGenericType(dictionaryType);
+                var outputDictionary = DeserializeValue(value, outputMapType, path);
+                var fromOutputMap = targetType.GetMethod(
+                    "op_Implicit",
+                    types: new[] { outputMapType })!;
+
+                return fromOutputMap.Invoke(null, new[] { outputDictionary });
+            }
+
+            if (targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(Output<>))
+            {
+                // deserialize as Input<T> and then convert to Output<T>
+                var elementType = targetType.GetGenericArguments()[0];
+                var inputType = typeof(Input<>).MakeGenericType(elementType);
+                var input = DeserializeValue(value, inputType, path);
+                var toOutputMethod =
+                    typeof(InputExtensions)
+                        .GetMethod("ToOutput", BindingFlags.Public | BindingFlags.Static)!
+                        .MakeGenericMethod(elementType);
+                return toOutputMethod.Invoke(null, new[] { input });
+            }
+
+            if (targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(Input<>))
+            {
+                var elementType = targetType.GetGenericArguments()[0];
+                var outputDataType = typeof(OutputData<>).MakeGenericType(elementType);
+                var createOutputData = outputDataType.GetConstructor(new[]
+                {
+                    typeof(ImmutableHashSet<Resource>),
+                    elementType,
+                    typeof(bool),
+                    typeof(bool)
+                });
+
+                if (createOutputData == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Could not find constructor for type OutputData<T> with parameters " +
+                        $"{nameof(ImmutableHashSet<Resource>)}, {elementType.Name}, bool, bool");
+                }
+
+                var createOutputMethod =
+                    typeof(Output<>)
+                        .MakeGenericType(elementType)
+                        .GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)
+                        .First(ctor =>
+                        {
+                            // expected parameter type == Task<OutputData<T>>
+                            var parameters = ctor.GetParameters();
+                            return parameters.Length == 1 &&
+                                   parameters[0].ParameterType == typeof(Task<>).MakeGenericType(outputDataType);
+                        })!;
+
+                object CreateOutput(object? outputData)
+                {
+                    var fromResultMethod =
+                        typeof(Task)
+                            .GetMethod("FromResult")!
+                            .MakeGenericMethod(outputDataType)!;
+
+                    return createOutputMethod.Invoke(new[]
+                    {
+                        fromResultMethod.Invoke(null, new [] { outputData })
+                    });
+                }
+
+                object CreateInput(object? outputData)
+                {
+                    var newInputCtor =
+                        typeof(Input<>)
+                            .MakeGenericType(elementType!)
+                            .GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)
+                            .First(ctor =>
+                            {
+                                var parameters = ctor.GetParameters();
+                                return parameters.Length == 1
+                                       && parameters[0].ParameterType == typeof(Output<>).MakeGenericType(elementType);
+                            });
+
+                    return newInputCtor.Invoke(new[] { CreateOutput(outputData) });
+                }
+
+                var unknownOutputData = createOutputData.Invoke(new object?[]
+                {
+                    ImmutableHashSet<Resource>.Empty, // resources
+                    null, // value
+                    false, // isKnown
+                    false // isSecret
+                });
+
+                var unknownOutput = CreateInput(unknownOutputData);
+
+                if (value.IsComputed)
+                {
+                    return unknownOutput;
+                }
+
+                if (value.TryGetSecret(out var secretValue))
+                {
+                    if (secretValue.IsComputed)
+                    {
+                        return unknownOutput;
+                    }
+
+                    if (secretValue.TryGetOutput(out var secretOutput) && secretOutput.Value != null)
+                    {
+                        // here we have Secret(Output(...)) being deserialized into Input<T>
+                        // deserialize the inner Output(...) into Input<T> then mark the output as secret
+                        var resources = ImmutableHashSet.CreateBuilder<Resource>();
+                        foreach (var dependencyUrn in secretOutput.Dependencies)
+                        {
+                            resources.Add(new DependencyResource(dependencyUrn));
+                        }
+
+                        var deserializedOutputValue = DeserializeValue(secretOutput.Value, elementType, path);
+                        var outputData = createOutputData.Invoke(new object?[]
+                        {
+                            resources.ToImmutable(),
+                            deserializedOutputValue,
+                            true, // isKnown
+                            true // isSecret
+                        });
+
+                        return CreateInput(outputData);
+                    }
+
+                    var deserializedValue = DeserializeValue(secretValue, elementType, path);
+                    // Create OutputData<T>
+                    var secretOutputData = createOutputData.Invoke(new object?[]
+                    {
+                        ImmutableHashSet<Resource>.Empty, // resources
+                        deserializedValue, // value
+                        true, // is known
+                        true // is secret
+                    });
+
+                    // return Output<T>
+                    return CreateInput(secretOutputData);
+                }
+
+                if (value.TryGetOutput(out var outputValue) && outputValue.Value != null)
+                {
+                    var secret = false;
+                    var innerOutputValue = outputValue.Value;
+
+                    if (outputValue.Value.TryGetSecret(out var secretOutputValue))
+                    {
+                        // here we have Output(Secret(...)) being deserialized into Input<T>
+                        innerOutputValue = secretOutputValue;
+                        secret = true;
+                    }
+
+                    var resources = ImmutableHashSet.CreateBuilder<Resource>();
+                    foreach (var dependencyUrn in outputValue.Dependencies)
+                    {
+                        resources.Add(new DependencyResource(dependencyUrn));
+                    }
+
+                    var deserializedValue = DeserializeValue(innerOutputValue, elementType, path);
+                    var outputData = createOutputData.Invoke(new object?[]
+                    {
+                        resources.ToImmutable(),
+                        deserializedValue,
+                        true, // isKnown
+                        secret // isSecret
+                    });
+
+                    return CreateInput(outputData);
+                }
+
+                var deserialized = DeserializeValue(value, elementType, path);
+                var outputDataValue = createOutputData.Invoke(new object?[]
+                {
+                    ImmutableHashSet<Resource>.Empty,
+                    deserialized,
+                    true,
+                    false
+                });
+
+                return CreateInput(outputDataValue);
+            }
+
+            if (targetType == typeof(int))
+            {
+                if (value.TryGetNumber(out var numberAsInt))
+                {
+                    return (int)numberAsInt;
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Number);
+            }
+
+            if (targetType == typeof(double))
+            {
+                if (value.TryGetNumber(out var numberAsDouble))
+                {
+                    return numberAsDouble;
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Number);
+            }
+
+            if (targetType == typeof(float))
+            {
+                if (value.TryGetNumber(out var numberAsFloat))
+                {
+                    return (float)numberAsFloat;
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Number);
+            }
+
+            if (targetType == typeof(decimal))
+            {
+                if (value.TryGetNumber(out var numberAsDecimal))
+                {
+                    return Convert.ToDecimal(numberAsDecimal);
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Number);
+            }
+
+            if (targetType == typeof(byte))
+            {
+                if (value.TryGetNumber(out var numberAsByte))
+                {
+                    return Convert.ToByte(numberAsByte);
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Number);
+            }
+
+            if (targetType == typeof(uint))
+            {
+                if (value.TryGetNumber(out var numberAsUInt32))
+                {
+                    return Convert.ToUInt32(numberAsUInt32);
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Number);
+            }
+
+            if (targetType == typeof(short))
+            {
+                if (value.TryGetNumber(out var numberAsShort))
+                {
+                    return Convert.ToInt16(numberAsShort);
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Number);
+            }
+
+            if (targetType == typeof(ushort))
+            {
+                if (value.TryGetNumber(out var numberAsUnsignedShort))
+                {
+                    return Convert.ToUInt16(numberAsUnsignedShort);
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Number);
+            }
+
+            if (targetType == typeof(long))
+            {
+                if (value.TryGetNumber(out var numberAsLong))
+                {
+                    return Convert.ToInt64(numberAsLong);
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Number);
+            }
+
+            if (targetType == typeof(ulong))
+            {
+                if (value.TryGetNumber(out var numberAsLong))
+                {
+                    return Convert.ToUInt64(numberAsLong);
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Number);
+            }
+
+            if (targetType == typeof(string))
+            {
+                if (value.TryGetString(out var stringValue))
+                {
+                    return stringValue;
+                }
+
+                if (value.IsNull)
+                {
+                    return null;
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.String);
+            }
+
+            if (targetType.IsEnum)
+            {
+                if (value.TryGetNumber(out var enumValue))
+                {
+                    return Enum.ToObject(targetType, Convert.ToInt32(enumValue));
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Number);
+            }
+
+            if (targetType == typeof(Asset))
+            {
+                if (value.TryGetAsset(out var asset))
+                {
+                    return asset;
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Asset);
+            }
+
+            if (targetType == typeof(Archive))
+            {
+                if (value.TryGetArchive(out var archive))
+                {
+                    return archive;
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Archive);
+            }
+
+            if (targetType == typeof(bool))
+            {
+                if (value.TryGetBool(out var boolValue))
+                {
+                    return boolValue;
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Bool);
+            }
+
+            if (targetType.IsArray)
+            {
+                if (value.TryGetArray(out var arrayValue))
+                {
+                    var elementType = targetType.GetElementType()!;
+                    var array = Array.CreateInstance(elementType, arrayValue.Length);
+                    for (var i = 0; i < arrayValue.Length; ++i)
+                    {
+                        var elementPath = path.Append($"index[{i}]").ToArray();
+                        var deserialized = DeserializeValue(arrayValue[i], elementType, elementPath);
+                        if (deserialized != null || IsNullable(elementType))
+                        {
+                            array.SetValue(deserialized, i);
+                        }
+                    }
+                    return array;
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Array);
+            }
+
+            if (targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(List<>))
+            {
+                if (value.TryGetArray(out var arrayValue))
+                {
+                    var elementType = targetType.GetGenericArguments()[0];
+                    var list = Activator.CreateInstance(targetType)!;
+                    var addMethod = targetType.GetMethod(nameof(List<int>.Add))!;
+                    var index = 0;
+                    foreach (var item in arrayValue)
+                    {
+                        var elementPath = path.Append($"index[{index}]").ToArray();
+                        var deserialized = DeserializeValue(item, elementType, elementPath);
+                        if (deserialized != null || IsNullable(elementType))
+                        {
+                            addMethod.Invoke(list, new[] { deserialized });
+                        }
+
+                        index++;
+                    }
+                    return list;
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Array);
+            }
+
+            if (targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(ImmutableArray<>))
+            {
+                var builder =
+                    typeof(ImmutableArray).GetMethod(nameof(ImmutableArray.CreateBuilder), Array.Empty<Type>())!
+                        .MakeGenericMethod(targetType.GenericTypeArguments)
+                        .Invoke(obj: null, parameters: null)!;
+
+                if (value.TryGetArray(out var arrayValue))
+                {
+                    var builderAdd = builder.GetType().GetMethod(nameof(ImmutableArray<int>.Builder.Add))!;
+                    var builderToImmutable = builder.GetType().GetMethod(nameof(ImmutableArray<int>.Builder.ToImmutable))!;
+                    var elementType = targetType.GetGenericArguments()[0];
+                    var index = 0;
+                    foreach (var item in arrayValue)
+                    {
+                        var elementPath = path.Append($"index[{index}]").ToArray();
+                        var deserialized = DeserializeValue(item, elementType, elementPath);
+                        if (deserialized != null || IsNullable(elementType))
+                        {
+                            builderAdd.Invoke(builder, new[] { deserialized });
+                        }
+
+                        index++;
+                    }
+
+                    return builderToImmutable.Invoke(builder, Array.Empty<object>());
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Array);
+            }
+
+            if (targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(Dictionary<,>))
+            {
+                if (value.TryGetObject(out var values))
+                {
+                    var dictionary = Activator.CreateInstance(targetType);
+                    var addMethod =
+                        targetType
+                            .GetMethods()
+                            .First(methodInfo => methodInfo.Name == "Add" && methodInfo.GetParameters().Count() == 2);
+
+                    var valueType = targetType.GenericTypeArguments[1];
+                    foreach (var pair in values)
+                    {
+                        var elementPath = path.Append(pair.Key).ToArray();
+                        var deserializedValue = DeserializeValue(pair.Value, valueType, elementPath);
+                        if (deserializedValue != null || IsNullable(valueType))
+                        {
+                            addMethod.Invoke(dictionary, new[] { pair.Key, deserializedValue });
+                        }
+                    }
+                    return dictionary;
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Object);
+            }
+
+            if (targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(ImmutableDictionary<,>))
+            {
+                var builder =
+                    typeof(ImmutableDictionary).GetMethod(nameof(ImmutableDictionary.CreateBuilder),
+                            Array.Empty<Type>())!
+                        .MakeGenericMethod(targetType.GenericTypeArguments)
+                        .Invoke(obj: null, parameters: null)!;
+
+                var builderAdd =
+                    builder
+                        .GetType()
+                        .GetMethods()
+                        .First(methodInfo => methodInfo.Name == "Add" && methodInfo.GetParameters().Count() == 2);
+
+                var builderToImmutable = builder.GetType()
+                    .GetMethod(nameof(ImmutableDictionary<int, int>.Builder.ToImmutable))!;
+                var valueType = targetType.GenericTypeArguments[1];
+
+                if (value.TryGetObject(out var values))
+                {
+                    foreach (var pair in values)
+                    {
+                        var elementPath = path.Append(pair.Key).ToArray();
+                        var deserializedValue = DeserializeValue(pair.Value, valueType, elementPath);
+                        if (deserializedValue != null || IsNullable(valueType))
+                        {
+                            builderAdd.Invoke(builder, new[] { pair.Key, deserializedValue });
+                        }
+                    }
+                    return builderToImmutable.Invoke(builder, Array.Empty<object>());
+                }
+
+                ThrowTypeMismatchError(PropertyValueType.Object);
+            }
+
+            if (targetType.IsClass || targetType.IsValueType)
+            {
+                if (value.TryGetObject(out var objectProperties))
+                {
+                    return DeserializeObject(objectProperties, targetType, path);
+                }
+            }
+
+            return null;
+        }
+
+        internal static async Task<PropertyValue> From(object? data)
+        {
+            var serializer = new Serializer(excessiveDebugOutput: false);
+            var value = await serializer.SerializeAsync(
+                prop: data,
+                keepResources: true,
+                keepOutputValues: true,
+                ctx: "");
+
+            return PropertyValue.Unmarshal(Serializer.CreateValue(value));
+        }
+
+        internal async Task<ImmutableDictionary<string, PropertyValue>> StateFromComponentResource(
+            ComponentResource component)
+        {
+            var state = new Dictionary<string, PropertyValue>();
+            var componentType = component.GetType();
+            var properties = componentType.GetProperties();
+            foreach (var property in properties)
+            {
+                var outputAttr = property
+                    .GetCustomAttributes(typeof(OutputAttribute), false)
+                    .FirstOrDefault();
+
+                if (outputAttr is OutputAttribute attr)
+                {
+                    var propertyName = property.Name;
+                    if (!string.IsNullOrWhiteSpace(attr.Name))
+                    {
+                        propertyName = attr.Name;
+                    }
+
+                    var value = property.GetValue(component);
+                    if (value != null)
+                    {
+                        var serialized = await Serialize(value);
+                        state.Add(propertyName, serialized);
+                    }
+                }
+            }
+
+            return state.ToImmutableDictionary();
+        }
+    }
+}

--- a/sdk/Pulumi/Serialization/Serializer.cs
+++ b/sdk/Pulumi/Serialization/Serializer.cs
@@ -386,7 +386,7 @@ $"Tasks are not allowed inside ResourceArgs. Please wrap your Task in an Output:
         /// The use of reflection is unavoidable because we cannot _statically_ resolve the
         /// generic type T in ImmutableArray[T].
         /// </summary>
-        private bool InitializedByDefault(IList list)
+        internal static bool InitializedByDefault(IList list)
         {
             var concreteType = list.GetType();
             if (concreteType.IsGenericType)


### PR DESCRIPTION
This PR implements a deserializer from `PropertyValue` into objects via reflection, to be used in native-provider implementations that operate on `PropertyValue` instead of the lower-level `Struct` and `Value` from gRPC. 

The implementation handles most commonly used primitive types and their containers: `string`, `int`, `bool`, `double`, enums, nullable types, arrays, immutable arrays, lists, dictionaries, immutable dictionaries, inputs, input list, input map and nested objects. 

When deserializing an object, if a non-nullable _primitive_ property is missing, an exception is thrown. However, this doesn't include arrays, dictionaries or lists: an empty container is constructed when the data is empty or missing. Also for strings, an empty string is created when deserializing from `Null` or the property is missing. This is to accommodate for the fact that gRPC treats null values as empty so I made the deserializer less strict about missing values. 