### PR TITLE
Run build & test steps on windows & macos if the ci/test label is set

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,6 +24,16 @@ jobs:
           os="${{ contains(github.event.pull_request.labels.*.name, 'ci/test') && 'ubuntu-latest macos-latest windows-latest' || 'ubuntu-latest' }}"
           echo "matrix={\"os\": $(echo $os | jq -cR 'split(" ")')}" >> $GITHUB_OUTPUT
 
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup dotnet SDK v6.0
+        uses: actions/setup-dotnet@v4
+      - name: Format Pulumi SDK
+        run: dotnet run format-sdk verify
+
   build:
     needs: setup_matrix
     strategy:
@@ -41,8 +51,6 @@ jobs:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Install Pulumi CLI
         uses: pulumi/actions@v5
-      - name: Format Pulumi SDK
-        run: dotnet run format-sdk verify
       - name: Build Pulumi SDK
         run: dotnet run build-sdk
       - name: Test Pulumi SDK
@@ -135,7 +143,7 @@ jobs:
       - name: TestDeletedWith
         run: dotnet run integration test TestDeletedWith
   check-pr:
-    needs: ["build", "integration-tests"]
+    needs: ["build", "integration-tests", "format"]
     runs-on: ubuntu-latest
     steps:
       - name: OK

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,12 +14,24 @@ env:
   PULUMI_TEST_OWNER: "moolumi"
 
 jobs:
+  setup_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          os="${{ contains(github.event.pull_request.labels.*.name, 'ci/test') && 'ubuntu-latest macos-latest windows-latest' || 'ubuntu-latest' }}"
+          echo "matrix={\"os\": $(echo $os | jq -cR 'split(" ")')}" >> $GITHUB_OUTPUT
+
   build:
+    needs: setup_matrix
     strategy:
       matrix:
+        os: ${{ fromJson(needs.setup_matrix.outputs.matrix).os }}
         dotnet-version: [6.0.x, 8.0.x]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -47,9 +59,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   integration-tests:
     strategy:
-        matrix:
-          os: [ubuntu-latest, windows-latest, macos-11]
-          dotnet-version: [6.0.x, 8.0.x]
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-11]
+        dotnet-version: [6.0.x, 8.0.x]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
Currently we only run a [certain integration tests](https://github.com/pulumi/pulumi-dotnet/blob/a5f3d6cefbab84efacd4df74a21aac8d3f3b3d2f/.github/workflows/pr.yml#L67) on windows & Mac.

Allow running the sdk and automation tests on windows & Mac by setting the `ci/test` label.