### PR TITLE
allow unknown values during up for apply

### DIFF
--- a/.changes/unreleased/Improvements-258.yaml
+++ b/.changes/unreleased/Improvements-258.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Allow apply to have unknown values during updates
+time: 2024-04-16T17:12:57.998257367+02:00
+custom:
+  PR: "258"

--- a/sdk/Pulumi.Tests/Core/OutputTests.cs
+++ b/sdk/Pulumi.Tests/Core/OutputTests.cs
@@ -441,7 +441,6 @@ namespace Pulumi.Tests.Core
                     var o2 = o1.Apply(a => a + 1);
                     var data = await o2.DataTask.ConfigureAwait(false);
                     Assert.False(data.IsKnown);
-                    Assert.Equal(1, data.Value);
                 });
 
             [Fact]
@@ -452,7 +451,6 @@ namespace Pulumi.Tests.Core
                     var o2 = o1.Apply(a => Task.FromResult("inner"));
                     var data = await o2.DataTask.ConfigureAwait(false);
                     Assert.False(data.IsKnown);
-                    Assert.Equal("inner", data.Value);
                 });
 
             [Fact]
@@ -463,7 +461,6 @@ namespace Pulumi.Tests.Core
                     var o2 = o1.Apply(a => CreateOutput("inner", isKnown: true));
                     var data = await o2.DataTask.ConfigureAwait(false);
                     Assert.False(data.IsKnown);
-                    Assert.Equal("inner", data.Value);
                 });
 
             [Fact]
@@ -474,7 +471,6 @@ namespace Pulumi.Tests.Core
                     var o2 = o1.Apply(a => CreateOutput("inner", isKnown: false));
                     var data = await o2.DataTask.ConfigureAwait(false);
                     Assert.False(data.IsKnown);
-                    Assert.Equal("inner", data.Value);
                 });
 
             [Fact]
@@ -534,7 +530,6 @@ namespace Pulumi.Tests.Core
                     var data = await o2.DataTask.ConfigureAwait(false);
                     Assert.False(data.IsKnown);
                     Assert.True(data.IsSecret);
-                    Assert.Equal(1, data.Value);
                 });
 
             [Fact]
@@ -546,7 +541,6 @@ namespace Pulumi.Tests.Core
                     var data = await o2.DataTask.ConfigureAwait(false);
                     Assert.False(data.IsKnown);
                     Assert.True(data.IsSecret);
-                    Assert.Equal("inner", data.Value);
                 });
 
             [Fact]
@@ -558,7 +552,6 @@ namespace Pulumi.Tests.Core
                     var data = await o2.DataTask.ConfigureAwait(false);
                     Assert.False(data.IsKnown);
                     Assert.True(data.IsSecret);
-                    Assert.Equal("inner", data.Value);
                 });
 
             [Fact]
@@ -570,7 +563,6 @@ namespace Pulumi.Tests.Core
                     var data = await o2.DataTask.ConfigureAwait(false);
                     Assert.False(data.IsKnown);
                     Assert.True(data.IsSecret);
-                    Assert.Equal("inner", data.Value);
                 });
 
             [Fact]
@@ -598,37 +590,12 @@ namespace Pulumi.Tests.Core
                 });
 
             [Fact]
-            public Task ApplyPropagatesSecretOnUnknownKnownOutput()
-                => RunInNormal(async () =>
-                {
-                    var o1 = CreateOutput(0, isKnown: false);
-                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: true, isSecret: true));
-                    var data = await o2.DataTask.ConfigureAwait(false);
-                    Assert.False(data.IsKnown);
-                    Assert.True(data.IsSecret);
-                    Assert.Equal("inner", data.Value);
-                });
-
-            [Fact]
-            public Task ApplyPropagatesSecretOnUnknownUnknownOutput()
-                => RunInNormal(async () =>
-                {
-                    var o1 = CreateOutput(0, isKnown: false);
-                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: false, isSecret: true));
-                    var data = await o2.DataTask.ConfigureAwait(false);
-                    Assert.False(data.IsKnown);
-                    Assert.True(data.IsSecret);
-                    Assert.Equal("inner", data.Value);
-                });
-
-            [Fact]
             public Task CreateUnknownRunsValueFactory()
                 => RunInNormal(async () =>
                 {
                     var output = OutputUtilities.CreateUnknown(() => Task.FromResult("value"));
                     var data = await output.DataTask.ConfigureAwait(false);
                     Assert.False(data.IsKnown);
-                    Assert.Equal("value", data.Value);
                 });
 
             [Fact]

--- a/sdk/Pulumi/Core/Output.cs
+++ b/sdk/Pulumi/Core/Output.cs
@@ -528,9 +528,9 @@ namespace Pulumi
         {
             var data = await dataTask.ConfigureAwait(false);
             var resources = data.Resources;
-            // During previews only perform the apply if the engine was able to
+            // Only perform the apply if the engine was able to
             // give us an actual value for this Output.
-            if (!data.IsKnown && Deployment.Instance.IsDryRun)
+            if (!data.IsKnown)
             {
                 return new OutputData<U>(resources, default!, isKnown: false, data.IsSecret);
             }


### PR DESCRIPTION
Similar to the changes we recently made for the Go, Node and Python SDKs, Dotnet should also support unknowns during `pulumi up`. Implement that.