### PR TITLE
Fix unknown inputs deserialization

### DIFF
--- a/.changes/unreleased/Bug Fixes-306.yaml
+++ b/.changes/unreleased/Bug Fixes-306.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Bug Fixes
+body: Fix unkown inputs deserialization
+time: 2024-07-24T14:53:11.4857503+02:00
+custom:
+    PR: "306"

--- a/.changes/unreleased/Bug Fixes-306.yaml
+++ b/.changes/unreleased/Bug Fixes-306.yaml
@@ -1,6 +1,6 @@
 component: sdk
 kind: Bug Fixes
-body: Fix unkown inputs deserialization
+body: Fix unknown inputs deserialization
 time: 2024-07-24T14:53:11.4857503+02:00
 custom:
     PR: "306"

--- a/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
+++ b/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
@@ -319,7 +319,6 @@ public class PropertyValueTests
     public async Task DeserializingWrappedUnknownOutputSecretWorks()
     {
         var serializer = CreateSerializer();
-        // secretOutput = Secret(Output(Unknown))
         var secretOutput = new PropertyValue(
             new PropertyValue(new OutputReference(
                 value:  PropertyValue.Computed,
@@ -356,7 +355,6 @@ public class PropertyValueTests
     public async Task DeserializingWrappedUnknownSecretInOutputWorks()
     {
         var serializer = CreateSerializer();
-        // secretOutput = Output(Secret(Unknown))
         var secretOutput = new PropertyValue(
             new OutputReference(
                 value: new PropertyValue(PropertyValue.Computed),

--- a/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
+++ b/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
@@ -321,7 +321,7 @@ public class PropertyValueTests
         var serializer = CreateSerializer();
         var secretOutput = new PropertyValue(
             new PropertyValue(new OutputReference(
-                value:  PropertyValue.Computed,
+                value: PropertyValue.Computed,
                 dependencies: ImmutableArray<Urn>.Empty)));
 
         var deserialized = await serializer.Deserialize<Input<string>>(secretOutput);

--- a/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
+++ b/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
@@ -359,7 +359,7 @@ public class PropertyValueTests
         // secretOutput = Output(Secret(Unknown))
         var secretOutput = new PropertyValue(
             new OutputReference(
-                value: new PropertyValue( PropertyValue.Computed),
+                value: new PropertyValue(PropertyValue.Computed),
                 dependencies: ImmutableArray<Urn>.Empty));
 
         var deserialized = await serializer.Deserialize<Input<string>>(secretOutput);

--- a/sdk/Pulumi/Provider/PropertyValue.cs
+++ b/sdk/Pulumi/Provider/PropertyValue.cs
@@ -706,6 +706,10 @@ namespace Pulumi.Experimental.Provider
                                         {
                                             element = Unmarshal(knownElement);
                                         }
+                                        else
+                                        {
+                                            element = PropertyValue.Computed;
+                                        }
                                         var secret = false;
                                         if (structValue.Fields.TryGetValue(Constants.SecretName, out var v))
                                         {

--- a/sdk/Pulumi/Provider/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Provider/PropertyValueSerializer.cs
@@ -490,6 +490,26 @@ namespace Pulumi.Experimental.Provider
                     return unknownOutput;
                 }
 
+                object GetOutputData(ImmutableHashSet<Resource>.Builder resources,  PropertyValue propertyValue, bool isSecret)
+                {
+                    object? deserializeValue = null;
+                    var isKnown = false;
+                    if (!propertyValue.IsComputed)
+                    {
+                        deserializeValue = DeserializeValue(propertyValue, elementType, path);
+                        isKnown = true;
+                    }
+
+                    var outputData = createOutputData.Invoke(new object?[]
+                    {
+                        resources.ToImmutable(),
+                        deserializeValue,
+                        isKnown,
+                        isSecret
+                    });
+                    return outputData;
+                }
+
                 if (value.TryGetSecret(out var secretValue))
                 {
                     if (secretValue.IsComputed)
@@ -507,14 +527,7 @@ namespace Pulumi.Experimental.Provider
                             resources.Add(new DependencyResource(dependencyUrn));
                         }
 
-                        var deserializedOutputValue = DeserializeValue(secretOutput.Value, elementType, path);
-                        var outputData = createOutputData.Invoke(new object?[]
-                        {
-                            resources.ToImmutable(),
-                            deserializedOutputValue,
-                            true, // isKnown
-                            true // isSecret
-                        });
+                        var outputData = GetOutputData(resources, secretOutput.Value, true);
 
                         return CreateInput(outputData);
                     }
@@ -551,21 +564,7 @@ namespace Pulumi.Experimental.Provider
                         resources.Add(new DependencyResource(dependencyUrn));
                     }
 
-                    object? deserializeValue = null;
-                    var isKnown = false;
-                    if (!innerOutputValue.IsComputed)
-                    {
-                        deserializeValue = DeserializeValue(innerOutputValue, elementType, path);
-                        isKnown = true;
-                    }
-
-                    var outputData = createOutputData.Invoke(new object?[]
-                    {
-                        resources.ToImmutable(),
-                        deserializeValue,
-                        isKnown,
-                        secret
-                    });
+                    var outputData = GetOutputData(resources, innerOutputValue, secret);
 
                     return CreateInput(outputData);
                 }

--- a/sdk/Pulumi/Provider/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Provider/PropertyValueSerializer.cs
@@ -490,7 +490,7 @@ namespace Pulumi.Experimental.Provider
                     return unknownOutput;
                 }
 
-                object GetOutputData(ImmutableHashSet<Resource>.Builder resources,  PropertyValue propertyValue, bool isSecret)
+                object GetOutputData(ImmutableHashSet<Resource>.Builder resources, PropertyValue propertyValue, bool isSecret)
                 {
                     object? deserializeValue = null;
                     var isKnown = false;

--- a/sdk/Pulumi/Provider/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Provider/PropertyValueSerializer.cs
@@ -525,8 +525,8 @@ namespace Pulumi.Experimental.Provider
                     {
                         ImmutableHashSet<Resource>.Empty, // resources
                         deserializedValue, // value
-                        true, // is known
-                        true // is secret
+                        true, // isKnown
+                        true // isSecret
                     });
 
                     // return Output<T>
@@ -551,13 +551,20 @@ namespace Pulumi.Experimental.Provider
                         resources.Add(new DependencyResource(dependencyUrn));
                     }
 
-                    var deserializedValue = DeserializeValue(innerOutputValue, elementType, path);
+                    object? deserializeValue = null;
+                    var isKnown = false;
+                    if (!innerOutputValue.IsComputed)
+                    {
+                        deserializeValue = DeserializeValue(innerOutputValue, elementType, path);
+                        isKnown = true;
+                    }
+
                     var outputData = createOutputData.Invoke(new object?[]
                     {
                         resources.ToImmutable(),
-                        deserializedValue,
-                        true, // isKnown
-                        secret // isSecret
+                        deserializeValue,
+                        isKnown,
+                        secret
                     });
 
                     return CreateInput(outputData);


### PR DESCRIPTION
Fix extracted from https://github.com/pulumi/pulumi-dotnet/pull/275

I also found the same bug for unkown secrets inputs. Which is also fixed.

I did not copy the intgeration test over since that was done using a c# component provider
But it is present in  the other pr, I added some unit tests to cover these edge cases though.