### PR TITLE
add a note about bumping the version in pulumi/pulumi

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,3 +27,5 @@ $ changie merge
 $ git add .
 $ git commit -m "Changelog for $(changie latest)"
 ```
+
+After the release, also bump the version in `pulumi/pulumi`.  It needs to be bumped both in `scripts/get-language-providers.sh` and `pkg/codegen/testing/test/helpers.go`.  Especially if the latter is not bumped, codegen tests will start failing once providers start requiring the new pulumi-dotnet version. See https://github.com/pulumi/pulumi/pull/16919/files for example.


### PR DESCRIPTION
If this is not bumped, codegen tests eventually start failing once providers start requiring the newer version.