### PR TITLE
fix: Add type annotations for proper inference

### DIFF
--- a/.changes/unreleased/Bug Fixes-301.yaml
+++ b/.changes/unreleased/Bug Fixes-301.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Bug Fixes
+body: Fix type annotations for inputListFromT0/1
+time: 2024-07-18T15:00:51.707811Z
+custom:
+    PR: "301"

--- a/sdk/Pulumi.FSharp/Library.fs
+++ b/sdk/Pulumi.FSharp/Library.fs
@@ -26,7 +26,7 @@ module Ops =
     
     /// <summary>
     /// Wraps a collection of raw items into an <see cref="InputList{'a}}" />.
-    /// <summary>
+    /// </summary>
     let toInputList<'a> (items: seq<'a>) = items |> Seq.map input |> inputList
 
     /// <summary>
@@ -51,13 +51,13 @@ module Ops =
     /// <summary>
     /// Wraps a collection of first types into an InputList{Union{'a,'b}}
     /// </summary>
-    let inputListFromT0<'a> (items: seq<'a>) =
+    let inputListFromT0<'a, 'b> (items: seq<'a>) : InputList<Union<'a, 'b>> =
         items |> Seq.map Union.FromT0 |> toInputList
 
     /// <summary>
     /// Wraps a collection of second types into an InputList{Union{'a,'b}}
     /// </summary>
-    let inputListFromT1<'b> (items: seq<'b>) =
+    let inputListFromT1<'a, 'b> (items: seq<'b>) : InputList<Union<'a, 'b>> =
         items |> Seq.map Union.FromT1 |> toInputList
 
 /// <summary>


### PR DESCRIPTION
Fixing my previous PR #250.

Without these annotations type inference incorrectly determines the other type as `<obj>`.