### PR TITLE
Add attribute to handle deserialization of constructor parameters with name overrides

### DIFF
--- a/.changes/unreleased/Improvements-231.yaml
+++ b/.changes/unreleased/Improvements-231.yaml
@@ -1,0 +1,7 @@
+component: sdk
+kind: Improvements
+body: Add attribute to handle deserialization of constructor parameters with name
+  overrides
+time: 2024-02-17T07:53:37.629486995-08:00
+custom:
+  PR: "231"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ This repo is made up of three main components. The host runtime (pulumi-language
 ## Changelog
 
 Changelog management is done via [`changie`](https://changie.dev/).
+See the [installation](https://changie.dev/guide/installation/) guide for `changie`.
 
 Run `changie new` in the top level directory. Here is an example of what that looks like:
 

--- a/sdk/Pulumi.Tests/Serialization/ConstructorParamAttributeTests.cs
+++ b/sdk/Pulumi.Tests/Serialization/ConstructorParamAttributeTests.cs
@@ -1,0 +1,40 @@
+// Copyright 2016-2024, Pulumi Corporation
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Pulumi.Serialization;
+using Xunit;
+
+namespace Pulumi.Tests.Serialization
+{
+    public class ConstructorParamAttributeTests : ConverterTests
+    {
+        [OutputType]
+        public class MyResource
+        {
+            public readonly string StringProp;
+
+            [OutputConstructor]
+            public MyResource([OutputConstructorParameter("string_prop")] string stringProp)
+            {
+                StringProp = stringProp;
+            }
+        }
+
+        [Fact]
+        public async Task TestOutputConstructorParameter()
+        {
+            var warnings = new List<string>();
+
+            var data = Converter.ConvertValue<MyResource>(warnings.Add, "", await SerializeToValueAsync(new Dictionary<string, object>
+            {
+                { "string_prop", "somevalue" },
+            }));
+
+            Assert.Equal("somevalue", data.Value.StringProp);
+        }
+    }
+}

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -2377,6 +2377,12 @@
                  but is recommended and is what our codegen does.
              </summary>
         </member>
+        <member name="T:Pulumi.OutputConstructorParameterAttribute">
+            <summary>
+            Attribute used by a Pulumi Cloud Provider Package to mark
+            constructor parameters with a name override.
+            </summary>
+        </member>
         <member name="F:Pulumi.Serialization.Constants.UnknownValue">
             <summary>
             Unknown values are encoded as a distinguished string value.
@@ -3650,7 +3656,7 @@
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
         </member>
         <member name="M:Pulumirpc.Analyzer.BindService(Grpc.Core.ServiceBinderBase,Pulumirpc.Analyzer.AnalyzerBase)">
-            <summary>Register service method with a service binder with or without implementation. Useful when customizing the  service binding logic.
+            <summary>Register service method with a service binder with or without implementation. Useful when customizing the service binding logic.
             Note: this method is part of an experimental API that can change or be removed without any prior notice.</summary>
             <param name="serviceBinder">Service methods will be bound by calling <c>AddMethod</c> on this object.</param>
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
@@ -4039,7 +4045,7 @@
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
         </member>
         <member name="M:Pulumirpc.Converter.BindService(Grpc.Core.ServiceBinderBase,Pulumirpc.Converter.ConverterBase)">
-            <summary>Register service method with a service binder with or without implementation. Useful when customizing the  service binding logic.
+            <summary>Register service method with a service binder with or without implementation. Useful when customizing the service binding logic.
             Note: this method is part of an experimental API that can change or be removed without any prior notice.</summary>
             <param name="serviceBinder">Service methods will be bound by calling <c>AddMethod</c> on this object.</param>
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
@@ -4323,7 +4329,7 @@
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
         </member>
         <member name="M:Pulumirpc.Engine.BindService(Grpc.Core.ServiceBinderBase,Pulumirpc.Engine.EngineBase)">
-            <summary>Register service method with a service binder with or without implementation. Useful when customizing the  service binding logic.
+            <summary>Register service method with a service binder with or without implementation. Useful when customizing the service binding logic.
             Note: this method is part of an experimental API that can change or be removed without any prior notice.</summary>
             <param name="serviceBinder">Service methods will be bound by calling <c>AddMethod</c> on this object.</param>
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
@@ -5319,7 +5325,7 @@
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
         </member>
         <member name="M:Pulumirpc.LanguageRuntime.BindService(Grpc.Core.ServiceBinderBase,Pulumirpc.LanguageRuntime.LanguageRuntimeBase)">
-            <summary>Register service method with a service binder with or without implementation. Useful when customizing the  service binding logic.
+            <summary>Register service method with a service binder with or without implementation. Useful when customizing the service binding logic.
             Note: this method is part of an experimental API that can change or be removed without any prior notice.</summary>
             <param name="serviceBinder">Service methods will be bound by calling <c>AddMethod</c> on this object.</param>
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
@@ -7548,7 +7554,7 @@
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
         </member>
         <member name="M:Pulumirpc.ResourceProvider.BindService(Grpc.Core.ServiceBinderBase,Pulumirpc.ResourceProvider.ResourceProviderBase)">
-            <summary>Register service method with a service binder with or without implementation. Useful when customizing the  service binding logic.
+            <summary>Register service method with a service binder with or without implementation. Useful when customizing the service binding logic.
             Note: this method is part of an experimental API that can change or be removed without any prior notice.</summary>
             <param name="serviceBinder">Service methods will be bound by calling <c>AddMethod</c> on this object.</param>
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
@@ -8207,7 +8213,7 @@
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
         </member>
         <member name="M:Pulumirpc.ResourceMonitor.BindService(Grpc.Core.ServiceBinderBase,Pulumirpc.ResourceMonitor.ResourceMonitorBase)">
-            <summary>Register service method with a service binder with or without implementation. Useful when customizing the  service binding logic.
+            <summary>Register service method with a service binder with or without implementation. Useful when customizing the service binding logic.
             Note: this method is part of an experimental API that can change or be removed without any prior notice.</summary>
             <param name="serviceBinder">Service methods will be bound by calling <c>AddMethod</c> on this object.</param>
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
@@ -8467,7 +8473,7 @@
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
         </member>
         <member name="M:Pulumirpc.Testing.LanguageTest.BindService(Grpc.Core.ServiceBinderBase,Pulumirpc.Testing.LanguageTest.LanguageTestBase)">
-            <summary>Register service method with a service binder with or without implementation. Useful when customizing the  service binding logic.
+            <summary>Register service method with a service binder with or without implementation. Useful when customizing the service binding logic.
             Note: this method is part of an experimental API that can change or be removed without any prior notice.</summary>
             <param name="serviceBinder">Service methods will be bound by calling <c>AddMethod</c> on this object.</param>
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
@@ -8594,7 +8600,7 @@
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
         </member>
         <member name="M:Codegen.Loader.BindService(Grpc.Core.ServiceBinderBase,Codegen.Loader.LoaderBase)">
-            <summary>Register service method with a service binder with or without implementation. Useful when customizing the  service binding logic.
+            <summary>Register service method with a service binder with or without implementation. Useful when customizing the service binding logic.
             Note: this method is part of an experimental API that can change or be removed without any prior notice.</summary>
             <param name="serviceBinder">Service methods will be bound by calling <c>AddMethod</c> on this object.</param>
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
@@ -8723,7 +8729,7 @@
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>
         </member>
         <member name="M:Codegen.Mapper.BindService(Grpc.Core.ServiceBinderBase,Codegen.Mapper.MapperBase)">
-            <summary>Register service method with a service binder with or without implementation. Useful when customizing the  service binding logic.
+            <summary>Register service method with a service binder with or without implementation. Useful when customizing the service binding logic.
             Note: this method is part of an experimental API that can change or be removed without any prior notice.</summary>
             <param name="serviceBinder">Service methods will be bound by calling <c>AddMethod</c> on this object.</param>
             <param name="serviceImpl">An object implementing the server-side handling logic.</param>

--- a/sdk/Pulumi/Serialization/Attributes.cs
+++ b/sdk/Pulumi/Serialization/Attributes.cs
@@ -114,13 +114,13 @@ namespace Pulumi
     /// constructor parameters with a name override.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
-    public class ConstructorParameterNameOverrideAttribute : Attribute
+    public sealed class OutputConstructorParameterAttribute : Attribute
     {
         public string Name { get; }
 
-        public ConstructorParameterNameOverrideAttribute(string apiName)
+        public OutputConstructorParameterAttribute(string name)
         {
-            Name = apiName;
+            Name = name;
         }
     }
 }

--- a/sdk/Pulumi/Serialization/Attributes.cs
+++ b/sdk/Pulumi/Serialization/Attributes.cs
@@ -108,4 +108,19 @@ namespace Pulumi
             Version = version;
         }
     }
