### PR TITLE
[automation] Implement Stack.ImportAsync() for batch importing resources into a stack

### DIFF
--- a/.changes/unreleased/Improvements-296.yaml
+++ b/.changes/unreleased/Improvements-296.yaml
@@ -1,0 +1,6 @@
+component: sdk/auto
+kind: Improvements
+body: Implement Stack.ImportAsync() for batch importing resources into a stack
+time: 2024-07-11T16:44:49.250502+02:00
+custom:
+    PR: "296"

--- a/sdk/Pulumi.Automation.Tests/Data/import/Pulumi.yaml
+++ b/sdk/Pulumi.Automation.Tests/Data/import/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: import
+runtime: yaml

--- a/sdk/Pulumi.Automation.Tests/Data/import/expected_generated_code.yaml
+++ b/sdk/Pulumi.Automation.Tests/Data/import/expected_generated_code.yaml
@@ -1,0 +1,10 @@
+resources:
+  randomPassword:
+    type: random:RandomPassword
+    properties:
+      length: 11
+      lower: true
+      number: true
+      numeric: true
+      special: true
+      upper: true

--- a/sdk/Pulumi.Automation/ImportOptions.cs
+++ b/sdk/Pulumi.Automation/ImportOptions.cs
@@ -1,0 +1,47 @@
+namespace Pulumi.Automation;
+
+using System;
+using System.Collections.Generic;
+
+public sealed class ImportOptions
+{
+    /// <summary>
+    /// The resource definitions to import into the stack.
+    /// </summary>
+    public List<ImportResource>? Resources { get; set; }
+    /// <summary>
+    /// The name table maps language names to parent and provider URNs. These names are
+    /// used in the generated definitions, and should match the corresponding declarations
+    /// in the source program. This table is required if any parents or providers are
+    /// specified by the resources to import.
+    /// </summary>
+    public Dictionary<string, string>? NameTable { get; set; }
+    /// <summary>
+    /// Allow resources to be imported with protection from deletion enabled. Set to true by default.
+    /// </summary>
+    public bool? Protect { get; set; }
+    /// <summary>
+    /// Generate resource declaration code for the imported resources. Set to true by default.
+    /// </summary>
+    public bool? GenerateCode { get; set; }
+    /// <summary>
+    /// Specify the name of a converter to import resources from.
+    /// </summary>
+    public string? Converter { get; set; }
+    /// <summary>
+    /// Additional arguments to pass to the converter, if the user specified one.
+    /// </summary>
+    public List<string>? ConverterArgs { get; set; }
+    /// <summary>
+    /// Show config secrets when they appear.
+    /// </summary>
+    public bool? ShowSecrets { get; set; }
+    /// <summary>
+    /// Optional callback which is invoked whenever StandardOutput is written into
+    /// </summary>
+    public Action<string>? OnStandardOutput { get; set; }
+    /// <summary>
+    /// Optional callback which is invoked whenever StandardError is written into
+    /// </summary>
+    public Action<string>? OnStandardError { get; set; }
+}

--- a/sdk/Pulumi.Automation/ImportResource.cs
+++ b/sdk/Pulumi.Automation/ImportResource.cs
@@ -1,0 +1,33 @@
+namespace Pulumi.Automation;
+
+using System.Collections.Generic;
+
+public class ImportResource
+{
+    /// <summary>
+    /// The name of the resource to import
+    /// </summary>
+    public string? Name { get; init; }
+    /// <summary>
+    /// The type of the resource to import
+    /// </summary>
+    public string? Type { get; init; }
+    /// <summary>
+    /// The ID of the resource to import. The format of the ID is specific to the resource type
+    /// </summary>
+    public string? Id { get; init; }
+
+    public string? Parent { get; init; }
+
+    public string? Provider { get; init; }
+
+    public string? Version { get; init; }
+
+    public string? LogicalName { get; init; }
+
+    public List<string>? Properties { get; init; }
+
+    public bool? Component { get; init; }
+
+    public bool? Remote { get; init; }
+}

--- a/sdk/Pulumi.Automation/ImportResult.cs
+++ b/sdk/Pulumi.Automation/ImportResult.cs
@@ -1,0 +1,21 @@
+namespace Pulumi.Automation;
+
+public sealed class ImportResult
+{
+    public string StandardOutput { get; init; }
+    public string StandardError { get; init; }
+    public string? GeneratedCode { get; set; }
+    public UpdateSummary Summary { get; init; }
+
+    public ImportResult(
+        string standardOutput,
+        string standardError,
+        UpdateSummary summary,
+        string? generatedCode = null)
+    {
+        StandardOutput = standardOutput;
+        StandardError = standardError;
+        GeneratedCode = generatedCode;
+        Summary = summary;
+    }
+}

