### PR TITLE
automation: always read complete lines

### DIFF
--- a/.changes/unreleased/Bug Fixes-245.yaml
+++ b/.changes/unreleased/Bug Fixes-245.yaml
@@ -1,0 +1,7 @@
+component: sdk/auto
+kind: Bug Fixes
+body: 'Make sure to read complete lines before trying to deserialize them as engine
+  events'
+time: 2024-03-26T10:27:29.381615999+01:00
+custom:
+  PR: "245"

--- a/sdk/Pulumi.Automation/Events/EventLogWatcher.cs
+++ b/sdk/Pulumi.Automation/Events/EventLogWatcher.cs
@@ -94,10 +94,17 @@ namespace Pulumi.Automation.Events
 
             await using var fs = new FileStream(LogFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite) { Position = this._position };
             using var reader = new StreamReader(fs);
+            var partialLine = "";
             while (reader.Peek() >= 0)
             {
                 var line = await reader.ReadLineAsync().ConfigureAwait(false);
                 this._position = fs.Position;
+                if (!string.IsNullOrWhiteSpace(line) && !_localSerializer.IsValidJson(line))
+                {
+                    partialLine += line;
+                    continue;
+                }
+                line = partialLine + line;
                 if (!string.IsNullOrWhiteSpace(line) && _localSerializer.IsValidJson(line))
                 {
                     line = line.Trim();


### PR DESCRIPTION
This is the equivalent as https://github.com/pulumi/pulumi/pull/15778 for dotnet.  When tailing the event log we currently don't make sure that we read complete lines.  Lines can be flushed in the middle by the OS while they are being written down, leading to incomplete JSON.

The JSON encoder always ends each line with a newline, so we can stitch the lines back together even if we occasionally read a partly written line.