+
+    /// <summary>
+    /// Attribute used by a Pulumi Cloud Provider Package to mark constructor parameters
+    /// whose API name is different from the C# name.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public class ConstructorParameterApiNameAttribute : Attribute
+    {
+        public string ApiName { get; }
+
+        public ConstructorParameterApiNameAttribute(string apiName)
+        {
+            ApiName = apiName;
+        }
+    }
 }

--- a/sdk/Pulumi/Serialization/Attributes.cs
+++ b/sdk/Pulumi/Serialization/Attributes.cs
@@ -78,6 +78,21 @@ namespace Pulumi
     }
 
     /// <summary>
+    /// Attribute used by a Pulumi Cloud Provider Package to mark
+    /// constructor parameters with a name override.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public sealed class OutputConstructorParameterAttribute : Attribute
+    {
+        public string Name { get; }
+
+        public OutputConstructorParameterAttribute(string name)
+        {
+            Name = name;
+        }
+    }
+
+    /// <summary>
     /// Attribute used by a Pulumi Cloud Provider Package to mark enum types.
     ///
     /// Requirements for a struct-based enum to be (de)serialized are as follows.
@@ -106,21 +121,6 @@ namespace Pulumi
         {
             Type = type;
             Version = version;
-        }
-    }
-
-    /// <summary>
-    /// Attribute used by a Pulumi Cloud Provider Package to mark
-    /// constructor parameters with a name override.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Parameter)]
-    public sealed class OutputConstructorParameterAttribute : Attribute
-    {
-        public string Name { get; }
-
-        public OutputConstructorParameterAttribute(string name)
-        {
-            Name = name;
         }
     }
 }

