### PR TITLE
[sdk] Support package parameterization for Read/RegisterResource/Call/Invoke

### DIFF
--- a/.changes/unreleased/Improvements-311.yaml
+++ b/.changes/unreleased/Improvements-311.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Support package parameterization for Read/RegisterResource/Call/Invoke
+time: 2024-08-02T14:34:44.919745+02:00
+custom:
+    PR: "311"

--- a/sdk/Pulumi.Tests/Core/OutputTests.cs
+++ b/sdk/Pulumi.Tests/Core/OutputTests.cs
@@ -712,7 +712,13 @@ namespace Pulumi.Tests.Core
                 mock.Setup(d => d.Stack).Returns(() => null!);
                 mock.Setup(d => d.Runner).Returns(runner.Object);
                 mock.Setup(d => d.Logger).Returns(logger.Object);
-                mock.Setup(d => d.ReadOrRegisterResource(Moq.It.IsAny<Resource>(), Moq.It.IsAny<bool>(), Moq.It.IsAny<System.Func<string, Resource>>(), Moq.It.IsAny<ResourceArgs>(), Moq.It.IsAny<ResourceOptions>()));
+                mock.Setup(d => d.ReadOrRegisterResource(
+                   Moq.It.IsAny<Resource>(),
+                   Moq.It.IsAny<bool>(),
+                   Moq.It.IsAny<System.Func<string, Resource>>(),
+                   Moq.It.IsAny<ResourceArgs>(),
+                   Moq.It.IsAny<ResourceOptions>(),
+                   Moq.It.IsAny<RegisterPackageRequest?>()));
 
                 Deployment.Instance = new DeploymentInstance(mock.Object);
 
@@ -796,7 +802,13 @@ namespace Pulumi.Tests.Core
                 mock.Setup(d => d.Stack).Returns(() => null!);
                 mock.Setup(d => d.Runner).Returns(runner.Object);
                 mock.Setup(d => d.Logger).Returns(logger.Object);
-                mock.Setup(d => d.ReadOrRegisterResource(Moq.It.IsAny<Resource>(), Moq.It.IsAny<bool>(), Moq.It.IsAny<System.Func<string, Resource>>(), Moq.It.IsAny<ResourceArgs>(), Moq.It.IsAny<ResourceOptions>()));
+                mock.Setup(d => d.ReadOrRegisterResource(
+                    Moq.It.IsAny<Resource>(),
+                    Moq.It.IsAny<bool>(),
+                    Moq.It.IsAny<System.Func<string, Resource>>(),
+                    Moq.It.IsAny<ResourceArgs>(),
+                    Moq.It.IsAny<ResourceOptions>(),
+                    Moq.It.IsAny<RegisterPackageRequest?>()));
 
                 Deployment.Instance = new DeploymentInstance(mock.Object);
 

--- a/sdk/Pulumi.Tests/Core/OutputTests.cs
+++ b/sdk/Pulumi.Tests/Core/OutputTests.cs
@@ -722,7 +722,7 @@ namespace Pulumi.Tests.Core
 
                 Deployment.Instance = new DeploymentInstance(mock.Object);
 
-                var resource = new CustomResource("type", "name", null);
+                var resource = new CustomResource("type", "name", ResourceArgs.Empty, new CustomResourceOptions());
 
                 var o1 = CreateOutput(new Output<int>[] {
                     CreateOutput(new Resource[] { resource}, 0, true, true),
@@ -812,7 +812,7 @@ namespace Pulumi.Tests.Core
 
                 Deployment.Instance = new DeploymentInstance(mock.Object);
 
-                var resource = new CustomResource("type", "name", null);
+                var resource = new CustomResource("type", "name", ResourceArgs.Empty, new CustomResourceOptions());
 
                 var o1 = CreateOutput(new Resource[] { resource }, "[0,1]", true, true);
                 var o2 = Output.JsonDeserialize<Output<int>[]>(o1);

--- a/sdk/Pulumi.Tests/StackTests.cs
+++ b/sdk/Pulumi.Tests/StackTests.cs
@@ -98,7 +98,9 @@ namespace Pulumi.Tests
             mock.Setup(d => d.Runner).Returns(runner.Object);
             mock.SetupSet(content => content.Stack = It.IsAny<Stack>());
             mock.Setup(d => d.ReadOrRegisterResource(It.IsAny<Stack>(), It.IsAny<bool>(),
-                It.IsAny<Func<string, Resource>>(), It.IsAny<ResourceArgs>(), It.IsAny<ResourceOptions>()));
+                It.IsAny<Func<string, Resource>>(), It.IsAny<ResourceArgs>(),
+                It.IsAny<ResourceOptions>(),
+                It.IsAny<RegisterPackageRequest?>()));
             mock.Setup(d => d.RegisterResourceOutputs(It.IsAny<Stack>(), It.IsAny<Output<IDictionary<string, object?>>>()))
                 .Callback((Resource _, Output<IDictionary<string, object?>> o) => outputs = o);
 

--- a/sdk/Pulumi/Deployment/DeploymentInstance.cs
+++ b/sdk/Pulumi/Deployment/DeploymentInstance.cs
@@ -47,8 +47,12 @@ namespace Pulumi
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
         /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
         /// </summary>
-        public Output<T> Invoke<T>(string token, InvokeArgs args, InvokeOptions? options = null)
-            => _deployment.Invoke<T>(token, args, options);
+        public Output<T> Invoke<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options = null,
+            RegisterPackageRequest? registerPackageRequest = null)
+            => _deployment.Invoke<T>(token, args, options, registerPackageRequest);
 
         /// <summary>
         /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
@@ -63,8 +67,12 @@ namespace Pulumi
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
         /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
         /// </summary>
-        public Output<T> InvokeSingle<T>(string token, InvokeArgs args, InvokeOptions? options = null)
-            => _deployment.InvokeSingle<T>(token, args, options);
+        public Output<T> InvokeSingle<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options = null,
+            RegisterPackageRequest? registerPackageRequest = null)
+            => _deployment.InvokeSingle<T>(token, args, options, registerPackageRequest);
 
         /// <summary>
         /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
@@ -76,8 +84,12 @@ namespace Pulumi
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
         /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
         /// </summary>
-        public Task<T> InvokeAsync<T>(string token, InvokeArgs args, InvokeOptions? options = null)
-            => _deployment.InvokeAsync<T>(token, args, options);
+        public Task<T> InvokeAsync<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options = null,
+            RegisterPackageRequest? registerPackageRequest = null)
+            => _deployment.InvokeAsync<T>(token, args, options, registerPackageRequest);
 
         /// <summary>
         /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
@@ -89,15 +101,19 @@ namespace Pulumi
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
         /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
         /// </summary>
-        public Task<T> InvokeSingleAsync<T>(string token, InvokeArgs args, InvokeOptions? options = null)
-            => _deployment.InvokeSingleAsync<T>(token, args, options);
+        public Task<T> InvokeSingleAsync<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options = null,
+            RegisterPackageRequest? registerPackageRequest = null)
+            => _deployment.InvokeSingleAsync<T>(token, args, options, registerPackageRequest);
 
         /// <summary>
-        /// Same as <see cref="InvokeAsync{T}(string, InvokeArgs, InvokeOptions)"/>, however the
+        /// Same as <see cref="InvokeAsync{T}(string, InvokeArgs, InvokeOptions, RegisterPackageRequest)"/>, however the
         /// return value is ignored.
         /// </summary>
-        public Task InvokeAsync(string token, InvokeArgs args, InvokeOptions? options = null)
-            => _deployment.InvokeAsync(token, args, options);
+        public Task InvokeAsync(string token, InvokeArgs args, InvokeOptions? options = null, RegisterPackageRequest? registerPackageRequest = null)
+            => _deployment.InvokeAsync(token, args, options, registerPackageRequest);
 
         /// <summary>
         /// Dynamically calls the function '<paramref name="token"/>', which is offered by a
@@ -109,14 +125,24 @@ namespace Pulumi
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
         /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
         /// </summary>
