### PR TITLE
Pin Google.Protobuf to 3.24

### DIFF
--- a/.changes/unreleased/Bug Fixes-263.yaml
+++ b/.changes/unreleased/Bug Fixes-263.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Bug Fixes
+body: Pin Google.Protobuf to 3.24.
+time: 2024-04-22T09:05:21.830015+01:00
+custom:
+  PR: "263"

--- a/sdk/Pulumi/Pulumi.csproj
+++ b/sdk/Pulumi/Pulumi.csproj
@@ -29,6 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.24.0" />
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Include="Grpc.Net.Client" Version="2.51.0" />
     <PackageReference Include="Grpc.AspNetCore.Server" Version="2.51.0" />


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-dotnet/issues/249.

We should get conformance tests up and running to confirm large request/responses to and from the engine work ok. For now we can just pin as the old version seemed to work.hw