### PR TITLE
Remove netcoreapp3.1 support

### DIFF
--- a/.changes/unreleased/Improvements-235.yaml
+++ b/.changes/unreleased/Improvements-235.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Drop support for netcoreapp3.1
+time: 2024-03-04T21:00:58.198958Z
+custom:
+  PR: "235"

--- a/sdk/Pulumi.Automation/Pulumi.Automation.csproj
+++ b/sdk/Pulumi.Automation/Pulumi.Automation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>
     <Company>Pulumi Corp.</Company>

--- a/sdk/Pulumi.Automation/Serialization/LocalSerializer.cs
+++ b/sdk/Pulumi.Automation/Serialization/LocalSerializer.cs
@@ -61,11 +61,7 @@ namespace Pulumi.Automation.Serialization
             var options = new JsonSerializerOptions
             {
                 AllowTrailingCommas = true,
-#if NETCOREAPP3_1
-                IgnoreNullValues = true,
-#else
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-#endif
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             };
 

--- a/sdk/Pulumi.FSharp/Pulumi.FSharp.fsproj
+++ b/sdk/Pulumi.FSharp/Pulumi.FSharp.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>
     <Company>Pulumi Corp.</Company>

--- a/sdk/Pulumi/Core/Output.cs
+++ b/sdk/Pulumi/Core/Output.cs
@@ -270,33 +270,9 @@ namespace Pulumi
 
                 // This needs to handle nested potentially secret and unknown Output values, we do this by
                 // hooking options to handle any seen Output<T> values.
-
-                // TODO: This can be simplified in net6.0 to just new System.Text.Json.JsonSerializerOptions(options);
-#if NETCOREAPP3_1
-                var internalOptions = new System.Text.Json.JsonSerializerOptions();
-                internalOptions.AllowTrailingCommas = options?.AllowTrailingCommas ?? internalOptions.AllowTrailingCommas;
-                if (options != null)
-                {
-                    foreach (var converter in options.Converters)
-                    {
-                        internalOptions.Converters.Add(converter);
-                    }
-                }
-                internalOptions.DefaultBufferSize = options?.DefaultBufferSize ?? internalOptions.DefaultBufferSize;
-                internalOptions.DictionaryKeyPolicy = options?.DictionaryKeyPolicy ?? internalOptions.DictionaryKeyPolicy;
-                internalOptions.Encoder = options?.Encoder ?? internalOptions.Encoder;
-                internalOptions.IgnoreNullValues = options?.IgnoreNullValues ?? internalOptions.IgnoreNullValues;
-                internalOptions.IgnoreReadOnlyProperties = options?.IgnoreReadOnlyProperties ?? internalOptions.IgnoreReadOnlyProperties;
-                internalOptions.MaxDepth = options?.MaxDepth ?? internalOptions.MaxDepth;
-                internalOptions.PropertyNameCaseInsensitive = options?.PropertyNameCaseInsensitive ?? internalOptions.PropertyNameCaseInsensitive;
-                internalOptions.PropertyNamingPolicy = options?.PropertyNamingPolicy ?? internalOptions.PropertyNamingPolicy;
-                internalOptions.ReadCommentHandling = options?.ReadCommentHandling ?? internalOptions.ReadCommentHandling;
-                internalOptions.WriteIndented = options?.WriteIndented ?? internalOptions.WriteIndented;
-#else
                 var internalOptions = options == null ?
                     new System.Text.Json.JsonSerializerOptions() :
                     new System.Text.Json.JsonSerializerOptions(options);
-#endif
 
                 // Add the magic converter to allow us to do nested outputs
                 var outputConverter = new OutputJsonConverter(result.Resources, result.IsSecret);
@@ -341,31 +317,9 @@ namespace Pulumi
                     return new OutputData<T>(result.Resources, default!, false, result.IsSecret);
                 }
 