-        public Output<T> Call<T>(string token, CallArgs args, Resource? self = null, CallOptions? options = null)
-            => _deployment.Call<T>(token, args, self, options);
+        public Output<T> Call<T>(
+            string token,
+            CallArgs args,
+            Resource? self = null,
+            CallOptions? options = null,
+            RegisterPackageRequest? registerPackageRequest = null)
+            => _deployment.Call<T>(token, args, self, options, registerPackageRequest);
 
         /// <summary>
         /// Same as <see cref="Call{T}"/>, however the return value is ignored.
         /// </summary>
-        public void Call(string token, CallArgs args, Resource? self = null, CallOptions? options = null)
-            => _deployment.Call(token, args, self, options);
+        public void Call(
+            string token,
+            CallArgs args,
+            Resource? self = null,
+            CallOptions? options = null,
+            RegisterPackageRequest? registerPackageRequest = null)
+            => _deployment.Call(token, args, self, options, registerPackageRequest);
 
         internal IDeploymentInternal Internal => (IDeploymentInternal)_deployment;
     }

--- a/sdk/Pulumi/Deployment/GrpcMonitor.cs
+++ b/sdk/Pulumi/Deployment/GrpcMonitor.cs
@@ -50,6 +50,9 @@ namespace Pulumi
         public async Task<CallResponse> CallAsync(ResourceCallRequest request)
             => await this._client.CallAsync(request);
 
+        public async Task<RegisterPackageResponse> RegisterPackageAsync(Pulumirpc.RegisterPackageRequest request)
+            => await this._client.RegisterPackageAsync(request);
+
         public async Task<ReadResourceResponse> ReadResourceAsync(Resource resource, ReadResourceRequest request)
             => await this._client.ReadResourceAsync(request);
 

--- a/sdk/Pulumi/Deployment/IDeployment.cs
+++ b/sdk/Pulumi/Deployment/IDeployment.cs
@@ -36,7 +36,11 @@ namespace Pulumi
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
         /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
         /// </summary>
-        Task<T> InvokeAsync<T>(string token, InvokeArgs args, InvokeOptions? options = null);
+        Task<T> InvokeAsync<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options = null,
+            RegisterPackageRequest? registerPackageRequest = null);
 
         /// <summary>
         /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
@@ -48,7 +52,11 @@ namespace Pulumi
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
         /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
         /// </summary>
-        Task<T> InvokeSingleAsync<T>(string token, InvokeArgs args, InvokeOptions? options = null);
+        Task<T> InvokeSingleAsync<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options = null,
+            RegisterPackageRequest? registerPackageRequest = null);
 
         /// <summary>
         /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
@@ -60,7 +68,11 @@ namespace Pulumi
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
         /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
         /// </summary>
-        Output<T> Invoke<T>(string token, InvokeArgs args, InvokeOptions? options = null);
+        Output<T> Invoke<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options = null,
+            RegisterPackageRequest? registerPackageRequest = null);
 
         /// <summary>
         /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
@@ -72,13 +84,21 @@ namespace Pulumi
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
         /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
         /// </summary>
-        Output<T> InvokeSingle<T>(string token, InvokeArgs args, InvokeOptions? options = null);
+        Output<T> InvokeSingle<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options = null,
+            RegisterPackageRequest? registerPackageRequest = null);
 
         /// <summary>
         /// Same as <see cref="InvokeAsync{T}(string, InvokeArgs, InvokeOptions)"/>, however the
         /// return value is ignored.
         /// </summary>
-        Task InvokeAsync(string token, InvokeArgs args, InvokeOptions? options = null);
+        Task InvokeAsync(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options = null,
+            RegisterPackageRequest? registerPackageRequest = null);
 
         /// <summary>
         /// Dynamically calls the function '<paramref name="token"/>', which is offered by a
@@ -91,11 +111,21 @@ namespace Pulumi
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
         /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
         /// </summary>
-        Output<T> Call<T>(string token, CallArgs args, Resource? self = null, CallOptions? options = null);
+        Output<T> Call<T>(
+            string token,
+            CallArgs args,
+            Resource? self = null,
+            CallOptions? options = null,
+            RegisterPackageRequest? registerPackageRequest = null);
 
         /// <summary>
         /// Same as <see cref="Call{T}"/>, however the return value is ignored.
         /// </summary>
-        void Call(string token, CallArgs args, Resource? self = null, CallOptions? options = null);
+        void Call(
+            string token,
+            CallArgs args,
+            Resource? self = null,
+            CallOptions? options = null,
+            RegisterPackageRequest? registerPackageRequest = null);
     }
 }

--- a/sdk/Pulumi/Deployment/IDeployment.cs
+++ b/sdk/Pulumi/Deployment/IDeployment.cs
@@ -91,7 +91,7 @@ namespace Pulumi
             RegisterPackageRequest? registerPackageRequest = null);
 
         /// <summary>
-        /// Same as <see cref="InvokeAsync{T}(string, InvokeArgs, InvokeOptions)"/>, however the
+        /// Same as <see cref="InvokeAsync{T}(string, InvokeArgs, InvokeOptions, RegisterPackageRequest)"/>, however the
         /// return value is ignored.
         /// </summary>
         Task InvokeAsync(

--- a/sdk/Pulumi/Deployment/IDeploymentInternal.cs
+++ b/sdk/Pulumi/Deployment/IDeploymentInternal.cs
@@ -17,7 +17,8 @@ namespace Pulumi
 
         void ReadOrRegisterResource(
             Resource resource, bool remote, Func<string, Resource> newDependency, ResourceArgs args,
-            ResourceOptions opts);
+            ResourceOptions opts,
+            RegisterPackageRequest? registerPackageRequest = null);
         void RegisterResourceOutputs(Resource resource, Output<IDictionary<string, object?>> outputs);
     }
 }

--- a/sdk/Pulumi/Deployment/IMonitor.cs
+++ b/sdk/Pulumi/Deployment/IMonitor.cs
@@ -13,6 +13,8 @@ namespace Pulumi
 
         Task<CallResponse> CallAsync(ResourceCallRequest request);
 
+        Task<RegisterPackageResponse> RegisterPackageAsync(Pulumirpc.RegisterPackageRequest request);
+
         Task<ReadResourceResponse> ReadResourceAsync(Resource resource, ReadResourceRequest request);
 
         Task<RegisterResourceResponse> RegisterResourceAsync(Resource resource, RegisterResourceRequest request);

