### PR TITLE
Update Grpc dependencies

### DIFF
--- a/.changes/unreleased/Improvements-219.yaml
+++ b/.changes/unreleased/Improvements-219.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Update Grpc dependency.
+time: 2024-01-04T10:08:56.2382789Z
+custom:
+  PR: "219"

--- a/sdk/Pulumi.Automation/Pulumi.Automation.csproj
+++ b/sdk/Pulumi.Automation/Pulumi.Automation.csproj
@@ -39,7 +39,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="CliWrap" Version="3.3.2" />
-    <PackageReference Include="Grpc.AspNetCore.Server" version="2.37.0" />
     <PackageReference Include="YamlDotNet" Version="11.1.1" />
   </ItemGroup>
 

--- a/sdk/Pulumi/Pulumi.csproj
+++ b/sdk/Pulumi/Pulumi.csproj
@@ -30,10 +30,10 @@
 
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.52.0" />
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.37.0" />
-    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.37.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.44.0">
+    <PackageReference Include="Grpc.Net.Client" Version="2.51.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.51.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.51.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.51.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-dotnet/issues/218.

2.51.0 seems to be the latest release we can safely update to.
2.52 and later of Grpc.Tools doesn't work on old macos versions (https://github.com/grpc/grpc/issues/32558).
2.57 and later Grpc libraries dropped support for netcore3 which we're still building for, although _technically_ it's well out of support so we ought to drop it at some point but we hit lots of pain last time we tried (https://github.com/pulumi/pulumi/issues/11768).