### PR TITLE
release pulumi dotnet 3.64.0

### DIFF
--- a/.changes/unreleased/Bug Fixes-279.yaml
+++ b/.changes/unreleased/Bug Fixes-279.yaml
@@ -1,6 +1,0 @@
-component: runtime
-kind: Bug Fixes
-body: Upgrade dependencies
-time: 2024-06-07T16:16:40.907419-07:00
-custom:
-    PR: "279"

--- a/.changes/unreleased/Improvements-270.yaml
+++ b/.changes/unreleased/Improvements-270.yaml
@@ -1,6 +1,0 @@
-component: sdk
-kind: Improvements
-body: Make transforms a stable feature, not experimental
-time: 2024-04-29T09:32:15.862863+01:00
-custom:
-  PR: "270"

--- a/.changes/unreleased/Improvements-277.yaml
+++ b/.changes/unreleased/Improvements-277.yaml
@@ -1,6 +1,0 @@
-component: sdk/provider
-kind: Improvements
-body: Refactor Provider tests in order to prepare integration testing
-time: 2024-06-07T12:20:39.7748217+02:00
-custom:
-    PR: "277"

--- a/.changes/v3.64.0.md
+++ b/.changes/v3.64.0.md
@@ -1,0 +1,12 @@
+## v3.64.0 - 2024-06-10
+
+### Improvements
+
+- [sdk] Make transforms a stable feature, not experimental [#270](https://github.com/pulumi/pulumi-dotnet/pull/270)
+
+- [sdk/provider] Refactor Provider tests in order to prepare integration testing [#277](https://github.com/pulumi/pulumi-dotnet/pull/277)
+
+### Bug Fixes
+
+- [runtime] Upgrade dependencies [#279](https://github.com/pulumi/pulumi-dotnet/pull/279)
+


### PR DESCRIPTION
Merging this should kick off the merge workflow according to https://github.com/pulumi/pulumi-dotnet/blob/main/CONTRIBUTING.md#release