### PR TITLE
Make dotnet SDK support result reporting

### DIFF
--- a/.changes/unreleased/Improvements-259.yaml
+++ b/.changes/unreleased/Improvements-259.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Support the SkipReason field for better support of up --continue-on-error
+time: 2024-04-16T18:16:07.237477918+02:00
+custom:
+  PR: "259"

--- a/.changes/unreleased/Improvements-259.yaml
+++ b/.changes/unreleased/Improvements-259.yaml
@@ -1,6 +1,6 @@
 component: sdk
 kind: Improvements
-body: Support the SkipReason field for better support of up --continue-on-error
+body: Support the Result field for better support of up --continue-on-error
 time: 2024-04-16T18:16:07.237477918+02:00
 custom:
   PR: "259"

--- a/proto/pulumi/callback.proto
+++ b/proto/pulumi/callback.proto
@@ -14,8 +14,6 @@
 
 syntax = "proto3";
 
-import "google/protobuf/struct.proto";
-
 package pulumirpc;
 
 option go_package = "github.com/pulumi/pulumi/sdk/v3/proto/go;pulumirpc";

--- a/proto/pulumi/codegen/loader.proto
+++ b/proto/pulumi/codegen/loader.proto
@@ -14,9 +14,6 @@
 
 syntax = "proto3";
 
-import "google/protobuf/empty.proto";
-import "google/protobuf/struct.proto";
-
 package codegen;
 
 option go_package = "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen";

--- a/proto/pulumi/codegen/mapper.proto
+++ b/proto/pulumi/codegen/mapper.proto
@@ -14,9 +14,6 @@
 
 syntax = "proto3";
 
-import "google/protobuf/empty.proto";
-import "google/protobuf/struct.proto";
-
 package codegen;
 
 option go_package = "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen";

--- a/proto/pulumi/converter.proto
+++ b/proto/pulumi/converter.proto
@@ -15,9 +15,6 @@
 syntax = "proto3";
 
 import "pulumi/codegen/hcl.proto";
-import "pulumi/plugin.proto";
-import "google/protobuf/empty.proto";
-import "google/protobuf/struct.proto";
 
 package pulumirpc;
 