--- a/sdk/Pulumi/Deployment/InvokeOptions.cs
+++ b/sdk/Pulumi/Deployment/InvokeOptions.cs
@@ -3,7 +3,7 @@
 namespace Pulumi
 {
     /// <summary>
-    /// Options to help control the behavior of <see cref="IDeployment.InvokeAsync{T}(string, InvokeArgs, InvokeOptions)"/>.
+    /// Options to help control the behavior of <see cref="IDeployment.InvokeAsync{T}(string, InvokeArgs, InvokeOptions, RegisterPackageRequest)"/>.
     /// </summary>
     public class InvokeOptions
     {

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -1107,9 +1107,9 @@
             otherwise we pass the full structure of the Aliases field to the resource monitor.
             </summary>
         </member>
-        <member name="M:Pulumi.Deployment.CompleteResourceAsync(Pulumi.Resource,System.Boolean,System.Func{System.String,Pulumi.Resource},Pulumi.ResourceArgs,Pulumi.ResourceOptions,System.Collections.Immutable.ImmutableDictionary{System.String,Pulumi.Serialization.IOutputCompletionSource})">
+        <member name="M:Pulumi.Deployment.CompleteResourceAsync(Pulumi.Resource,System.Boolean,System.Func{System.String,Pulumi.Resource},Pulumi.ResourceArgs,Pulumi.ResourceOptions,System.Collections.Immutable.ImmutableDictionary{System.String,Pulumi.Serialization.IOutputCompletionSource},Pulumi.RegisterPackageRequest)">
             <summary>
-            Calls <see cref="M:Pulumi.Deployment.ReadOrRegisterResourceAsync(Pulumi.Resource,System.Boolean,System.Func{System.String,Pulumi.Resource},Pulumi.ResourceArgs,Pulumi.ResourceOptions)"/> then completes all the
+            Calls <see cref="M:Pulumi.Deployment.ReadOrRegisterResourceAsync(Pulumi.Resource,System.Boolean,System.Func{System.String,Pulumi.Resource},Pulumi.ResourceArgs,Pulumi.ResourceOptions,Pulumi.RegisterPackageRequest)"/> then completes all the
             <see cref="T:Pulumi.Serialization.IOutputCompletionSource"/> sources on the <paramref name="resource"/> with
             the results of it.
             </summary>
@@ -1983,6 +1983,41 @@
             <param name="options">A bag of options that control this provider's behavior.</param>
             <param name="dependency">True if this is a synthetic resource used internally for dependency tracking.</param>
         </member>
+        <member name="F:Pulumi.RegisterPackageRequest.PackageParameterization.Name">
+            <summary>
+            The name of the parameterized package
+            </summary>
+        </member>
+        <member name="F:Pulumi.RegisterPackageRequest.PackageParameterization.Version">
+            <summary>
+            The version of the parameterized package
+            </summary>
+        </member>
+        <member name="F:Pulumi.RegisterPackageRequest.PackageParameterization.Value">
+            <summary>
+            The paramter value for the parameterized package
+            </summary>
+        </member>
+        <member name="F:Pulumi.RegisterPackageRequest.Name">
+            <summary>
+            The plugin name
+            </summary>
+        </member>
+        <member name="F:Pulumi.RegisterPackageRequest.Version">
+            <summary>
+            The plugin version
+            </summary>
+        </member>
+        <member name="F:Pulumi.RegisterPackageRequest.DownloadUrl">
+            <summary>
+            the optional plugin download url.
+            </summary>
+        </member>
+        <member name="F:Pulumi.RegisterPackageRequest.Checksums">
+            <summary>
+            the optional plugin checksums
+            </summary>
+        </member>
         <member name="T:Pulumi.Resource">
             <summary>
             Resource represents a class whose CRUD operations are implemented by a provider plugin.
@@ -2076,7 +2111,7 @@
             The specified provider download URL.
             </summary>
         </member>
-        <member name="M:Pulumi.Resource.#ctor(System.String,System.String,System.Boolean,Pulumi.ResourceArgs,Pulumi.ResourceOptions,System.Boolean,System.Boolean)">
+        <member name="M:Pulumi.Resource.#ctor(System.String,System.String,System.Boolean,Pulumi.ResourceArgs,Pulumi.ResourceOptions,System.Boolean,System.Boolean,Pulumi.RegisterPackageRequest)">
             <summary>
             Creates and registers a new resource object.  <paramref name="type"/> is the fully
             qualified type token and <paramref name="name"/> is the "name" part to use in creating a
@@ -2091,6 +2126,7 @@
             <param name="options">A bag of options that control this resource's behavior.</param>
             <param name="remote">True if this is a remote component resource.</param>
             <param name="dependency">True if this is a synthetic resource used internally for dependency tracking.</param>
+            <param name="registerPackageRequest">Options for package parameterization</param>
         </member>
         <member name="M:Pulumi.Resource.GetProvider(System.String)">
             <summary>
@@ -5126,6 +5162,9 @@
         <member name="F:Pulumirpc.RuntimeOptionPrompt.Types.RuntimeOptionValue.Int32ValueFieldNumber">
             <summary>Field number for the "int32Value" field.</summary>
         </member>
+        <member name="F:Pulumirpc.RuntimeOptionPrompt.Types.RuntimeOptionValue.DisplayNameFieldNumber">
+            <summary>Field number for the "displayName" field.</summary>
+        </member>
         <member name="F:Pulumirpc.RuntimeOptionsResponse.PromptsFieldNumber">
             <summary>Field number for the "prompts" field.</summary>
         </member>
@@ -5233,6 +5272,14 @@
         <member name="P:Pulumirpc.GenerateProgramRequest.LoaderTarget">
             <summary>
             The target of a codegen.LoaderServer to use for loading schemas.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.GenerateProgramRequest.StrictFieldNumber">
+            <summary>Field number for the "strict" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.GenerateProgramRequest.Strict">
+            <summary>
+            if PCL binding should be strict or not.
             </summary>
         </member>
         <member name="F:Pulumirpc.GenerateProgramResponse.DiagnosticsFieldNumber">
@@ -6419,9 +6466,15 @@
             <summary>Field number for the "news" field.</summary>
         </member>
         <member name="P:Pulumirpc.CheckRequest.News">
-            <summary>
-            the new Pulumi inputs for this resource.
-            </summary>
+             <summary>
+             the new Pulumi inputs for this resource.
+            
+             Note that if the user specifies the ignoreChanges resource option, the value of news passed
+             to the provider here may differ from the values written in the program source. It will be pre-processed by
+             replacing every ignoreChanges property by a matching value from the old inputs stored in the state.
+            
+             See also: https://www.pulumi.com/docs/concepts/options/ignorechanges/
+             </summary>
         </member>
         <member name="F:Pulumirpc.CheckRequest.RandomSeedFieldNumber">
             <summary>Field number for the "randomSeed" field.</summary>
@@ -6492,7 +6545,7 @@
         </member>
         <member name="P:Pulumirpc.DiffRequest.News">
             <summary>
-            the new input values of resource to diff.
+            the new input values of resource to diff, copied from CheckResponse.inputs.
             </summary>
         </member>
         <member name="F:Pulumirpc.DiffRequest.IgnoreChangesFieldNumber">
@@ -6806,7 +6859,7 @@
         </member>
         <member name="P:Pulumirpc.UpdateRequest.News">
             <summary>
-            the new values of provider inputs for the resource to update.
+            the new values of provider inputs for the resource to update, copied from CheckResponse.inputs.
             </summary>
         </member>
         <member name="F:Pulumirpc.UpdateRequest.TimeoutFieldNumber">
@@ -7315,7 +7368,7 @@
             
              Parameterize should work the same for both the `ParametersArgs` input and the `ParametersValue` input. Either way
              should return the sub-package name and version (which for `ParametersValue` should match the given input).
-             
+            
              For extension resources their CRUD operations will include the version of which sub-package they correspond to.
              </summary>
              <param name="request">The request received from the client.</param>
@@ -7520,7 +7573,7 @@
             
              Parameterize should work the same for both the `ParametersArgs` input and the `ParametersValue` input. Either way
              should return the sub-package name and version (which for `ParametersValue` should match the given input).
-             
+            
              For extension resources their CRUD operations will include the version of which sub-package they correspond to.
              </summary>
              <param name="request">The request to send to the server.</param>
@@ -7542,7 +7595,7 @@
             
              Parameterize should work the same for both the `ParametersArgs` input and the `ParametersValue` input. Either way
              should return the sub-package name and version (which for `ParametersValue` should match the given input).
-             
+            
              For extension resources their CRUD operations will include the version of which sub-package they correspond to.
              </summary>
              <param name="request">The request to send to the server.</param>
@@ -7562,7 +7615,7 @@
             
              Parameterize should work the same for both the `ParametersArgs` input and the `ParametersValue` input. Either way
              should return the sub-package name and version (which for `ParametersValue` should match the given input).
-             
+            
              For extension resources their CRUD operations will include the version of which sub-package they correspond to.
              </summary>
              <param name="request">The request to send to the server.</param>
@@ -7584,7 +7637,7 @@
             
              Parameterize should work the same for both the `ParametersArgs` input and the `ParametersValue` input. Either way
              should return the sub-package name and version (which for `ParametersValue` should match the given input).
-             
+            
              For extension resources their CRUD operations will include the version of which sub-package they correspond to.
              </summary>
              <param name="request">The request to send to the server.</param>
@@ -8469,6 +8522,14 @@
             the optional source position of the user code that initiated the read.
             </summary>
         </member>
+        <member name="F:Pulumirpc.ReadResourceRequest.PackageRefFieldNumber">
+            <summary>Field number for the "packageRef" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ReadResourceRequest.PackageRef">
+            <summary>
+            a reference from RegisterProviderRequest.
+            </summary>
+        </member>
         <member name="T:Pulumirpc.ReadResourceResponse">
             <summary>
             ReadResourceResponse contains the result of reading a resource's state.
@@ -8757,6 +8818,14 @@
             true if the request is from an SDK that supports the result field in the response.
             </summary>
         </member>
+        <member name="F:Pulumirpc.RegisterResourceRequest.PackageRefFieldNumber">
+            <summary>Field number for the "packageRef" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.RegisterResourceRequest.PackageRef">
+            <summary>
+            a reference from RegisterProviderRequest.
+            </summary>
+        </member>
         <member name="T:Pulumirpc.RegisterResourceRequest.Types">
             <summary>Container for nested types declared in the RegisterResourceRequest message type.</summary>
         </member>
@@ -8965,6 +9034,14 @@
             the optional source position of the user code that initiated the invoke.
             </summary>
         </member>
+        <member name="F:Pulumirpc.ResourceInvokeRequest.PackageRefFieldNumber">
+            <summary>Field number for the "packageRef" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ResourceInvokeRequest.PackageRef">
+            <summary>
+            a reference from RegisterProviderRequest.
+            </summary>
+        </member>
         <member name="F:Pulumirpc.ResourceCallRequest.TokFieldNumber">
             <summary>Field number for the "tok" field.</summary>
         </member>
@@ -9027,6 +9104,14 @@
         <member name="P:Pulumirpc.ResourceCallRequest.SourcePosition">
             <summary>
             the optional source position of the user code that initiated the call.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.ResourceCallRequest.PackageRefFieldNumber">
+            <summary>Field number for the "packageRef" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ResourceCallRequest.PackageRef">
+            <summary>
+            a reference from RegisterProviderRequest.
             </summary>
         </member>
         <member name="T:Pulumirpc.ResourceCallRequest.Types">
@@ -9165,37 +9250,144 @@
             the options for the resource.
             </summary>
         </member>
-        <member name="F:Pulumirpc.RegisterProviderRequest.NameFieldNumber">
-            <summary>Field number for the "name" field.</summary>
-        </member>
-        <member name="F:Pulumirpc.RegisterProviderRequest.VersionFieldNumber">
-            <summary>Field number for the "version" field.</summary>
-        </member>
-        <member name="F:Pulumirpc.RegisterProviderRequest.PluginDownloadUrlFieldNumber">
-            <summary>Field number for the "plugin_download_url" field.</summary>
-        </member>
-        <member name="F:Pulumirpc.RegisterProviderRequest.PluginChecksumsFieldNumber">
-            <summary>Field number for the "plugin_checksums" field.</summary>
-        </member>
-        <member name="F:Pulumirpc.RegisterProviderRequest.ParameterFieldNumber">
-            <summary>Field number for the "parameter" field.</summary>
-        </member>
-        <member name="F:Pulumirpc.RegisterProviderResponse.RefFieldNumber">
-            <summary>Field number for the "ref" field.</summary>
-        </member>
-        <member name="P:Pulumirpc.RegisterProviderResponse.Ref">
+        <member name="T:Pulumirpc.TransformInvokeRequest">
             <summary>
-            The UUID package reference for this registered provider package.
+            TransformInvokeRequest is the request object for the TransformInvoke RPC.
             </summary>
         </member>
-        <member name="F:Pulumirpc.ProviderParameter.NameFieldNumber">
-            <summary>Field number for the "name" field.</summary>
+        <member name="F:Pulumirpc.TransformInvokeRequest.TokenFieldNumber">
+            <summary>Field number for the "token" field.</summary>
         </member>
-        <member name="F:Pulumirpc.ProviderParameter.VersionFieldNumber">
+        <member name="P:Pulumirpc.TransformInvokeRequest.Token">
+            <summary>
+            the token for the invoke request.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.TransformInvokeRequest.ArgsFieldNumber">
+            <summary>Field number for the "args" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.TransformInvokeRequest.Args">
+            <summary>
+            the input args of the resource.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.TransformInvokeRequest.OptionsFieldNumber">
+            <summary>Field number for the "options" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.TransformInvokeRequest.Options">
+            <summary>
+            the options for the resource.
+            </summary>
+        </member>
+        <member name="T:Pulumirpc.TransformInvokeResponse">
+            <summary>
+            TransformInvokeResponse is the response object for the TransformInvoke RPC.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.TransformInvokeResponse.ArgsFieldNumber">
+            <summary>Field number for the "args" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.TransformInvokeResponse.Args">
+            <summary>
+            the transformed input args.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.TransformInvokeResponse.OptionsFieldNumber">
+            <summary>Field number for the "options" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.TransformInvokeResponse.Options">
+            <summary>
+            the options for the resource.
+            </summary>
+        </member>
+        <member name="T:Pulumirpc.TransformInvokeOptions">
+            <summary>
+            TransformInvokeOptions is a subset of all invoke options that are relevant to transforms.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.TransformInvokeOptions.ProviderFieldNumber">
+            <summary>Field number for the "provider" field.</summary>
+        </member>
+        <member name="F:Pulumirpc.TransformInvokeOptions.PluginDownloadUrlFieldNumber">
+            <summary>Field number for the "plugin_download_url" field.</summary>
+        </member>
+        <member name="F:Pulumirpc.TransformInvokeOptions.VersionFieldNumber">
             <summary>Field number for the "version" field.</summary>
         </member>
-        <member name="F:Pulumirpc.ProviderParameter.ValueFieldNumber">
+        <member name="F:Pulumirpc.TransformInvokeOptions.PluginChecksumsFieldNumber">
+            <summary>Field number for the "plugin_checksums" field.</summary>
+        </member>
+        <member name="F:Pulumirpc.RegisterPackageRequest.NameFieldNumber">
+            <summary>Field number for the "name" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.RegisterPackageRequest.Name">
+            <summary>
+            the plugin name.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.RegisterPackageRequest.VersionFieldNumber">
+            <summary>Field number for the "version" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.RegisterPackageRequest.Version">
+            <summary>
+            the plugin version.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.RegisterPackageRequest.DownloadUrlFieldNumber">
+            <summary>Field number for the "download_url" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.RegisterPackageRequest.DownloadUrl">
+            <summary>
+            the optional plugin download url.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.RegisterPackageRequest.ChecksumsFieldNumber">
+            <summary>Field number for the "checksums" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.RegisterPackageRequest.Checksums">
+            <summary>
+            the optional plugin checksums.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.RegisterPackageRequest.ParameterizationFieldNumber">
+            <summary>Field number for the "parameterization" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.RegisterPackageRequest.Parameterization">
+            <summary>
+            the optional parameterization for this package.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.RegisterPackageResponse.RefFieldNumber">
+            <summary>Field number for the "ref" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.RegisterPackageResponse.Ref">
+            <summary>
+            The UUID package reference for this registered package.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.Parameterization.NameFieldNumber">
+            <summary>Field number for the "name" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.Parameterization.Name">
+            <summary>
+            the parameterized package name.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.Parameterization.VersionFieldNumber">
+            <summary>Field number for the "version" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.Parameterization.Version">
+            <summary>
+            the parameterized package version.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.Parameterization.ValueFieldNumber">
             <summary>Field number for the "value" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.Parameterization.Value">
+            <summary>
+            the parameter value for the parameterized package.
+            </summary>
         </member>
         <member name="T:Pulumirpc.ResourceMonitor">
             <summary>
@@ -9207,6 +9399,22 @@
         </member>
         <member name="T:Pulumirpc.ResourceMonitor.ResourceMonitorBase">
             <summary>Base class for server-side implementations of ResourceMonitor</summary>
+        </member>
+        <member name="M:Pulumirpc.ResourceMonitor.ResourceMonitorBase.RegisterStackTransform(Pulumirpc.Callback,Grpc.Core.ServerCallContext)">
+            <summary>
+            Register a resource transform for the stack
+            </summary>
+            <param name="request">The request received from the client.</param>
+            <param name="context">The context of the server-side call handler being invoked.</param>
+            <returns>The response to send back to the client (wrapped by a task).</returns>
+        </member>
+        <member name="M:Pulumirpc.ResourceMonitor.ResourceMonitorBase.RegisterStackInvokeTransform(Pulumirpc.Callback,Grpc.Core.ServerCallContext)">
+            <summary>
+            Register an invoke transform for the stack
+            </summary>
+            <param name="request">The request received from the client.</param>
+            <param name="context">The context of the server-side call handler being invoked.</param>
+            <returns>The response to send back to the client (wrapped by a task).</returns>
         </member>
         <member name="T:Pulumirpc.ResourceMonitor.ResourceMonitorClient">
             <summary>Client for ResourceMonitor</summary>
@@ -9225,6 +9433,78 @@
         <member name="M:Pulumirpc.ResourceMonitor.ResourceMonitorClient.#ctor(Grpc.Core.ClientBase.ClientBaseConfiguration)">
             <summary>Protected constructor to allow creation of configured clients.</summary>
             <param name="configuration">The client configuration.</param>
+        </member>
+        <member name="M:Pulumirpc.ResourceMonitor.ResourceMonitorClient.RegisterStackTransform(Pulumirpc.Callback,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
+            <summary>
+            Register a resource transform for the stack
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+            <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+            <param name="cancellationToken">An optional token for canceling the call.</param>
+            <returns>The response received from the server.</returns>
+        </member>
+        <member name="M:Pulumirpc.ResourceMonitor.ResourceMonitorClient.RegisterStackTransform(Pulumirpc.Callback,Grpc.Core.CallOptions)">
+            <summary>
+            Register a resource transform for the stack
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="options">The options for the call.</param>
+            <returns>The response received from the server.</returns>
+        </member>
+        <member name="M:Pulumirpc.ResourceMonitor.ResourceMonitorClient.RegisterStackTransformAsync(Pulumirpc.Callback,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
+            <summary>
+            Register a resource transform for the stack
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+            <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+            <param name="cancellationToken">An optional token for canceling the call.</param>
+            <returns>The call object.</returns>
+        </member>
+        <member name="M:Pulumirpc.ResourceMonitor.ResourceMonitorClient.RegisterStackTransformAsync(Pulumirpc.Callback,Grpc.Core.CallOptions)">
+            <summary>
+            Register a resource transform for the stack
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="options">The options for the call.</param>
+            <returns>The call object.</returns>
+        </member>
+        <member name="M:Pulumirpc.ResourceMonitor.ResourceMonitorClient.RegisterStackInvokeTransform(Pulumirpc.Callback,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
+            <summary>
+            Register an invoke transform for the stack
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+            <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+            <param name="cancellationToken">An optional token for canceling the call.</param>
+            <returns>The response received from the server.</returns>
+        </member>
+        <member name="M:Pulumirpc.ResourceMonitor.ResourceMonitorClient.RegisterStackInvokeTransform(Pulumirpc.Callback,Grpc.Core.CallOptions)">
+            <summary>
+            Register an invoke transform for the stack
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="options">The options for the call.</param>
+            <returns>The response received from the server.</returns>
+        </member>
+        <member name="M:Pulumirpc.ResourceMonitor.ResourceMonitorClient.RegisterStackInvokeTransformAsync(Pulumirpc.Callback,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
+            <summary>
+            Register an invoke transform for the stack
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+            <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+            <param name="cancellationToken">An optional token for canceling the call.</param>
+            <returns>The call object.</returns>
+        </member>
+        <member name="M:Pulumirpc.ResourceMonitor.ResourceMonitorClient.RegisterStackInvokeTransformAsync(Pulumirpc.Callback,Grpc.Core.CallOptions)">
+            <summary>
+            Register an invoke transform for the stack
+            </summary>
+            <param name="request">The request to send to the server.</param>
+            <param name="options">The options for the call.</param>
+            <returns>The call object.</returns>
         </member>
         <member name="M:Pulumirpc.ResourceMonitor.ResourceMonitorClient.NewInstance(Grpc.Core.ClientBase.ClientBaseConfiguration)">
             <summary>Creates a new instance of client from given <c>ClientBaseConfiguration</c>.</summary>

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -912,7 +912,7 @@
         </member>
         <member name="T:Pulumi.CallOptions">
             <summary>
-            Options to help control the behavior of <see cref="M:Pulumi.Deployment.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,System.Boolean)"/>.
+            Options to help control the behavior of <see cref="M:Pulumi.Deployment.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,System.Boolean,Pulumi.RegisterPackageRequest)"/>.
             </summary>
         </member>
         <member name="P:Pulumi.CallOptions.Parent">
@@ -1265,7 +1265,7 @@
              in which case an internal TestStack is used to create the resources.
             
              This function takes the created resources from the TestStack and filters it out of the created resources
-             (since it is internal) and obtains the outputs returned, if any from that TestStack. 
+             (since it is internal) and obtains the outputs returned, if any from that TestStack.
              </summary>
              <param name="resources">The created resources from TestAsync</param>
              <returns>Resources and outputs</returns>
@@ -1274,7 +1274,7 @@
             <summary>
             Entry point to test a Pulumi application. Deployment will
             run the provided function that creates resources but doesn't actually deploy them
-            Note: Currently, unit tests that call this function 
+            Note: Currently, unit tests that call this function
             must run serially; parallel execution is not supported.
             </summary>
             <param name="testMocks">Hooks to mock the engine calls.</param>
@@ -1286,7 +1286,7 @@
             <summary>
             Entry point to test a Pulumi application. Deployment will
             run the provided function that creates resources but doesn't actually deploy them
-            Note: Currently, unit tests that call this function 
+            Note: Currently, unit tests that call this function
             must run serially; parallel execution is not supported.
             </summary>
             <param name="testMocks">Hooks to mock the engine calls.</param>
@@ -1298,7 +1298,7 @@
             <summary>
             Entry point to test a Pulumi application. Deployment will
             run the provided function that creates resources but doesn't actually deploy them
-            Note: Currently, unit tests that call this function 
+            Note: Currently, unit tests that call this function
             must run serially; parallel execution is not supported.
             </summary>
             <param name="testMocks">Hooks to mock the engine calls.</param>
@@ -1310,7 +1310,7 @@
             <summary>
             Entry point to test a Pulumi application. Deployment will
             run the provided function that creates resources but doesn't actually deploy them
-            Note: Currently, unit tests that call this function 
+            Note: Currently, unit tests that call this function
             must run serially; parallel execution is not supported.
             </summary>
             <param name="testMocks">Hooks to mock the engine calls.</param>
@@ -1382,81 +1382,81 @@
             Whether or not the application is currently being previewed or actually applied.
             </summary>
         </member>
-        <member name="M:Pulumi.DeploymentInstance.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+        <member name="M:Pulumi.DeploymentInstance.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <summary>
             Dynamically invokes the function '<paramref name="token"/>', which is offered by a
             provider plugin.
             <para/>
-            The result of <see cref="M:Pulumi.DeploymentInstance.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
+            The result of <see cref="M:Pulumi.DeploymentInstance.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
             result value of the provider plugin.
             <para/>
-            Similar to the earlier <see cref="M:Pulumi.DeploymentInstance.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/>, but supports passing input values
+            Similar to the earlier <see cref="M:Pulumi.DeploymentInstance.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/>, but supports passing input values
             and returns an Output value.
             <para/>
             The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
             <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
             </summary>
         </member>
-        <member name="M:Pulumi.DeploymentInstance.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+        <member name="M:Pulumi.DeploymentInstance.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <summary>
             Dynamically invokes the function '<paramref name="token"/>', which is offered by a
             provider plugin.
             <para/>
-            The result of <see cref="M:Pulumi.DeploymentInstance.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
+            The result of <see cref="M:Pulumi.DeploymentInstance.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
             result value of the provider plugin.
             <para/>
-            Similar to the earlier <see cref="M:Pulumi.DeploymentInstance.InvokeSingleAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/>, but supports passing input values
+            Similar to the earlier <see cref="M:Pulumi.DeploymentInstance.InvokeSingleAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/>, but supports passing input values
             and returns an Output value.
             <para/>
             The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
             <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
             </summary>
         </member>
-        <member name="M:Pulumi.DeploymentInstance.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+        <member name="M:Pulumi.DeploymentInstance.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <summary>
             Dynamically invokes the function '<paramref name="token"/>', which is offered by a
             provider plugin.
             <para/>
-            The result of <see cref="M:Pulumi.DeploymentInstance.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/> will be a <see cref="T:System.Threading.Tasks.Task"/> resolved to the
+            The result of <see cref="M:Pulumi.DeploymentInstance.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:System.Threading.Tasks.Task"/> resolved to the
             result value of the provider plugin.
             <para/>
             The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
             <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
             </summary>
         </member>
-        <member name="M:Pulumi.DeploymentInstance.InvokeSingleAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+        <member name="M:Pulumi.DeploymentInstance.InvokeSingleAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <summary>
             Dynamically invokes the function '<paramref name="token"/>', which is offered by a
             provider plugin.
             <para/>
-            The result of <see cref="M:Pulumi.DeploymentInstance.InvokeSingleAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/> will be a <see cref="T:System.Threading.Tasks.Task"/> resolved to the
+            The result of <see cref="M:Pulumi.DeploymentInstance.InvokeSingleAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:System.Threading.Tasks.Task"/> resolved to the
             result value of the provider plugin which is expected to be a dictionary with single value.
             <para/>
             The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
             <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
             </summary>
         </member>
-        <member name="M:Pulumi.DeploymentInstance.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+        <member name="M:Pulumi.DeploymentInstance.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <summary>
-            Same as <see cref="M:Pulumi.DeploymentInstance.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/>, however the
+            Same as <see cref="M:Pulumi.DeploymentInstance.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/>, however the
             return value is ignored.
             </summary>
         </member>
-        <member name="M:Pulumi.DeploymentInstance.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions)">
+        <member name="M:Pulumi.DeploymentInstance.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,Pulumi.RegisterPackageRequest)">
             <summary>
             Dynamically calls the function '<paramref name="token"/>', which is offered by a
             provider plugin.
             <para/>
-            The result of <see cref="M:Pulumi.DeploymentInstance.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions)"/> will be a <see cref="T:Pulumi.Output`1"/> resolved to the
+            The result of <see cref="M:Pulumi.DeploymentInstance.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:Pulumi.Output`1"/> resolved to the
             result value of the provider plugin.
             <para/>
             The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
             <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
             </summary>
         </member>
-        <member name="M:Pulumi.DeploymentInstance.Call(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions)">
+        <member name="M:Pulumi.DeploymentInstance.Call(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,Pulumi.RegisterPackageRequest)">
             <summary>
-            Same as <see cref="M:Pulumi.DeploymentInstance.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions)"/>, however the return value is ignored.
+            Same as <see cref="M:Pulumi.DeploymentInstance.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,Pulumi.RegisterPackageRequest)"/>, however the return value is ignored.
             </summary>
         </member>
         <member name="P:Pulumi.IDeployment.StackName">
@@ -1479,81 +1479,81 @@
             Whether or not the application is currently being previewed or actually applied.
             </summary>
         </member>
-        <member name="M:Pulumi.IDeployment.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+        <member name="M:Pulumi.IDeployment.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <summary>
             Dynamically invokes the function '<paramref name="token"/>', which is offered by a
             provider plugin.
             <para/>
-            The result of <see cref="M:Pulumi.IDeployment.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/> will be a <see cref="T:System.Threading.Tasks.Task"/> resolved to the
+            The result of <see cref="M:Pulumi.IDeployment.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:System.Threading.Tasks.Task"/> resolved to the
             result value of the provider plugin.
             <para/>
             The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
             <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
             </summary>
         </member>
-        <member name="M:Pulumi.IDeployment.InvokeSingleAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+        <member name="M:Pulumi.IDeployment.InvokeSingleAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <summary>
             Dynamically invokes the function '<paramref name="token"/>', which is offered by a
             provider plugin.
             <para/>
-            The result of <see cref="M:Pulumi.IDeployment.InvokeSingleAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/> will be a <see cref="T:System.Threading.Tasks.Task"/> resolved to the
+            The result of <see cref="M:Pulumi.IDeployment.InvokeSingleAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:System.Threading.Tasks.Task"/> resolved to the
             result value of the provider plugin that returns a bag of properties with a single value that is returned.
             <para/>
             The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
             <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
             </summary>
         </member>
-        <member name="M:Pulumi.IDeployment.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+        <member name="M:Pulumi.IDeployment.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <summary>
             Dynamically invokes the function '<paramref name="token"/>', which is offered by a
             provider plugin.
             <para/>
-            The result of <see cref="M:Pulumi.IDeployment.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
+            The result of <see cref="M:Pulumi.IDeployment.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
             result value of the provider plugin.
             <para/>
             The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
             <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
             </summary>
         </member>
-        <member name="M:Pulumi.IDeployment.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+        <member name="M:Pulumi.IDeployment.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <summary>
             Dynamically invokes the function '<paramref name="token"/>', which is offered by a
             provider plugin.
             <para/>
-            The result of <see cref="M:Pulumi.IDeployment.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
+            The result of <see cref="M:Pulumi.IDeployment.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
             result value of the provider plugin that returns a bag of properties with a single value that is returned.
             <para/>
             The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
             <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
             </summary>
         </member>
-        <member name="M:Pulumi.IDeployment.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+        <member name="M:Pulumi.IDeployment.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <summary>
-            Same as <see cref="M:Pulumi.IDeployment.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/>, however the
+            Same as <see cref="M:Pulumi.IDeployment.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/>, however the
             return value is ignored.
             </summary>
         </member>
-        <member name="M:Pulumi.IDeployment.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions)">
+        <member name="M:Pulumi.IDeployment.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,Pulumi.RegisterPackageRequest)">
             <summary>
             Dynamically calls the function '<paramref name="token"/>', which is offered by a
-            provider plugin. <see cref="M:Pulumi.IDeployment.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions)"/> returns immediately while the operation takes
+            provider plugin. <see cref="M:Pulumi.IDeployment.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,Pulumi.RegisterPackageRequest)"/> returns immediately while the operation takes
             place asynchronously in the background, similar to Resource constructors.
             <para/>
-            The result of <see cref="M:Pulumi.IDeployment.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions)"/> will be a <see cref="T:Pulumi.Output`1"/> resolved to the
+            The result of <see cref="M:Pulumi.IDeployment.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:Pulumi.Output`1"/> resolved to the
             result value of the provider plugin.
             <para/>
             The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
             <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
             </summary>
         </member>
-        <member name="M:Pulumi.IDeployment.Call(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions)">
+        <member name="M:Pulumi.IDeployment.Call(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,Pulumi.RegisterPackageRequest)">
             <summary>
-            Same as <see cref="M:Pulumi.IDeployment.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions)"/>, however the return value is ignored.
+            Same as <see cref="M:Pulumi.IDeployment.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,Pulumi.RegisterPackageRequest)"/>, however the return value is ignored.
             </summary>
         </member>
         <member name="T:Pulumi.InvokeOptions">
             <summary>
-            Options to help control the behavior of <see cref="M:Pulumi.IDeployment.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/>.
+            Options to help control the behavior of <see cref="M:Pulumi.IDeployment.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/>.
             </summary>
         </member>
         <member name="P:Pulumi.InvokeOptions.Parent">

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -1265,7 +1265,7 @@
              in which case an internal TestStack is used to create the resources.
             
              This function takes the created resources from the TestStack and filters it out of the created resources
-             (since it is internal) and obtains the outputs returned, if any from that TestStack.
+             (since it is internal) and obtains the outputs returned, if any from that TestStack. 
              </summary>
              <param name="resources">The created resources from TestAsync</param>
              <returns>Resources and outputs</returns>
@@ -1274,7 +1274,7 @@
             <summary>
             Entry point to test a Pulumi application. Deployment will
             run the provided function that creates resources but doesn't actually deploy them
-            Note: Currently, unit tests that call this function
+            Note: Currently, unit tests that call this function 
             must run serially; parallel execution is not supported.
             </summary>
             <param name="testMocks">Hooks to mock the engine calls.</param>
@@ -1286,7 +1286,7 @@
             <summary>
             Entry point to test a Pulumi application. Deployment will
             run the provided function that creates resources but doesn't actually deploy them
-            Note: Currently, unit tests that call this function
+            Note: Currently, unit tests that call this function 
             must run serially; parallel execution is not supported.
             </summary>
             <param name="testMocks">Hooks to mock the engine calls.</param>
@@ -1298,7 +1298,7 @@
             <summary>
             Entry point to test a Pulumi application. Deployment will
             run the provided function that creates resources but doesn't actually deploy them
-            Note: Currently, unit tests that call this function
+            Note: Currently, unit tests that call this function 
             must run serially; parallel execution is not supported.
             </summary>
             <param name="testMocks">Hooks to mock the engine calls.</param>
@@ -1310,7 +1310,7 @@
             <summary>
             Entry point to test a Pulumi application. Deployment will
             run the provided function that creates resources but doesn't actually deploy them
-            Note: Currently, unit tests that call this function
+            Note: Currently, unit tests that call this function 
             must run serially; parallel execution is not supported.
             </summary>
             <param name="testMocks">Hooks to mock the engine calls.</param>
@@ -1767,6 +1767,23 @@
             deployments and may be missing (unknown) during planning phases.
             </summary>
         </member>
+        <member name="M:Pulumi.CustomResource.#ctor(System.String,System.String,Pulumi.ResourceArgs,Pulumi.CustomResourceOptions,Pulumi.RegisterPackageRequest)">
+            <summary>
+            Creates and registers a new managed resource.  <paramref name="type"/> is the fully
+            qualified type token and <paramref name="name"/> is the "name" part to use in creating a
+            stable and globally unique URN for the object.  <see cref="P:Pulumi.ResourceOptions.DependsOn"/>
+            is an optional list of other resources that this resource depends on, controlling the
+            order in which we perform resource operations.  Creating an instance does not necessarily
+            perform a create on the physical entity which it represents, and instead, this is
+            dependent upon the diffing of the new goal state compared to the current known resource
+            state.
+            </summary>
+            <param name="type">The type of the resource.</param>
+            <param name="name">The unique name of the resource.</param>
+            <param name="args">The arguments to use to populate the new resource.</param>
+            <param name="options">A bag of options that control this resource's behavior.</param>
+            <param name="registerPackageRequest">Package parameterization options</param>
+        </member>
         <member name="M:Pulumi.CustomResource.#ctor(System.String,System.String,Pulumi.ResourceArgs,Pulumi.CustomResourceOptions)">
             <summary>
             Creates and registers a new managed resource.  <paramref name="type"/> is the fully
@@ -1783,7 +1800,7 @@
             <param name="args">The arguments to use to populate the new resource.</param>
             <param name="options">A bag of options that control this resource's behavior.</param>
         </member>
-        <member name="M:Pulumi.CustomResource.#ctor(System.String,System.String,Pulumi.ResourceArgs,Pulumi.CustomResourceOptions,System.Boolean)">
+        <member name="M:Pulumi.CustomResource.#ctor(System.String,System.String,Pulumi.ResourceArgs,Pulumi.CustomResourceOptions,System.Boolean,Pulumi.RegisterPackageRequest)">
             <summary>
             Creates and registers a new managed resource.  <paramref name="type"/> is the fully
             qualified type token and <paramref name="name"/> is the "name" part to use in creating a
@@ -1799,6 +1816,7 @@
             <param name="args">The arguments to use to populate the new resource.</param>
             <param name="options">A bag of options that control this resource's behavior.</param>
             <param name="dependency">True if this is a synthetic resource used internally for dependency tracking.</param>
+            <param name="registerPackageRequest">Package parameterization options</param>
         </member>
         <member name="T:Pulumi.CustomResourceOptions">
             <summary>
@@ -1964,7 +1982,7 @@
             including the usual diffing and update semantics.
             </summary>
         </member>
-        <member name="M:Pulumi.ProviderResource.#ctor(System.String,System.String,Pulumi.ResourceArgs,Pulumi.CustomResourceOptions)">
+        <member name="M:Pulumi.ProviderResource.#ctor(System.String,System.String,Pulumi.ResourceArgs,Pulumi.CustomResourceOptions,Pulumi.RegisterPackageRequest)">
             <summary>
             Creates and registers a new provider resource for a particular package.
             </summary>
@@ -1972,8 +1990,9 @@
             <param name="name">The unique name of the provider.</param>
             <param name="args">The configuration to use for this provider.</param>
             <param name="options">A bag of options that control this provider's behavior.</param>
+            <param name="registerPackageRequest">Options for package parameterization</param>
         </member>
-        <member name="M:Pulumi.ProviderResource.#ctor(System.String,System.String,Pulumi.ResourceArgs,Pulumi.CustomResourceOptions,System.Boolean)">
+        <member name="M:Pulumi.ProviderResource.#ctor(System.String,System.String,Pulumi.ResourceArgs,Pulumi.CustomResourceOptions,System.Boolean,Pulumi.RegisterPackageRequest)">
             <summary>
             Creates and registers a new provider resource for a particular package.
             </summary>
@@ -1982,6 +2001,7 @@
             <param name="args">The configuration to use for this provider.</param>
             <param name="options">A bag of options that control this provider's behavior.</param>
             <param name="dependency">True if this is a synthetic resource used internally for dependency tracking.</param>
+            <param name="registerPackageRequest">Options for package parameterization.</param>
         </member>
         <member name="F:Pulumi.RegisterPackageRequest.PackageParameterization.Name">
             <summary>

--- a/sdk/Pulumi/Resources/CustomResource.cs
+++ b/sdk/Pulumi/Resources/CustomResource.cs
@@ -34,9 +34,40 @@ namespace Pulumi
         /// <param name="name">The unique name of the resource.</param>
         /// <param name="args">The arguments to use to populate the new resource.</param>
         /// <param name="options">A bag of options that control this resource's behavior.</param>
+        /// <param name="registerPackageRequest">Package parameterization options</param>
 #pragma warning disable RS0022 // Constructor make noninheritable base class inheritable
-        public CustomResource(string type, string name, ResourceArgs? args, CustomResourceOptions? options = null)
-            : this(type, name, args, options, dependency: false)
+        public CustomResource(
+            string type,
+            string name,
+            ResourceArgs? args,
+            CustomResourceOptions? options = null,
+            RegisterPackageRequest? registerPackageRequest = null)
+            : this(type, name, args, options, dependency: false, registerPackageRequest)
+#pragma warning restore RS0022 // Constructor make noninheritable base class inheritable
+        {
+        }
+
+        /// <summary>
+        /// Creates and registers a new managed resource.  <paramref name="type"/> is the fully
+        /// qualified type token and <paramref name="name"/> is the "name" part to use in creating a
+        /// stable and globally unique URN for the object.  <see cref="ResourceOptions.DependsOn"/>
+        /// is an optional list of other resources that this resource depends on, controlling the
+        /// order in which we perform resource operations.  Creating an instance does not necessarily
+        /// perform a create on the physical entity which it represents, and instead, this is
+        /// dependent upon the diffing of the new goal state compared to the current known resource
+        /// state.
+        /// </summary>
+        /// <param name="type">The type of the resource.</param>
+        /// <param name="name">The unique name of the resource.</param>
+        /// <param name="args">The arguments to use to populate the new resource.</param>
+        /// <param name="options">A bag of options that control this resource's behavior.</param>
+#pragma warning disable RS0022 // Constructor make noninheritable base class inheritable
+        public CustomResource(
+            string type,
+            string name,
+            ResourceArgs? args,
+            CustomResourceOptions? options = null)
+            : this(type, name, args, options, dependency: false, null)
 #pragma warning restore RS0022 // Constructor make noninheritable base class inheritable
         {
         }
@@ -56,10 +87,16 @@ namespace Pulumi
         /// <param name="args">The arguments to use to populate the new resource.</param>
         /// <param name="options">A bag of options that control this resource's behavior.</param>
         /// <param name="dependency">True if this is a synthetic resource used internally for dependency tracking.</param>
+        /// <param name="registerPackageRequest">Package parameterization options</param>
         private protected CustomResource(
-            string type, string name, ResourceArgs? args, CustomResourceOptions? options = null, bool dependency = false)
+            string type,
+            string name,
+            ResourceArgs? args,
+            CustomResourceOptions? options = null,
+            bool dependency = false,
+            RegisterPackageRequest? registerPackageRequest = null)
             : base(type, name, custom: true, args ?? ResourceArgs.Empty, options ?? new CustomResourceOptions(),
-                   remote: false, dependency: dependency)
+                   remote: false, dependency: dependency, registerPackageRequest)
         {
         }
     }

