### PR TITLE
check if the workspace is clean after building the SDKs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,6 +57,8 @@ jobs:
         run: dotnet run test-sdk coverage
       - name: Test Pulumi Automation SDK
         run: dotnet run test-automation-sdk coverage
+      - name: Workspace clean (are xml doc file updates committed?)
+        uses: pulumi/git-status-check-action@v1
       - name: Upload coverage data
         uses: codecov/codecov-action@v4
         with:
@@ -200,4 +202,3 @@ jobs:
         run: exit 1
       - name: CI succeeded
         run: exit 0
-


### PR DESCRIPTION
It's easy to forget to check in the xml doc files that are created during the build.  See for example https://github.com/pulumi/pulumi-dotnet/pull/299.

Add a CI check that checks if the workspace is clean, to make sure all the relevant files have been checked in.