### PR TITLE
Fix race condition in GrpcMonitor's GrpcChannel management

### DIFF
--- a/.changes/unreleased/Bug Fixes-304.yaml
+++ b/.changes/unreleased/Bug Fixes-304.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Bug Fixes
+body: Fix race condition in GrpcMonitor's GrpcChannel management
+time: 2024-07-21T08:17:42.5134291+02:00
+custom:
+    PR: "304"


### PR DESCRIPTION
While creating integration tests I faced a race condition in GrpcMonitor when the channel retrieved from the static _monitorChannels was null although the key had already been set.
Replacing the complex implementation with custom locking by the standard pattern ConcurrentDictionary<K, Lazy<V>> has resolved this.