### PR TITLE
Add more FSharp Ops helpers

### DIFF
--- a/.changes/unreleased/Improvements-250.yaml
+++ b/.changes/unreleased/Improvements-250.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Add FSharp Ops helpers
+time: 2024-03-30T01:07:06.801787Z
+custom:
+  PR: "250"

--- a/sdk/Pulumi.FSharp/Library.fs
+++ b/sdk/Pulumi.FSharp/Library.fs
@@ -25,6 +25,11 @@ module Ops =
         result
     
     /// <summary>
+    /// Wraps a collection of raw items into an <see cref="InputList{'a}}" />.
+    /// <summary>
+    let toInputList<'a> (items: seq<'a>) = items |> Seq.map input |> inputList
+
+    /// <summary>
     /// Wraps a collection of key-value pairs into an <see cref="InputMap{'a}}" />.
     /// </summary>
     let inputMap<'a> (items: seq<string * Input<'a>>) =
@@ -43,6 +48,17 @@ module Ops =
     /// </summary>
     let inputUnion2Of2<'a, 'b> (valB: 'b) = InputUnion<'a, 'b>.op_Implicit(valB)
 
+    /// <summary>
+    /// Wraps a collection of first types into an InputList{Union{'a,'b}}
+    /// </summary>
+    let inputListFromT0<'a> (items: seq<'a>) =
+        items |> Seq.map Union.FromT0 |> toInputList
+
+    /// <summary>
+    /// Wraps a collection of second types into an InputList{Union{'a,'b}}
+    /// </summary>
+    let inputListFromT1<'a> (items: seq<'a>) =
+        items |> Seq.map Union.FromT1 |> toInputList
 
 /// <summary>
 /// Pulumi deployment functions.

--- a/sdk/Pulumi.FSharp/Library.fs
+++ b/sdk/Pulumi.FSharp/Library.fs
@@ -57,7 +57,7 @@ module Ops =
     /// <summary>
     /// Wraps a collection of second types into an InputList{Union{'a,'b}}
     /// </summary>
-    let inputListFromT1<'a> (items: seq<'a>) =
+    let inputListFromT1<'b> (items: seq<'b>) =
         items |> Seq.map Union.FromT1 |> toInputList
 
 /// <summary>


### PR DESCRIPTION
Since F# 6 improvements to implicit type conversions, it has been much more enjoyable to work with Pulumi.

Though I find there are still a few situations where it's not as easy as it could be, for me they were often properties with `InputList` type.

Adding these to the Ops module would make life easier.