-#if NETCOREAPP3_1
-                var internalOptions = new System.Text.Json.JsonSerializerOptions();
-                internalOptions.AllowTrailingCommas = options?.AllowTrailingCommas ?? internalOptions.AllowTrailingCommas;
-                if (options != null)
-                {
-                    foreach (var converter in options.Converters)
-                    {
-                        internalOptions.Converters.Add(converter);
-                    }
-                }
-                internalOptions.DefaultBufferSize = options?.DefaultBufferSize ?? internalOptions.DefaultBufferSize;
-                internalOptions.DictionaryKeyPolicy = options?.DictionaryKeyPolicy ?? internalOptions.DictionaryKeyPolicy;
-                internalOptions.Encoder = options?.Encoder ?? internalOptions.Encoder;
-                internalOptions.IgnoreNullValues = options?.IgnoreNullValues ?? internalOptions.IgnoreNullValues;
-                internalOptions.IgnoreReadOnlyProperties = options?.IgnoreReadOnlyProperties ?? internalOptions.IgnoreReadOnlyProperties;
-                internalOptions.MaxDepth = options?.MaxDepth ?? internalOptions.MaxDepth;
-                internalOptions.PropertyNameCaseInsensitive = options?.PropertyNameCaseInsensitive ?? internalOptions.PropertyNameCaseInsensitive;
-                internalOptions.PropertyNamingPolicy = options?.PropertyNamingPolicy ?? internalOptions.PropertyNamingPolicy;
-                internalOptions.ReadCommentHandling = options?.ReadCommentHandling ?? internalOptions.ReadCommentHandling;
-                internalOptions.WriteIndented = options?.WriteIndented ?? internalOptions.WriteIndented;
-#else
                 var internalOptions = options == null ?
                     new System.Text.Json.JsonSerializerOptions() :
                     new System.Text.Json.JsonSerializerOptions(options);
-#endif
 
                 // Add the magic converter to allow us to do nested outputs
                 var outputConverter = new OutputJsonConverter(result.Resources, result.IsSecret);

--- a/sdk/Pulumi/Deployment/GrpcEngine.cs
+++ b/sdk/Pulumi/Deployment/GrpcEngine.cs
@@ -17,9 +17,6 @@ namespace Pulumi
         private static readonly object _channelsLock = new object();
         public GrpcEngine(string engineAddress)
         {
-            // Allow for insecure HTTP/2 transport (only needed for netcoreapp3.x)
-            // https://docs.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-6.0#call-insecure-grpc-services-with-net-core-client
-            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
             // maxRpcMessageSize raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
             const int maxRpcMessageSize = 400 * 1024 * 1024;
             if (_engineChannels.TryGetValue(engineAddress, out var engineChannel))

--- a/sdk/Pulumi/Deployment/GrpcMonitor.cs
+++ b/sdk/Pulumi/Deployment/GrpcMonitor.cs
@@ -19,9 +19,6 @@ namespace Pulumi
         private static readonly object _channelsLock = new object();
         public GrpcMonitor(string monitorAddress)
         {
-            // Allow for insecure HTTP/2 transport (only needed for netcoreapp3.x)
-            // https://docs.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-6.0#call-insecure-grpc-services-with-net-core-client
-            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
             // maxRpcMessageSize raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
             const int maxRpcMessageSize = 400 * 1024 * 1024;
             if (_monitorChannels.TryGetValue(monitorAddress, out var monitorChannel))

--- a/sdk/Pulumi/Provider/Host.cs
+++ b/sdk/Pulumi/Provider/Host.cs
@@ -99,9 +99,6 @@ namespace Pulumi.Experimental.Provider
         private static readonly object _channelsLock = new object();
         public GrpcHost(string engineAddress)
         {
-            // Allow for insecure HTTP/2 transport (only needed for netcoreapp3.x)
-            // https://docs.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-6.0#call-insecure-grpc-services-with-net-core-client
-            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
             // maxRpcMessageSize raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
             const int maxRpcMessageSize = 400 * 1024 * 1024;
             if (_engineChannels.TryGetValue(engineAddress, out var engineChannel))

--- a/sdk/Pulumi/Pulumi.csproj
+++ b/sdk/Pulumi/Pulumi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>
     <Company>Pulumi Corp.</Company>


### PR DESCRIPTION
netcore 3.1 is well out of it's support lifecycle. The code generators in pulumi/pulumi no longer emit any reference to netcoreapp3.1. Users should have updated to net6.0 or later, as netcoreapp3.1 is no longer supported by Microsoft either.