### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release-dotnet-provider.yml
+++ b/.github/workflows/release-dotnet-provider.yml
@@ -46,9 +46,9 @@ jobs:
         id: check-release
         run: |
           if [ -z "$(git tag -l ${{ env.GORELEASER_CURRENT_TAG }})" ]; then
-            echo "::set-output name=exists::false"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=exists::true"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Run GoReleaser
         if: steps.check-release.outputs.exists == 'false'


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter