### PR TITLE
Add support for deserializing output values

### DIFF
--- a/.changes/unreleased/Bug Fixes-298.yaml
+++ b/.changes/unreleased/Bug Fixes-298.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Bug Fixes
+body: Add support for deserializing output values and use them from transforms
+time: 2024-07-16T19:46:29.831748-07:00
+custom:
+    PR: "298"

--- a/integration_tests/transformations_remote/Program.cs
+++ b/integration_tests/transformations_remote/Program.cs
@@ -105,6 +105,46 @@ class TransformsStack : Stack
                 }
             }
         });
+
+        // Scenario #6 - make the length property a secret.
+        var res6 = new Random("res6", new RandomArgs { Length = 10 }, new CustomResourceOptions
+        {
+            ResourceTransforms =
+            {
+                async (args, _) =>
+                {
+                    if (args.Type == "testprovider:index:Random")
+                    {
+                        var resultArgs = args.Args;
+                        var length = (double)resultArgs["length"] * 2;
+                        resultArgs = resultArgs.SetItem("length", Output.CreateSecret(length));
+                        return new ResourceTransformResult(resultArgs, args.Options);
+                    }
+
+                    return null;
+                }
+            }
+        });
+
+        // Scenario #7 - Unsecret
+        var res7 = new Random("res7", new RandomArgs { Length = Output.CreateSecret(21) }, new CustomResourceOptions
+        {
+            ResourceTransforms =
+            {
+                async (args, _) =>
+                {
+                    if (args.Type == "testprovider:index:Random")
+                    {
+                        var resultArgs = args.Args;
+                        var length = ((Output<double>)resultArgs["length"]).Apply(v => v * 2);
+                        resultArgs = resultArgs.SetItem("length", Output.Unsecret(length));
+                        return new ResourceTransformResult(resultArgs, args.Options);
+                    }
+
+                    return null;
+                }
+            }
+        });
     }
 
     // Scenario #3 - apply a transformation to the Stack to transform all (future) resources in the stack

--- a/integration_tests/transformations_simple_test.go
+++ b/integration_tests/transformations_simple_test.go
@@ -107,6 +107,8 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 	foundRes3 := false
 	foundRes4Child := false
 	foundRes5 := false
+	foundRes6 := false
+	foundRes7 := false
 	for _, res := range stack.Deployment.Resources {
 		// "res1" has a transformation which adds additionalSecretOutputs
 		if res.URN.Name() == "res1" {
@@ -159,10 +161,31 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			assert.NotNil(t, length)
 			assert.Equal(t, 20.0, length.(float64))
 		}
+		// "res6" should have made the length a secret
+		if res.URN.Name() == "res6" {
+			foundRes6 = true
+			assert.Equal(t, res.Type, tokens.Type(randomResName))
+			length := res.Inputs["length"]
+			assert.NotNil(t, length)
+			// length should be secret
+			secret, ok := length.(map[string]interface{})
+			assert.True(t, ok, "length should be a secret")
+			assert.Equal(t, resource.SecretSig, secret[resource.SigKey])
+		}
+		// "res6" should have mutated the length and unsecreted it
+		if res.URN.Name() == "res7" {
+			foundRes7 = true
+			assert.Equal(t, res.Type, tokens.Type(randomResName))
+			length := res.Inputs["length"]
+			assert.NotNil(t, length)
+			assert.Equal(t, 42.0, length.(float64))
+		}
 	}
 	assert.True(t, foundRes1)
 	assert.True(t, foundRes2Child)
 	assert.True(t, foundRes3)
 	assert.True(t, foundRes4Child)
 	assert.True(t, foundRes5)
+	assert.True(t, foundRes6)
+	assert.True(t, foundRes7)
 }

