### PR TITLE
add ContinueOnError to Automation API

### DIFF
--- a/.changes/unreleased/Improvements-265.yaml
+++ b/.changes/unreleased/Improvements-265.yaml
@@ -1,0 +1,6 @@
+component: sdk/auto
+kind: Improvements
+body: Add ContinueOnError option to the automation API
+time: 2024-04-23T15:37:51.574775387+02:00
+custom:
+  PR: "265"

--- a/sdk/Pulumi.Automation/DestroyOptions.cs
+++ b/sdk/Pulumi.Automation/DestroyOptions.cs
@@ -14,9 +14,9 @@ namespace Pulumi.Automation
         /// </summary>
         public bool? ShowSecrets { get; set; }
 
-	/// <summary>
-	/// Continue to perform the destroy operation despite the occurrence of errors.
-	/// </summary>
-	public bool? ContinueOnError { get; set; }
+        /// <summary>
+        /// Continue to perform the destroy operation despite the occurrence of errors.
+        /// </summary>
+        public bool? ContinueOnError { get; set; }
     }
 }

--- a/sdk/Pulumi.Automation/DestroyOptions.cs
+++ b/sdk/Pulumi.Automation/DestroyOptions.cs
@@ -13,5 +13,10 @@ namespace Pulumi.Automation
         /// Show config secrets when they appear.
         /// </summary>
         public bool? ShowSecrets { get; set; }
+
+	/// <summary>
+	/// Continue to perform the destroy operation despite the occurrence of errors.
+	/// </summary>
+	public bool? ContinueOnError { get; set; }
     }
 }

--- a/sdk/Pulumi.Automation/UpOptions.cs
+++ b/sdk/Pulumi.Automation/UpOptions.cs
@@ -35,5 +35,10 @@ namespace Pulumi.Automation
         /// if <see cref="Program"/> is also provided.
         /// </summary>
         public ILogger? Logger { get; set; }
+
+	/// <summary>
+	/// Continue to perform the update operation despite the occurrence of errors.
+	/// </summary>
+	public bool? ContinueOnError { get; set; }
     }
 }

--- a/sdk/Pulumi.Automation/UpOptions.cs
+++ b/sdk/Pulumi.Automation/UpOptions.cs
@@ -36,9 +36,9 @@ namespace Pulumi.Automation
         /// </summary>
         public ILogger? Logger { get; set; }
 
-	/// <summary>
-	/// Continue to perform the update operation despite the occurrence of errors.
-	/// </summary>
-	public bool? ContinueOnError { get; set; }
+        /// <summary>
+        /// Continue to perform the update operation despite the occurrence of errors.
+        /// </summary>
+        public bool? ContinueOnError { get; set; }
     }
 }

--- a/sdk/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/Pulumi.Automation/WorkspaceStack.cs
@@ -348,6 +348,9 @@ namespace Pulumi.Automation
                 if (options.TargetDependents is true)
                     args.Add("--target-dependents");
 
+		if (options.ContinueOnError is true)
+		    args.Add("--continue-on-error");
+
                 ApplyUpdateOptions(options, args);
             }
 
@@ -611,6 +614,9 @@ namespace Pulumi.Automation
             {
                 if (options.TargetDependents is true)
                     args.Add("--target-dependents");
+
+		if (options.ContinueOnError is true)
+		    args.Add("--continue-on-error");
 
                 ApplyUpdateOptions(options, args);
             }

--- a/sdk/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/Pulumi.Automation/WorkspaceStack.cs
@@ -348,8 +348,8 @@ namespace Pulumi.Automation
                 if (options.TargetDependents is true)
                     args.Add("--target-dependents");
 
-		if (options.ContinueOnError is true)
-		    args.Add("--continue-on-error");
+                if (options.ContinueOnError is true)
+                    args.Add("--continue-on-error");
 
                 ApplyUpdateOptions(options, args);
             }
@@ -615,8 +615,8 @@ namespace Pulumi.Automation
                 if (options.TargetDependents is true)
                     args.Add("--target-dependents");
 
-		if (options.ContinueOnError is true)
-		    args.Add("--continue-on-error");
+                if (options.ContinueOnError is true)
+                    args.Add("--continue-on-error");
 
                 ApplyUpdateOptions(options, args);
             }


### PR DESCRIPTION
Similar to what we did for Go, Python and NodeJS, add ContinueOnError to the dotnet automation api.