### PR TITLE
Revert "Update Grpc dependencies (#219)"

### DIFF
--- a/.changes/unreleased/Bug Fixes-266.yaml
+++ b/.changes/unreleased/Bug Fixes-266.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Bug Fixes
+body: Revert gRPC update that broke large messages.
+time: 2024-04-24T12:22:47.510223+01:00
+custom:
+  PR: "266"

--- a/sdk/Pulumi.Automation/Pulumi.Automation.csproj
+++ b/sdk/Pulumi.Automation/Pulumi.Automation.csproj
@@ -41,6 +41,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="CliWrap" Version="3.3.2" />
+    <PackageReference Include="Grpc.AspNetCore.Server" version="2.37.0" />
     <PackageReference Include="YamlDotNet" Version="11.1.1" />
   </ItemGroup>
 

--- a/sdk/Pulumi/Pulumi.csproj
+++ b/sdk/Pulumi/Pulumi.csproj
@@ -31,10 +31,10 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.24.0" />
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.51.0" />
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.51.0" />
-    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.51.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.51.0">
+    <PackageReference Include="Grpc.Net.Client" Version="2.52.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.37.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.37.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.44.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This reverts commit d87f6a0f9d4780ed27bea8f97a7bff6a73a27914.

Fixes https://github.com/pulumi/pulumi-dotnet/issues/249.