--- a/sdk/Pulumi/Resources/ProviderResource.cs
+++ b/sdk/Pulumi/Resources/ProviderResource.cs
@@ -23,7 +23,7 @@ namespace Pulumi
         /// <param name="name">The unique name of the provider.</param>
         /// <param name="args">The configuration to use for this provider.</param>
         /// <param name="options">A bag of options that control this provider's behavior.</param>
-        /// <param name="registerPackageRequest">Options for package parameterization</param>
+        /// <param name="registerPackageRequest">Options for package parameterization.</param>
         public ProviderResource(
             string package,
             string name,

--- a/sdk/Pulumi/Resources/ProviderResource.cs
+++ b/sdk/Pulumi/Resources/ProviderResource.cs
@@ -23,8 +23,14 @@ namespace Pulumi
         /// <param name="name">The unique name of the provider.</param>
         /// <param name="args">The configuration to use for this provider.</param>
         /// <param name="options">A bag of options that control this provider's behavior.</param>
-        public ProviderResource(string package, string name, ResourceArgs args, CustomResourceOptions? options = null)
-            : this(package, name, args, options, dependency: false)
+        /// <param name="registerPackageRequest">Options for package parameterization</param>
+        public ProviderResource(
+            string package,
+            string name,
+            ResourceArgs args,
+            CustomResourceOptions? options = null,
+            RegisterPackageRequest? registerPackageRequest = null)
+            : this(package, name, args, options, dependency: false, registerPackageRequest)
         {
         }
 
@@ -36,9 +42,10 @@ namespace Pulumi
         /// <param name="args">The configuration to use for this provider.</param>
         /// <param name="options">A bag of options that control this provider's behavior.</param>
         /// <param name="dependency">True if this is a synthetic resource used internally for dependency tracking.</param>
+        /// <param name="registerPackageRequest">Options for package parameterization.</param>
         private protected ProviderResource(
             string package, string name,
-            ResourceArgs args, CustomResourceOptions? options = null, bool dependency = false)
+            ResourceArgs args, CustomResourceOptions? options = null, bool dependency = false, RegisterPackageRequest? registerPackageRequest = null)
             : base($"pulumi:providers:{package}", name, args, options, dependency)
         {
             this.Package = package;

--- a/sdk/Pulumi/Resources/RegisterPackageRequest.cs
+++ b/sdk/Pulumi/Resources/RegisterPackageRequest.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+
+namespace Pulumi;
+
+public sealed class RegisterPackageRequest
+{
+    public sealed class PackageParameterization
+    {
+        /// <summary>
+        /// The name of the parameterized package
+        /// </summary>
+        public readonly string Name;
+        /// <summary>
+        /// The version of the parameterized package
+        /// </summary>
+        public readonly string Version;
+        /// <summary>
+        /// The paramter value for the parameterized package
+        /// </summary>
+        public readonly byte[] Value;
+
+        public PackageParameterization(string name, string version, byte[] value)
+        {
+            Name = name;
+            Version = version;
+            Value = value;
+        }
+    }
+
+    /// <summary>
+    /// The plugin name
+    /// </summary>
+    public readonly string Name;
+    /// <summary>
+    /// The plugin version
+    /// </summary>
+    public readonly string Version;
+    /// <summary>
+    /// the optional plugin download url.
+    /// </summary>
+    public readonly string DownloadUrl;
+    /// <summary>
+    /// the optional plugin checksums
+    /// </summary>
+    public readonly Dictionary<string, byte[]> Checksums;
+
+    public readonly PackageParameterization? Parameterization;
+
+    public RegisterPackageRequest(
+        string name,
+        string version,
+        string? downloadUrl,
+        Dictionary<string, byte[]>? checksums = null,
+        PackageParameterization? parameterization = null)
+    {
+        Name = name;
+        Version = version;
+        DownloadUrl = downloadUrl ?? "";
+        Checksums = checksums ?? new Dictionary<string, byte[]>();
+        Parameterization = parameterization;
+    }
+}

--- a/sdk/Pulumi/Resources/Resource.cs
+++ b/sdk/Pulumi/Resources/Resource.cs
@@ -124,7 +124,7 @@ namespace Pulumi
         /// <param name="options">A bag of options that control this resource's behavior.</param>
         /// <param name="remote">True if this is a remote component resource.</param>
         /// <param name="dependency">True if this is a synthetic resource used internally for dependency tracking.</param>
-        /// <param name="registerPackageRequest">Options for package parameterization</param>
+        /// <param name="registerPackageRequest">Options for package parameterization.</param>
         private protected Resource(
             string type, string name, bool custom,
             ResourceArgs args, ResourceOptions options,

--- a/sdk/Pulumi/Resources/Resource.cs
+++ b/sdk/Pulumi/Resources/Resource.cs
@@ -124,10 +124,11 @@ namespace Pulumi
         /// <param name="options">A bag of options that control this resource's behavior.</param>
         /// <param name="remote">True if this is a remote component resource.</param>
         /// <param name="dependency">True if this is a synthetic resource used internally for dependency tracking.</param>
+        /// <param name="registerPackageRequest">Options for package parameterization</param>
         private protected Resource(
             string type, string name, bool custom,
             ResourceArgs args, ResourceOptions options,
-            bool remote = false, bool dependency = false)
+            bool remote = false, bool dependency = false, RegisterPackageRequest? registerPackageRequest = null)
         {
             if (dependency)
             {
@@ -270,7 +271,13 @@ namespace Pulumi
             }
 
             this._aliases = aliases.ToImmutableArray();
-            Deployment.InternalInstance.ReadOrRegisterResource(this, remote, urn => new DependencyResource(urn), args, options);
+            Deployment.InternalInstance.ReadOrRegisterResource(
+                resource: this,
+                remote: remote,
+                newDependency: urn => new DependencyResource(urn),
+                args: args,
+                opts: options,
+                registerPackageRequest: registerPackageRequest);
         }
 
         /// <summary>

--- a/sdk/Pulumi/Testing/MockMonitor.cs
+++ b/sdk/Pulumi/Testing/MockMonitor.cs
@@ -77,6 +77,14 @@ namespace Pulumi.Testing
             return new CallResponse { Return = await SerializeAsync(result).ConfigureAwait(false) };
         }
 
+        public Task<RegisterPackageResponse> RegisterPackageAsync(Pulumirpc.RegisterPackageRequest request)
+        {
+            return Task.FromResult(new RegisterPackageResponse
+            {
+                Ref = $"{request.Name}-{request.Version}"
+            });
+        }
+
         public async Task<ReadResourceResponse> ReadResourceAsync(Resource resource, ReadResourceRequest request)
         {
             var (id, state) = await _mocks.NewResourceAsync(new MockResourceArgs


### PR DESCRIPTION
This PR extends the SDK to support parameterized providers, accepting a `RegisterPackageRequest` in `Read`, `RegisterResource`, `Call` and `Invoke` such that we can (lazily) register a parameterized package, retrieve its reference from the engine and use it in the request of these operations.

Addresses https://github.com/pulumi/pulumi/issues/16798