--- a/sdk/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/Pulumi.Automation/Pulumi.Automation.xml
@@ -365,6 +365,69 @@
             Show config secrets when they appear.
             </summary>
         </member>
+        <member name="P:Pulumi.Automation.ImportOptions.Resources">
+            <summary>
+            The resource definitions to import into the stack.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.ImportOptions.NameTable">
+            <summary>
+            The name table maps language names to parent and provider URNs. These names are
+            used in the generated definitions, and should match the corresponding declarations
+            in the source program. This table is required if any parents or providers are
+            specified by the resources to import.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.ImportOptions.Protect">
+            <summary>
+            Allow resources to be imported with protection from deletion enabled. Set to true by default.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.ImportOptions.GenerateCode">
+            <summary>
+            Generate resource declaration code for the imported resources. Set to true by default.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.ImportOptions.Converter">
+            <summary>
+            Specify the name of a converter to import resources from.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.ImportOptions.ConverterArgs">
+            <summary>
+            Additional arguments to pass to the converter, if the user specified one.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.ImportOptions.ShowSecrets">
+            <summary>
+            Show config secrets when they appear.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.ImportOptions.OnStandardOutput">
+            <summary>
+            Optional callback which is invoked whenever StandardOutput is written into
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.ImportOptions.OnStandardError">
+            <summary>
+            Optional callback which is invoked whenever StandardError is written into
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.ImportResource.Name">
+            <summary>
+            The name of the resource to import
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.ImportResource.Type">
+            <summary>
+            The type of the resource to import
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.ImportResource.Id">
+            <summary>
+            The ID of the resource to import. The format of the ID is specific to the resource type
+            </summary>
+        </member>
         <member name="T:Pulumi.Automation.LocalProgramArgs">
             <summary>
             Description of a stack backed by pre-existing local Pulumi CLI program.
@@ -385,7 +448,7 @@
             This is identical to the behavior of Pulumi CLI driven workspaces.
             <para/>
             If not provided a working directory - causing LocalWorkspace to create a temp directory,
-            than the temp directory will be cleaned up on <see cref="M:Pulumi.Automation.LocalWorkspace.Dispose"/>.
+            than the temp directory will be cleaned up on <see cref="M:Pulumi.Automation.LocalWorkspace.Dispose(System.Boolean)"/>.
             </summary>
         </member>
         <member name="P:Pulumi.Automation.LocalWorkspace.WorkDir">
@@ -1987,6 +2050,14 @@
             </summary>
             <param name="options">Options to customize the behavior of the destroy.</param>
             <param name="cancellationToken">A cancellation token.</param>
+        </member>
+        <member name="M:Pulumi.Automation.WorkspaceStack.ImportAsync(Pulumi.Automation.ImportOptions,System.Threading.CancellationToken)">
+            <summary>
+            Import resources into a stack.
+            </summary>
+            <param name="options">Import options to customize the behaviour of the import operation</param>
+            <param name="cancellationToken">A cancellation token.</param>
+            <returns>The output of the import command, including the generated code, if any.</returns>
         </member>
         <member name="M:Pulumi.Automation.WorkspaceStack.GetOutputsAsync(System.Threading.CancellationToken)">
             <summary>

--- a/sdk/Pulumi.Automation/Serialization/LocalSerializer.cs
+++ b/sdk/Pulumi.Automation/Serialization/LocalSerializer.cs
@@ -67,6 +67,7 @@ namespace Pulumi.Automation.Serialization
 
             options.Converters.Add(new StringToEnumJsonConverter<OperationType, OperationTypeConverter>());
             options.Converters.Add(new StringToEnumJsonConverter<DiffKind, DiffKindConverter>());
+            options.Converters.Add(new StringToEnumJsonConverter<UpdateKind, UpdateKindConverter>());
             options.Converters.Add(new JsonStringEnumConverter(new LowercaseJsonNamingPolicy()));
             options.Converters.Add(new SystemObjectJsonConverter());
             options.Converters.Add(new MapToModelJsonConverter<ConfigValue, ConfigValueModel>());

--- a/sdk/Pulumi.Automation/Serialization/UpdateKindConverter.cs
+++ b/sdk/Pulumi.Automation/Serialization/UpdateKindConverter.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Pulumi.Automation.Serialization;
+
+public class UpdateKindConverter : IStringToEnumConverter<UpdateKind>
+{
+    public UpdateKind Convert(string input) => input switch
+    {
+        "update" => UpdateKind.Update,
+        "preview" => UpdateKind.Preview,
+        "refresh" => UpdateKind.Refresh,
+        "rename" => UpdateKind.Rename,
+        "destroy" => UpdateKind.Destroy,
+        "import" => UpdateKind.Import,
+        "resource-import" => UpdateKind.ResourceImport,
+        _ => throw new InvalidOperationException($"'{input}' is not a valid {typeof(UpdateKind).FullName}"),
+    };
+}

