### PR TITLE
Handle Outputs in derived Stacks

### DIFF
--- a/.changes/unreleased/Improvements-251.yaml
+++ b/.changes/unreleased/Improvements-251.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Handle Outputs in derived Stacks
+time: 2024-04-11T11:10:42.227518+02:00
+custom:
+  PR: "251"

--- a/sdk/Pulumi.Tests/StackTests.cs
+++ b/sdk/Pulumi.Tests/StackTests.cs
@@ -63,6 +63,27 @@ namespace Pulumi.Tests
             throw new XunitException("Should not come here");
         }
 
+        private class ValidDerivedStack : ValidStack
+        {
+            [Output("child")]
+            public Output<string> ChildProperty { get; set; }
+
+            public ValidDerivedStack()
+            {
+                this.ChildProperty = Output.Create("hello from derived stack");
+            }
+        }
+
+        [Fact]
+        public async Task ValidDerivedStackInstantiationSucceeds()
+        {
+            var (stack, outputs) = await Run<ValidDerivedStack>();
+            Assert.Equal(3, outputs.Count);
+            Assert.Same(stack.ExplicitName, outputs["foo"]);
+            Assert.Same(stack.ImplicitName, outputs["ImplicitName"]);
+            Assert.Same(stack.ChildProperty, outputs["child"]);
+        }
+
         private async Task<(T, IDictionary<string, object?>)> Run<T>() where T : Stack, new()
         {
             // Arrange

--- a/sdk/Pulumi/Stack.cs
+++ b/sdk/Pulumi/Stack.cs
@@ -79,9 +79,10 @@ namespace Pulumi
         /// </summary>
         internal void RegisterPropertyOutputs()
         {
-            var outputs = (from property in this.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            var outputs = (from property in this.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance)
                            let attr = property.GetCustomAttribute<OutputAttribute>()
                            where attr != null
+                           where property.DeclaringType?.IsAssignableFrom(typeof(Stack)) != true
                            let name = attr?.Name ?? property.Name
                            select new KeyValuePair<string, object?>(name, property.GetValue(this))).ToList();
 


### PR DESCRIPTION
I want to be able to write a base class for a stack, which will be reused for a few projects which have separate, but similar infrastructures. Currently, the Output properties defined on the base class are not being registered in the derived stacks because of the `BindingFlags.DeclaredOnly` flag used in the `Stack.RegisterPropertyOutputs` method.

In this PR I remove this flag. Instead, I explicitly cut off properties from ancestors of the `Stack` class (currently the `Resource` class has `Urn` output property and I believe this was the reason to add the `DeclaredOnly` flag in the first place).

Check the test I added to see exactly what I wanted to achieve.