--- a/proto/pulumi/language.proto
+++ b/proto/pulumi/language.proto
@@ -210,6 +210,9 @@ message GeneratePackageRequest {
     map<string, bytes> extra_files = 3;
     // The target of a codegen.LoaderServer to use for loading schemas.
     string loader_target = 4;
+    // local dependencies to use instead of using the package system. This is a map of package name to a local
+    // path of a language specific artifact to use for the SDK for that package.
+    map<string, string> local_dependencies = 5;
 }
 
 message GeneratePackageResponse {
@@ -220,10 +223,8 @@ message GeneratePackageResponse {
 message PackRequest {
     // the directory of a package to pack.
     string package_directory = 1;
-    // the version to tag the artifact with.
-    string version = 2;
     // the directory to write the packed artifact to.
-    string destination_directory = 3;
+    string destination_directory = 2;
 }
 
 message PackResponse {

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -17,7 +17,6 @@ syntax = "proto3";
 import "pulumi/plugin.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
-import "pulumi/source.proto";
 
 package pulumirpc;
 

--- a/proto/pulumi/resource.proto
+++ b/proto/pulumi/resource.proto
@@ -139,6 +139,13 @@ message RegisterResourceRequest {
     SourcePosition sourcePosition = 29;    // the optional source position of the user code that initiated the register.
 
     repeated Callback transforms = 31; // a list of transforms to apply to the resource before registering it.
+    bool supportsResultReporting = 32; // true if the request is from an SDK that supports the result field in the response.
+}
+
+enum Result {
+	SUCCESS = 0;
+	FAIL = 1;
+	SKIP = 2;
 }
 
 // RegisterResourceResponse is returned by the engine after a resource has finished being initialized.  It includes the
@@ -155,6 +162,7 @@ message RegisterResourceResponse {
     bool stable = 4;                                            // if true, the object's state is stable and may be trusted not to change.
     repeated string stables = 5;                                // an optional list of guaranteed-stable properties.
     map<string, PropertyDependencies> propertyDependencies = 6; // a map from property keys to the dependencies of the property.
+    Result result = 7;                                          // the reason, whether the resource registration was successful, failed, or skipped.
 }
 
 // RegisterResourceOutputsRequest adds extra resource outputs created by the program after registration has occurred.

--- a/proto/pulumi/testing/language.proto
+++ b/proto/pulumi/testing/language.proto
@@ -14,8 +14,6 @@
 
 syntax = "proto3";
 
-import "google/protobuf/empty.proto";
-
 package pulumirpc.testing;
 
 option go_package = "github.com/pulumi/pulumi/sdk/v3/proto/go/testing";
@@ -43,11 +41,19 @@ message GetLanguageTestsResponse {
 }
 
 message PrepareLanguageTestsRequest {
+    message Replacement {
+        string path = 1;
+        string pattern = 2;
+        string replacement = 3;
+    }
+
     string language_plugin_name = 1;
     string language_plugin_target = 2;
     string snapshot_directory = 3;
     string temporary_directory = 4;
     string core_sdk_directory = 5;
+    string core_sdk_version = 6;
+    repeated Replacement snapshot_edits = 7;
 }
 
 message PrepareLanguageTestsResponse {

--- a/sdk/Pulumi/Deployment/Deployment_ReadOrRegisterResource.cs
+++ b/sdk/Pulumi/Deployment/Deployment_ReadOrRegisterResource.cs
@@ -27,7 +27,7 @@ namespace Pulumi
                 CompleteResourceAsync(resource, remote, newDependency, args, options, resource.CompletionSources));
         }
 
-        private async Task<(string urn, string id, Struct data, ImmutableDictionary<string, ImmutableHashSet<Resource>> dependencies)> ReadOrRegisterResourceAsync(
+        private async Task<(string urn, string id, Struct data, ImmutableDictionary<string, ImmutableHashSet<Resource>> dependencies, Pulumirpc.Result result)> ReadOrRegisterResourceAsync(
             Resource resource, bool remote, Func<string, Resource> newDependency, ResourceArgs args,
             ResourceOptions options)
         {
@@ -43,7 +43,7 @@ namespace Pulumi
                 var urn = result.Fields["urn"].StringValue;
                 var id = result.Fields["id"].StringValue;
                 var state = result.Fields["state"].StructValue;
-                return (urn, id, state, ImmutableDictionary<string, ImmutableHashSet<Resource>>.Empty);
+                return (urn, id, state, ImmutableDictionary<string, ImmutableHashSet<Resource>>.Empty, Pulumirpc.Result.Success);
             }
 
             if (options.Id != null)
@@ -118,7 +118,8 @@ namespace Pulumi
                     }
                 }
 
-                if (response.SkipReason > 0) {
+                if (response.result != Pulumirpc.Result.Success)
+                {
                     keepUnknowns = true;
                 }
             }

--- a/sdk/Pulumi/Deployment/Deployment_ReadResource.cs
+++ b/sdk/Pulumi/Deployment/Deployment_ReadResource.cs
@@ -9,7 +9,7 @@ namespace Pulumi
 {
     public partial class Deployment
     {
-        private async Task<(string urn, string id, Struct data, ImmutableDictionary<string, ImmutableHashSet<Resource>> dependencies)> ReadResourceAsync(
+        private async Task<(string urn, string id, Struct data, ImmutableDictionary<string, ImmutableHashSet<Resource>> dependencies, Pulumirpc.Result result)> ReadResourceAsync(
             Resource resource, string id, ResourceArgs args, ResourceOptions options)
         {
             var name = resource.GetResourceName();
@@ -42,7 +42,7 @@ namespace Pulumi
             // Now run the operation, serializing the invocation if necessary.
             var response = await this.Monitor.ReadResourceAsync(resource, request).ConfigureAwait(false);
 
-            return (response.Urn, id, response.Properties, ImmutableDictionary<string, ImmutableHashSet<Resource>>.Empty);
+            return (response.Urn, id, response.Properties, ImmutableDictionary<string, ImmutableHashSet<Resource>>.Empty, Pulumirpc.Result.Success);
         }
     }
 }

--- a/sdk/Pulumi/Deployment/Deployment_RegisterResource.cs
+++ b/sdk/Pulumi/Deployment/Deployment_RegisterResource.cs
@@ -108,6 +108,7 @@ namespace Pulumi
                 Remote = remote,
                 RetainOnDelete = options.RetainOnDelete ?? false,
                 DeletedWith = deletedWith,
+                SupportsSkipReason = true,
             };
 
             if (customOpts != null)

--- a/sdk/Pulumi/Deployment/Deployment_RegisterResource.cs
+++ b/sdk/Pulumi/Deployment/Deployment_RegisterResource.cs
@@ -11,7 +11,7 @@ namespace Pulumi
 {
     public partial class Deployment
     {
-        private async Task<(string urn, string id, Struct data, ImmutableDictionary<string, ImmutableHashSet<Resource>> dependencies)> RegisterResourceAsync(
+        private async Task<(string urn, string id, Struct data, ImmutableDictionary<string, ImmutableHashSet<Resource>> dependencies, Pulumirpc.Result result)> RegisterResourceAsync(
             Resource resource, bool remote, Func<string, Resource> newDependency, ResourceArgs args,
             ResourceOptions options)
         {
@@ -50,7 +50,7 @@ namespace Pulumi
                 dependencies[key] = urns.ToImmutable();
             }
 
-            return (result.Urn, result.Id, result.Object, dependencies.ToImmutable());
+            return (result.Urn, result.Id, result.Object, dependencies.ToImmutable(), result.Result);
         }
 
         private static void PopulateRequest(RegisterResourceRequest request, PrepareResult prepareResult)
@@ -108,7 +108,7 @@ namespace Pulumi
                 Remote = remote,
                 RetainOnDelete = options.RetainOnDelete ?? false,
                 DeletedWith = deletedWith,
-                SupportsSkipReason = true,
+                SupportsResultReporting = true,
             };
 
             if (customOpts != null)


### PR DESCRIPTION
Similar to what we're doing to the other SDKs in https://github.com/pulumi/pulumi/pull/15740, this enables dealing with the Result field in the RegisterResource response.


