### PR TITLE
Fix program hanging when a resource transformation throws an exception

### DIFF
--- a/.changes/unreleased/Bug Fixes-307.yaml
+++ b/.changes/unreleased/Bug Fixes-307.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Bug Fixes
+body: Fix program hanging when a resource transformation throws an exception
+time: 2024-07-25T19:03:20.914101+02:00
+custom:
+    PR: "307"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -146,8 +146,8 @@ jobs:
         run: dotnet run integration test TestDeletedWith
       - name: TestDotNetTransforms
         run: dotnet run integration test TestDotNetTransforms
-      - name: TestFailingTransfomationExistProgram
-        run: dotnet run integration test TestFailingTransfomationExistProgram
+      - name: TestFailingTransfomationExitsProgram
+        run: dotnet run integration test TestFailingTransfomationExitsProgram
 
   info:
     name: gather

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -146,6 +146,8 @@ jobs:
         run: dotnet run integration test TestDeletedWith
       - name: TestDotNetTransforms
         run: dotnet run integration test TestDotNetTransforms
+      - name: TestFailingTransfomationExistProgram
+        run: dotnet run integration test TestFailingTransfomationExistProgram
 
   info:
     name: gather

--- a/integration_tests/failing_transformation_exits/Program.cs
+++ b/integration_tests/failing_transformation_exits/Program.cs
@@ -1,0 +1,38 @@
+﻿using Pulumi;
+using System.Threading.Tasks;
+
+class ComponentArgs : ResourceArgs { }
+
+class Component : ComponentResource
+{
+    public Component(string name, ComponentArgs args, ComponentResourceOptions? options = null) : base("test:index:Component", name, args, options)
+    {
+    }
+}
+
+class MyStack : Stack
+{
+    static StackOptions Options() => new StackOptions()
+    {
+        ResourceTransformations = { FailingTransform() } 
+    };
+
+    public MyStack() : base(Options())
+    {
+        var component = new Component("test", new ComponentArgs());
+    }
+
+    static ResourceTransformation FailingTransform() 
+    {
+        return args => 
+        {
+            throw new System.Exception("Boom!");
+            return null;
+        };
+    }
+}
+
+class Program 
+{
+    static Task<int> Main() => Deployment.RunAsync<MyStack>();
+}

--- a/integration_tests/failing_transformation_exits/Pulumi.yaml
+++ b/integration_tests/failing_transformation_exits/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: failing_transformation_exits
+description: A program that has a resource transformation which throws an exception
+runtime: dotnet

--- a/integration_tests/failing_transformation_exits/failing_transformation_exits.csproj
+++ b/integration_tests/failing_transformation_exits/failing_transformation_exits.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/integration_tests/integration_dotnet_test.go
+++ b/integration_tests/integration_dotnet_test.go
@@ -303,7 +303,7 @@ func TestLargeResourceDotNet(t *testing.T) {
 
 // tests that when a resource transformation throws an exception, the program exists
 // and doesn't hang indefinitely.
-func TestFailingTransfomationExistProgram(t *testing.T) {
+func TestFailingTransfomationExitsProgram(t *testing.T) {
 	stderr := &strings.Builder{}
 	testDotnetProgram(t, &integration.ProgramTestOptions{
 		Dir:           "failing_transformation_exits",

--- a/integration_tests/integration_dotnet_test.go
+++ b/integration_tests/integration_dotnet_test.go
@@ -301,7 +301,7 @@ func TestLargeResourceDotNet(t *testing.T) {
 	})
 }
 
-// tests that when a resource transformation throws an exception, the program exists
+// tests that when a resource transformation throws an exception, the program exits
 // and doesn't hang indefinitely.
 func TestFailingTransfomationExitsProgram(t *testing.T) {
 	stderr := &strings.Builder{}

--- a/integration_tests/integration_dotnet_test.go
+++ b/integration_tests/integration_dotnet_test.go
@@ -301,6 +301,19 @@ func TestLargeResourceDotNet(t *testing.T) {
 	})
 }
 
+// tests that when a resource transformation throws an exception, the program exists
+// and doesn't hang indefinitely.
+func TestFailingTransfomationExistProgram(t *testing.T) {
+	stderr := &strings.Builder{}
+	testDotnetProgram(t, &integration.ProgramTestOptions{
+		Dir:           "failing_transformation_exits",
+		ExpectFailure: true,
+		Stderr:        stderr,
+	})
+
+	assert.Contains(t, stderr.String(), "Boom!")
+}
+
 // Test remote component construction with a child resource that takes a long time to be created, ensuring it's created.
 //func TestConstructSlowDotnet(t *testing.T) {
 //	localProvider := testComponentSlowLocalProvider(t)

--- a/sdk/Pulumi/Deployment/Deployment.EnginerLogger.cs
+++ b/sdk/Pulumi/Deployment/Deployment.EnginerLogger.cs
@@ -92,9 +92,7 @@ namespace Pulumi
 
                     // Use a Task.Run here so that we don't end up aggressively running the actual
                     // logging while holding this lock.
-                    _lastLogTask = _lastLogTask.ContinueWith(
-                        _ => Task.Run(() => LogAsync(severity, message, resource, streamId, ephemeral)),
-                        CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default).Unwrap();
+                    _lastLogTask = Task.Run(() => LogAsync(severity, message, resource, streamId, ephemeral));
                     task = _lastLogTask;
                 }
 


### PR DESCRIPTION
Fixes #291 Fixes #174 (duplicate of the former)

The problem is that the task that is created for logging the exception never resolves. Simplified to use `Task.Run(...)` without `Task.ContinueWith(...)` and added an integration test to verify that a failing transformation actually exits the program without hanging.