--- a/sdk/Pulumi.Automation/UpdateKind.cs
+++ b/sdk/Pulumi.Automation/UpdateKind.cs
@@ -10,5 +10,6 @@ namespace Pulumi.Automation
         Rename,
         Destroy,
         Import,
+        ResourceImport,
     }
 }

--- a/sdk/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/Pulumi.Automation/WorkspaceStack.cs
@@ -5,10 +5,12 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Runtime.ExceptionServices;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -634,6 +636,105 @@ namespace Pulumi.Automation
                 result.StandardOutput,
                 result.StandardError,
                 summary!);
+        }
+
+        /// <summary>
+        /// Import resources into a stack.
+        /// </summary>
+        /// <param name="options">Import options to customize the behaviour of the import operation</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>The output of the import command, including the generated code, if any.</returns>
+        public async Task<ImportResult> ImportAsync(
+            ImportOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            var args = new List<string>
+            {
+                "import",
+                "--yes",
+                "--skip-preview",
+            };
+
+            var tempDirectoryPath = "";
+            try
+            {
+                // for import operations, generate a temporary directory to store the following:
+                //   - the import file when the user specifies resources to import
+                //   - the output file for the generated code
+                // we use the import file as input to the import command
+                // we the output file to read the generated code and return it to the user
+                tempDirectoryPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+                if (options.Resources?.Any() == true)
+                {
+                    Directory.CreateDirectory(tempDirectoryPath);
+                    var importPath = Path.Combine(tempDirectoryPath, "import.json");
+                    var importContent = new
+                    {
+                        nameTable = options.NameTable,
+                        resources = options.Resources,
+                    };
+
+                    var importJson = JsonSerializer.Serialize(importContent, new JsonSerializerOptions
+                    {
+                        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                    });
+
+                    await File.WriteAllTextAsync(importPath, importJson, cancellationToken);
+                    args.Add("--file");
+                    args.Add(importPath);
+                }
+
+                if (options.Protect is false)
+                {
+                    args.Add("--protect=false");
+                }
+
+                var generatedCodeOutputPath = Path.Combine(tempDirectoryPath, "generated.cs");
+                if (options.GenerateCode is false)
+                {
+                    args.Add("--generate-code=false");
+                }
+                else
+                {
+                    args.Add("--out");
+                    args.Add(generatedCodeOutputPath);
+                }
+
+                if (options.Converter != null)
+                {
+                    // if the user specifies a converter, pass it to `--from <converter>` argument of import.
+                    args.Add("--from");
+                    args.Add(options.Converter);
+                    if (options.ConverterArgs?.Any() == true)
+                    {
+                        // pass any additional arguments to the converter
+                        args.AddRange(options.ConverterArgs);
+                    }
+                }
+
+                var result = await this.RunCommandAsync(args, options.OnStandardOutput, options.OnStandardError, null, cancellationToken).ConfigureAwait(false);
+                var summary = await this.GetInfoAsync(cancellationToken, options.ShowSecrets).ConfigureAwait(false);
+                var generatedCode =
+                    options.GenerateCode is not false
+                        ? await File.ReadAllTextAsync(generatedCodeOutputPath, cancellationToken).ConfigureAwait(false)
+                        : "";
+
+                return new ImportResult(
+                    standardOutput: result.StandardOutput,
+                    standardError: result.StandardError,
+                    summary: summary!,
+                    generatedCode: generatedCode);
+            }
+            finally
+            {
+                if (tempDirectoryPath != "")
+                {
+                    // clean up the temporary directory we used for the import operation
+                    Directory.Delete(tempDirectoryPath, recursive: true);
+                }
+            }
         }
 
         /// <summary>

--- a/sdk/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/Pulumi.Automation/WorkspaceStack.cs
@@ -710,6 +710,7 @@ namespace Pulumi.Automation
                     if (options.ConverterArgs?.Any() == true)
                     {
                         // pass any additional arguments to the converter
+                        args.Add("--");
                         args.AddRange(options.ConverterArgs);
                     }
                 }


### PR DESCRIPTION
Addressing https://github.com/pulumi/pulumi/issues/8237

Following a similar pattern to how I implemented the NodeJS API https://github.com/pulumi/pulumi/pull/16615

This PR extends the automation API to allow batch importing resources into a stack. An example of how this looks like:
```cs
var result = await stack.ImportAsync(new()
{
    Protect = false,
    Resources = new()
    {
        new()
        {
            Type = "random:index/randomPassword:RandomPassword",
            Name = "randomPassword",
            Id = "supersecret"
        }
    }
});
```

Also implements an enum converter for `UpdateKind` since JSON deserialization was failing when encountering update kind `resource-import`, this is now fixed. 