### PR TITLE
check for workspace clean after the build not after tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,12 +53,12 @@ jobs:
         uses: pulumi/actions@v5
       - name: Build Pulumi SDK
         run: dotnet run build-sdk
+      - name: Workspace clean (are xml doc file updates committed?)
+        uses: pulumi/git-status-check-action@v1
       - name: Test Pulumi SDK
         run: dotnet run test-sdk coverage
       - name: Test Pulumi Automation SDK
         run: dotnet run test-automation-sdk coverage
-      - name: Workspace clean (are xml doc file updates committed?)
-        uses: pulumi/git-status-check-action@v1
       - name: Upload coverage data
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
Our tests seem to pollute the workspace at least for community PRs. The intention of adding the workspace clean script was never to catch that, but rather just that all the generated files are committed correctly.

Move the check up to make sure to check just that.