--- a/sdk/Pulumi/Serialization/Attributes.cs
+++ b/sdk/Pulumi/Serialization/Attributes.cs
@@ -110,17 +110,17 @@ namespace Pulumi
     }
 
     /// <summary>
-    /// Attribute used by a Pulumi Cloud Provider Package to mark constructor parameters
-    /// whose API name is different from the C# name.
+    /// Attribute used by a Pulumi Cloud Provider Package to mark
+    /// constructor parameters with a name override.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
-    public class ConstructorParameterApiNameAttribute : Attribute
+    public class ConstructorParameterNameOverrideAttribute : Attribute
     {
-        public string ApiName { get; }
+        public string Name { get; }
 
-        public ConstructorParameterApiNameAttribute(string apiName)
+        public ConstructorParameterNameOverrideAttribute(string apiName)
         {
-            ApiName = apiName;
+            Name = apiName;
         }
     }
 }

--- a/sdk/Pulumi/Serialization/Converter.cs
+++ b/sdk/Pulumi/Serialization/Converter.cs
@@ -200,11 +200,18 @@ namespace Pulumi.Serialization
             for (int i = 0, n = constructorParameters.Length; i < n; i++)
             {
                 var parameter = constructorParameters[i];
+                var parameterName = parameter.Name!;
+                var attribute = parameter.GetCustomAttribute<ConstructorParameterApiNameAttribute>();
+
+                if (attribute != null)
+                {
+                    parameterName = attribute.ApiName;
+                }
 
                 // Note: TryGetValue may not find a value here.  That can happen for things like
                 // unknown vals.  That's ok.  We'll pass that through to 'Convert' and will get the
                 // default value needed for the parameter type.
-                dictionary!.TryGetValue(parameter.Name!, out var argValue);
+                dictionary!.TryGetValue(parameterName, out var argValue);
 
                 arguments[i] = ConvertObject(warn, $"{targetType.FullName}({parameter.Name})", argValue, parameter.ParameterType);
             }

--- a/sdk/Pulumi/Serialization/Converter.cs
+++ b/sdk/Pulumi/Serialization/Converter.cs
@@ -201,8 +201,7 @@ namespace Pulumi.Serialization
             {
                 var parameter = constructorParameters[i];
                 var parameterName = parameter.Name!;
-                var attribute = parameter.GetCustomAttribute<ConstructorParameterNameOverrideAttribute>();
-
+                var attribute = parameter.GetCustomAttribute<OutputConstructorParameterAttribute>();
                 if (attribute != null)
                 {
                     parameterName = attribute.Name;

--- a/sdk/Pulumi/Serialization/Converter.cs
+++ b/sdk/Pulumi/Serialization/Converter.cs
@@ -201,11 +201,11 @@ namespace Pulumi.Serialization
             {
                 var parameter = constructorParameters[i];
                 var parameterName = parameter.Name!;
-                var attribute = parameter.GetCustomAttribute<ConstructorParameterApiNameAttribute>();
+                var attribute = parameter.GetCustomAttribute<ConstructorParameterNameOverrideAttribute>();
 
                 if (attribute != null)
                 {
-                    parameterName = attribute.ApiName;
+                    parameterName = attribute.Name;
                 }
 
                 // Note: TryGetValue may not find a value here.  That can happen for things like


### PR DESCRIPTION
This PR is in support of https://github.com/pulumi/pulumi/issues/14130.

I have a local override for the native provider in question to use the changes in this PR, as well as codegen changes in pulumi/pulumi using the PR https://github.com/pulumi/pulumi/pull/14246 with additional changes to emit the attribute introduced in this PR.

Here's how it looks in practice in a provider's SDK:

```csharp
    [OutputType]
    public sealed class ListOneClicksProperties
    {
        public readonly ImmutableArray<Outputs.OneClicks> _1Clicks;

        [OutputConstructor]
        private ListOneClicksProperties([OutputConstructorParameterAttribute("1_clicks")] ImmutableArray<Outputs.OneClicks> _1Clicks)
        {
            this._1Clicks = _1Clicks;
        }
    }
```