--- a/sdk/Pulumi.Tests/Serialization/OutputValueTests.cs
+++ b/sdk/Pulumi.Tests/Serialization/OutputValueTests.cs
@@ -1,0 +1,256 @@
+// Copyright 2016-2024, Pulumi Corporation
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Google.Protobuf.WellKnownTypes;
+using Pulumi.Serialization;
+using Xunit;
+
+namespace Pulumi.Tests.Serialization
+{
+    public class OutputValueTests : ConverterTests
+    {
+        static Value CreateOutputValue(ImmutableHashSet<string> resources, Value? value = null, bool isSecret = false)
+        {
+            var result = new Value
+            {
+                StructValue = new Struct
+                {
+                    Fields =
+                    {
+                        { Constants.SpecialSigKey, new Value { StringValue = Constants.SpecialOutputValueSig } },
+                    }
+                }
+            };
+            if (value is not null)
+            {
+                result.StructValue.Fields.Add(Constants.ValueName, value);
+            }
+            if (isSecret)
+            {
+                result.StructValue.Fields.Add(Constants.SecretName, new Value { BoolValue = true });
+            }
+            if (resources.Count > 0)
+            {
+                var dependencies = new Value { ListValue = new ListValue() };
+                foreach (var resource in resources)
+                {
+                    dependencies.ListValue.Values.Add(new Value { StringValue = resource });
+                }
+                result.StructValue.Fields.Add(Constants.DependenciesName, dependencies);
+            }
+            return result;
+        }
+
+        [Fact]
+        public async Task TestUnknown()
+        {
+            var input = CreateOutputValue(ImmutableHashSet<string>.Empty);
+            var result = Deserializer.Deserialize(input);
+            var o = Assert.IsType<Output<object>>(result.Value);
+            var data = await o.DataTask.ConfigureAwait(false);
+            Assert.Null(data.Value);
+            Assert.False(data.IsKnown);
+            Assert.False(data.IsSecret);
+            Assert.Empty(data.Resources);
+        }
+
+        [Fact]
+        public async Task TestString()
+        {
+            var input = CreateOutputValue(ImmutableHashSet<string>.Empty, new Value { StringValue = "hello" });
+            var result = Deserializer.Deserialize(input);
+            var o = Assert.IsType<Output<string>>(result.Value);
+            var data = await o.DataTask.ConfigureAwait(false);
+            Assert.Equal("hello", data.Value);
+            Assert.True(data.IsKnown);
+            Assert.False(data.IsSecret);
+            Assert.Empty(data.Resources);
+        }
+
+        [Fact]
+        public async Task TestStringSecret()
+        {
+            var input = CreateOutputValue(
+                ImmutableHashSet<string>.Empty, new Value { StringValue = "hello" }, isSecret: true);
+            var result = Deserializer.Deserialize(input);
+            var o = Assert.IsType<Output<string>>(result.Value);
+            var data = await o.DataTask.ConfigureAwait(false);
+            Assert.Equal("hello", data.Value);
+            Assert.True(data.IsKnown);
+            Assert.True(data.IsSecret);
+            Assert.Empty(data.Resources);
+        }
+
+        [Fact]
+        public async Task TestStringDependencies()
+        {
+            var input = CreateOutputValue(
+                ImmutableHashSet<string>.Empty.Add("foo"), new Value { StringValue = "hello" });
+            var result = Deserializer.Deserialize(input);
+            var o = Assert.IsType<Output<string>>(result.Value);
+            var data = await o.DataTask.ConfigureAwait(false);
+            Assert.Equal("hello", data.Value);
+            Assert.True(data.IsKnown);
+            Assert.False(data.IsSecret);
+            var resources = ImmutableHashSet<string>.Empty;
+            foreach (var resource in data.Resources)
+            {
+                var urn = await resource.Urn.DataTask.ConfigureAwait(false);
+                resources = resources.Add(urn.Value);
+            }
+            Assert.Equal(ImmutableHashSet<string>.Empty.Add("foo"), resources);
+        }
+
+        [Fact]
+        public async Task TestList()
+        {
+            var input = CreateOutputValue(ImmutableHashSet<string>.Empty, new Value
+            {
+                ListValue = new ListValue
+                {
+                    Values =
+                    {
+                        new Value { StringValue = "hello" },
+                        new Value { StringValue = "world" },
+                    }
+                }
+            });
+            var result = Deserializer.Deserialize(input);
+            var o = Assert.IsType<Output<ImmutableArray<object>>>(result.Value);
+            var data = await o.DataTask.ConfigureAwait(false);
+            Assert.Equal(ImmutableArray<string>.Empty.Add("hello").Add("world"), data.Value);
+            Assert.True(data.IsKnown);
+            Assert.False(data.IsSecret);
+            Assert.Empty(data.Resources);
+        }
+
+        [Fact]
+        public async Task TestListNestedOutput()
+        {
+            var input = new Value
+            {
+                ListValue = new ListValue
+                {
+                    Values =
+                    {
+                        new Value { StringValue = "hello" },
+                        CreateOutputValue(ImmutableHashSet<string>.Empty, new Value { StringValue = "world" }),
+                    }
+                }
+            };
+
+            var result = Deserializer.Deserialize(input);
+            var v = Assert.IsType<ImmutableArray<object>>(result.Value);
+            Assert.Equal("hello", v[0]);
+            var o = Assert.IsType<Output<string>>(v[1]);
+            var data = await o.DataTask.ConfigureAwait(false);
+            Assert.Equal("world", data.Value);
+            Assert.True(data.IsKnown);
+            Assert.False(data.IsSecret);
+            Assert.Empty(data.Resources);
+        }
+
+        [Fact]
+        public async Task TestListNestedOutputUnknown()
+        {
+            var input = new Value
+            {
+                ListValue = new ListValue
+                {
+                    Values =
+                    {
+                        new Value { StringValue = "hello" },
+                        CreateOutputValue(ImmutableHashSet<string>.Empty),
+                    }
+                }
+            };
+
+            var result = Deserializer.Deserialize(input);
+            var v = Assert.IsType<ImmutableArray<object>>(result.Value);
+            Assert.Equal("hello", v[0]);
+            var o = Assert.IsType<Output<object?>>(v[1]);
+            var data = await o.DataTask.ConfigureAwait(false);
+            Assert.Null(data.Value);
+            Assert.False(data.IsKnown);
+            Assert.False(data.IsSecret);
+            Assert.Empty(data.Resources);
+        }
+
+        [Fact]
+        public async Task TestStruct()
+        {
+            var input = CreateOutputValue(ImmutableHashSet<string>.Empty, new Value
+            {
+                StructValue = new Struct
+                {
+                    Fields =
+                    {
+                        { "hello", new Value { StringValue = "world" } },
+                        { "foo", new Value { StringValue = "bar" } },
+                    }
+                }
+            });
+            var result = Deserializer.Deserialize(input);
+            var o = Assert.IsType<Output<ImmutableDictionary<string, object>>>(result.Value);
+            var data = await o.DataTask.ConfigureAwait(false);
+            var expected = ImmutableDictionary.Create<string, object>()
+                .Add("hello", "world")
+                .Add("foo", "bar");
+            Assert.Equal(expected, data.Value);
+            Assert.True(data.IsKnown);
+            Assert.False(data.IsSecret);
+            Assert.Empty(data.Resources);
+        }
+
+        [Fact]
+        public async Task TestStructNestedOutput()
+        {
+            var input = new Value
+            {
+                StructValue = new Struct
+                {
+                    Fields =
+                    {
+                        { "hello", new Value { StringValue = "world" } },
+                        { "foo", CreateOutputValue(ImmutableHashSet<string>.Empty, new Value { StringValue = "bar" }) },
+                    }
+                }
+            };
+            var result = Deserializer.Deserialize(input);
+            var v = Assert.IsType<ImmutableDictionary<string, object>>(result.Value);
+            Assert.Equal("world", v["hello"]);
+            var o = Assert.IsType<Output<string>>(v["foo"]);
+            var data = await o.DataTask.ConfigureAwait(false);
+            Assert.Equal("bar", data.Value);
+            Assert.True(data.IsKnown);
+            Assert.False(data.IsSecret);
+            Assert.Empty(data.Resources);
+        }
+
+        [Fact]
+        public async Task TestStructNestedOutputUnknown()
+        {
+            var input = new Value
+            {
+                StructValue = new Struct
+                {
+                    Fields =
+                    {
+                        { "hello", new Value { StringValue = "world" } },
+                        { "foo", CreateOutputValue(ImmutableHashSet<string>.Empty) },
+                    }
+                }
+            };
+            var result = Deserializer.Deserialize(input);
+            var v = Assert.IsType<ImmutableDictionary<string, object?>>(result.Value);
+            Assert.Equal("world", v["hello"]);
+            var o = Assert.IsType<Output<object?>>(v["foo"]);
+            var data = await o.DataTask.ConfigureAwait(false);
+            Assert.Null(data.Value);
+            Assert.False(data.IsKnown);
+            Assert.False(data.IsSecret);
+            Assert.Empty(data.Resources);
+        }
+    }
+}


### PR DESCRIPTION
This change adds support for deserializing output values and ensures they work for transforms. This is necessary as the engine will send output values to transforms, so we need to handle deserializing them before calling the transform and then properly serializing them when returning the results.

Fixes #297