### PR TITLE
Fix binary compatibility with provider SDKs built using older version of the core SDK

### DIFF
--- a/.changes/unreleased/Bug Fixes-318.yaml
+++ b/.changes/unreleased/Bug Fixes-318.yaml
@@ -1,6 +1,6 @@
 component: sdk
 kind: Bug Fixes
-body: Fix binary compatiblity with provider SDKs built using older version of the core SDK
+body: Fix binary compatibility with provider SDKs built using older version of the core SDK
 time: 2024-08-09T19:05:20.54029+02:00
 custom:
     PR: "318"

--- a/.changes/unreleased/Bug Fixes-318.yaml
+++ b/.changes/unreleased/Bug Fixes-318.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Bug Fixes
+body: Fix binary compatiblity with provider SDKs built using older version of the core SDK
+time: 2024-08-09T19:05:20.54029+02:00
+custom:
+    PR: "318"

--- a/sdk/Pulumi.Tests/Resources/ComponentResourceTests.cs
+++ b/sdk/Pulumi.Tests/Resources/ComponentResourceTests.cs
@@ -25,7 +25,8 @@ namespace Pulumi.Tests.Resources
                 var provider = new ProviderResource(
                     "test",
                     "prov",
-                    ResourceArgs.Empty
+                    ResourceArgs.Empty,
+                    null
                 );
 
                 // The Provider is passed in to the ComponentResource,
@@ -68,7 +69,8 @@ namespace Pulumi.Tests.Resources
                 var provider = new ProviderResource(
                     "test",
                     "prov",
-                    ResourceArgs.Empty
+                    ResourceArgs.Empty,
+                    null
                 );
 
                 // The Provider is passed in to the ComponentResource

--- a/sdk/Pulumi/Deployment/DeploymentInstance.cs
+++ b/sdk/Pulumi/Deployment/DeploymentInstance.cs
@@ -34,115 +34,113 @@ namespace Pulumi
         /// </summary>
         public bool IsDryRun => _deployment.IsDryRun;
 
-        /// <summary>
-        /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
-        /// provider plugin.
-        /// <para/>
-        /// The result of <see cref="Invoke"/> will be a <see cref="Output"/> resolved to the
-        /// result value of the provider plugin.
-        /// <para/>
-        /// Similar to the earlier <see cref="InvokeAsync"/>, but supports passing input values
-        /// and returns an Output value.
-        /// <para/>
-        /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
-        /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
-        /// </summary>
+        /// <inheritdoc />
         public Output<T> Invoke<T>(
             string token,
             InvokeArgs args,
-            InvokeOptions? options = null,
-            RegisterPackageRequest? registerPackageRequest = null)
+            InvokeOptions? options,
+            RegisterPackageRequest? registerPackageRequest)
             => _deployment.Invoke<T>(token, args, options, registerPackageRequest);
 
-        /// <summary>
-        /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
-        /// provider plugin.
-        /// <para/>
-        /// The result of <see cref="InvokeSingle"/> will be a <see cref="Output"/> resolved to the
-        /// result value of the provider plugin.
-        /// <para/>
-        /// Similar to the earlier <see cref="InvokeSingleAsync"/>, but supports passing input values
-        /// and returns an Output value.
-        /// <para/>
-        /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
-        /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
-        /// </summary>
+        /// <inheritdoc />
+        public Output<T> Invoke<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options = null)
+            => _deployment.Invoke<T>(token, args, options, null);
+
+        /// <inheritdoc />
         public Output<T> InvokeSingle<T>(
             string token,
             InvokeArgs args,
-            InvokeOptions? options = null,
-            RegisterPackageRequest? registerPackageRequest = null)
+            InvokeOptions? options,
+            RegisterPackageRequest? registerPackageRequest)
             => _deployment.InvokeSingle<T>(token, args, options, registerPackageRequest);
 
-        /// <summary>
-        /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
-        /// provider plugin.
-        /// <para/>
-        /// The result of <see cref="InvokeAsync"/> will be a <see cref="Task"/> resolved to the
-        /// result value of the provider plugin.
-        /// <para/>
-        /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
-        /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
-        /// </summary>
+        /// <inheritdoc />
+        public Output<T> InvokeSingle<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options = null)
+            => _deployment.InvokeSingle<T>(token, args, options, null);
+
+        /// <inheritdoc />
         public Task<T> InvokeAsync<T>(
             string token,
             InvokeArgs args,
-            InvokeOptions? options = null,
-            RegisterPackageRequest? registerPackageRequest = null)
+            InvokeOptions? options,
+            RegisterPackageRequest? registerPackageRequest)
             => _deployment.InvokeAsync<T>(token, args, options, registerPackageRequest);
 
-        /// <summary>
-        /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
-        /// provider plugin.
-        /// <para/>
-        /// The result of <see cref="InvokeSingleAsync"/> will be a <see cref="Task"/> resolved to the
-        /// result value of the provider plugin which is expected to be a dictionary with single value.
-        /// <para/>
-        /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
-        /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
-        /// </summary>
+        /// <inheritdoc />
+        public Task<T> InvokeAsync<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options = null)
+            => _deployment.InvokeAsync<T>(token, args, options, null);
+
+        /// <inheritdoc />
         public Task<T> InvokeSingleAsync<T>(
             string token,
             InvokeArgs args,
-            InvokeOptions? options = null,
-            RegisterPackageRequest? registerPackageRequest = null)
+            InvokeOptions? options,
+            RegisterPackageRequest? registerPackageRequest)
             => _deployment.InvokeSingleAsync<T>(token, args, options, registerPackageRequest);
+
+        /// <inheritdoc />
+        public Task<T> InvokeSingleAsync<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options = null)
+            => _deployment.InvokeSingleAsync<T>(token, args, options, null);
 
         /// <summary>
         /// Same as <see cref="InvokeAsync{T}(string, InvokeArgs, InvokeOptions, RegisterPackageRequest)"/>, however the
         /// return value is ignored.
         /// </summary>
-        public Task InvokeAsync(string token, InvokeArgs args, InvokeOptions? options = null, RegisterPackageRequest? registerPackageRequest = null)
+        public Task InvokeAsync(string token, InvokeArgs args, InvokeOptions? options, RegisterPackageRequest? registerPackageRequest)
             => _deployment.InvokeAsync(token, args, options, registerPackageRequest);
 
         /// <summary>
-        /// Dynamically calls the function '<paramref name="token"/>', which is offered by a
-        /// provider plugin.
-        /// <para/>
-        /// The result of <see cref="Call{T}"/> will be a <see cref="Output{T}"/> resolved to the
-        /// result value of the provider plugin.
-        /// <para/>
-        /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
-        /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
+        /// Same as <see cref="InvokeAsync{T}(string, InvokeArgs, InvokeOptions, RegisterPackageRequest)"/>, however the
+        /// return value is ignored.
         /// </summary>
+        public Task InvokeAsync(string token, InvokeArgs args, InvokeOptions? options = null)
+            => _deployment.InvokeAsync(token, args, options, null);
+
+        /// <inheritdoc />
+        public Output<T> Call<T>(
+            string token,
+            CallArgs args,
+            Resource? self,
+            CallOptions? options,
+            RegisterPackageRequest? registerPackageRequest)
+            => _deployment.Call<T>(token, args, self, options, registerPackageRequest);
+
+        /// <inheritdoc />
         public Output<T> Call<T>(
             string token,
             CallArgs args,
             Resource? self = null,
-            CallOptions? options = null,
-            RegisterPackageRequest? registerPackageRequest = null)
-            => _deployment.Call<T>(token, args, self, options, registerPackageRequest);
+            CallOptions? options = null)
+            => _deployment.Call<T>(token, args, self, options, null);
 
-        /// <summary>
-        /// Same as <see cref="Call{T}"/>, however the return value is ignored.
-        /// </summary>
+        /// <inheritdoc />
+        public void Call(
+            string token,
+            CallArgs args,
+            Resource? self,
+            CallOptions? options,
+            RegisterPackageRequest? registerPackageRequest)
+            => _deployment.Call(token, args, self, options, registerPackageRequest);
+
+        /// <inheritdoc />
         public void Call(
             string token,
             CallArgs args,
             Resource? self = null,
-            CallOptions? options = null,
-            RegisterPackageRequest? registerPackageRequest = null)
-            => _deployment.Call(token, args, self, options, registerPackageRequest);
+            CallOptions? options = null)
+            => _deployment.Call(token, args, self, options, null);
 
         internal IDeploymentInternal Internal => (IDeploymentInternal)_deployment;
     }

--- a/sdk/Pulumi/Deployment/Deployment_Call.cs
+++ b/sdk/Pulumi/Deployment/Deployment_Call.cs
@@ -19,6 +19,13 @@ namespace Pulumi
             RegisterPackageRequest? registerPackageRequest)
             => Call<object>(token, args, self, options, convertResult: false, registerPackageRequest);
 
+        void IDeployment.Call(
+            string token,
+            CallArgs args,
+            Resource? self,
+            CallOptions? options)
+            => Call<object>(token, args, self, options, convertResult: false, registerPackageRequest: null);
+
         Output<T> IDeployment.Call<T>(
             string token,
             CallArgs args,
@@ -26,6 +33,13 @@ namespace Pulumi
             CallOptions? options,
             RegisterPackageRequest? registerPackageRequest)
             => Call<T>(token, args, self, options, convertResult: true, registerPackageRequest);
+
+        Output<T> IDeployment.Call<T>(
+            string token,
+            CallArgs args,
+            Resource? self,
+            CallOptions? options)
+            => Call<T>(token, args, self, options, convertResult: true, registerPackageRequest: null);
 
         private Output<T> Call<T>(
             string token,

--- a/sdk/Pulumi/Deployment/Deployment_Invoke.cs
+++ b/sdk/Pulumi/Deployment/Deployment_Invoke.cs
@@ -16,8 +16,14 @@ namespace Pulumi
         Task IDeployment.InvokeAsync(string token, InvokeArgs args, InvokeOptions? options, RegisterPackageRequest? registerPackageRequest)
             => InvokeAsync<object>(token, args, options, convertResult: false);
 
+        Task IDeployment.InvokeAsync(string token, InvokeArgs args, InvokeOptions? options)
+            => InvokeAsync<object>(token, args, options, convertResult: false, registerPackageRequest: null);
+
         Task<T> IDeployment.InvokeAsync<T>(string token, InvokeArgs args, InvokeOptions? options, RegisterPackageRequest? registerPackageRequest)
             => InvokeAsync<T>(token, args, options, convertResult: true);
+
+        Task<T> IDeployment.InvokeAsync<T>(string token, InvokeArgs args, InvokeOptions? options)
+            => InvokeAsync<T>(token, args, options, convertResult: false, registerPackageRequest: null);
 
         async Task<T> IDeployment.InvokeSingleAsync<T>(
             string token,
@@ -29,12 +35,29 @@ namespace Pulumi
             return outputs.Values.First();
         }
 
+        async Task<T> IDeployment.InvokeSingleAsync<T>(string token, InvokeArgs args, InvokeOptions? options)
+        {
+            var outputs = await InvokeAsync<Dictionary<string, T>>(
+                token: token,
+                args: args,
+                options: options,
+                convertResult: true,
+                registerPackageRequest: null);
+
+            return outputs.Values.First();
+        }
+
         Output<T> IDeployment.Invoke<T>(
             string token,
             InvokeArgs args,
             InvokeOptions? options,
             RegisterPackageRequest? registerPackageRequest)
             => new Output<T>(RawInvoke<T>(token, args, options, registerPackageRequest));
+
+        Output<T> IDeployment.Invoke<T>(string token, InvokeArgs args, InvokeOptions? options)
+            => new Output<T>(RawInvoke<T>(token, args, options, registerPackageRequest: null));
+
+
 
         Output<T> IDeployment.InvokeSingle<T>(
             string token,
@@ -43,6 +66,13 @@ namespace Pulumi
             RegisterPackageRequest? registerPackageRequest)
         {
             var outputResult = new Output<Dictionary<string, T>>(RawInvoke<Dictionary<string, T>>(token, args, options, registerPackageRequest));
+            return outputResult.Apply(outputs => outputs.Values.First());
+        }
+
+        Output<T> IDeployment.InvokeSingle<T>(string token, InvokeArgs args, InvokeOptions? options)
+        {
+            var outputResult = new Output<Dictionary<string, T>>(
+                RawInvoke<Dictionary<string, T>>(token, args, options, registerPackageRequest: null));
             return outputResult.Apply(outputs => outputs.Values.First());
         }
 

--- a/sdk/Pulumi/Deployment/IDeployment.cs
+++ b/sdk/Pulumi/Deployment/IDeployment.cs
@@ -30,7 +30,7 @@ namespace Pulumi
         /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
         /// provider plugin.
         /// <para/>
-        /// The result of <see cref="InvokeAsync"/> will be a <see cref="Task"/> resolved to the
+        /// The result of <see cref="InvokeAsync(string, InvokeArgs, InvokeOptions)"/> will be a <see cref="Task"/> resolved to the
         /// result value of the provider plugin.
         /// <para/>
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
@@ -39,14 +39,29 @@ namespace Pulumi
         Task<T> InvokeAsync<T>(
             string token,
             InvokeArgs args,
-            InvokeOptions? options = null,
-            RegisterPackageRequest? registerPackageRequest = null);
+            InvokeOptions? options = null);
 
         /// <summary>
         /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
         /// provider plugin.
         /// <para/>
-        /// The result of <see cref="InvokeSingleAsync"/> will be a <see cref="Task"/> resolved to the
+        /// The result of <see cref="InvokeAsync(string, InvokeArgs, InvokeOptions, RegisterPackageRequest)"/> will be a <see cref="Task"/> resolved to the
+        /// result value of the provider plugin.
+        /// <para/>
+        /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+        /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
+        /// </summary>
+        Task<T> InvokeAsync<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? option,
+            RegisterPackageRequest? registerPackageRequest);
+
+        /// <summary>
+        /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
+        /// provider plugin.
+        /// <para/>
+        /// The result of <see cref="InvokeSingleAsync{T}(string, InvokeArgs, InvokeOptions, RegisterPackageRequest)"/> will be a <see cref="Task"/> resolved to the
         /// result value of the provider plugin that returns a bag of properties with a single value that is returned.
         /// <para/>
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
@@ -55,14 +70,29 @@ namespace Pulumi
         Task<T> InvokeSingleAsync<T>(
             string token,
             InvokeArgs args,
-            InvokeOptions? options = null,
-            RegisterPackageRequest? registerPackageRequest = null);
+            InvokeOptions? options,
+            RegisterPackageRequest? registerPackageRequest);
 
         /// <summary>
         /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
         /// provider plugin.
         /// <para/>
-        /// The result of <see cref="Invoke"/> will be a <see cref="Output"/> resolved to the
+        /// The result of <see cref="InvokeSingleAsync{T}(string, InvokeArgs, InvokeOptions)"/> will be a <see cref="Task"/> resolved to the
+        /// result value of the provider plugin that returns a bag of properties with a single value that is returned.
+        /// <para/>
+        /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+        /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
+        /// </summary>
+        Task<T> InvokeSingleAsync<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options = null);
+
+        /// <summary>
+        /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
+        /// provider plugin.
+        /// <para/>
+        /// The result of <see cref="Invoke{T}(string, InvokeArgs, InvokeOptions)"/> will be a <see cref="Output"/> resolved to the
         /// result value of the provider plugin.
         /// <para/>
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
@@ -71,14 +101,29 @@ namespace Pulumi
         Output<T> Invoke<T>(
             string token,
             InvokeArgs args,
-            InvokeOptions? options = null,
-            RegisterPackageRequest? registerPackageRequest = null);
+            InvokeOptions? options = null);
 
         /// <summary>
         /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
         /// provider plugin.
         /// <para/>
-        /// The result of <see cref="InvokeSingle"/> will be a <see cref="Output"/> resolved to the
+        /// The result of <see cref="Invoke{T}(string, InvokeArgs, InvokeOptions, RegisterPackageRequest)"/> will be a <see cref="Output"/> resolved to the
+        /// result value of the provider plugin.
+        /// <para/>
+        /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+        /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
+        /// </summary>
+        Output<T> Invoke<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options,
+            RegisterPackageRequest? registerPackageRequest);
+
+        /// <summary>
+        /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
+        /// provider plugin.
+        /// <para/>
+        /// The result of <see cref="InvokeSingle{T}(string, InvokeArgs, InvokeOptions)"/> will be a <see cref="Output"/> resolved to the
         /// result value of the provider plugin that returns a bag of properties with a single value that is returned.
         /// <para/>
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
@@ -87,8 +132,32 @@ namespace Pulumi
         Output<T> InvokeSingle<T>(
             string token,
             InvokeArgs args,
-            InvokeOptions? options = null,
-            RegisterPackageRequest? registerPackageRequest = null);
+            InvokeOptions? options = null);
+
+        /// <summary>
+        /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
+        /// provider plugin.
+        /// <para/>
+        /// The result of <see cref="InvokeSingle{T}(string, InvokeArgs, InvokeOptions, RegisterPackageRequest)"/> will be a <see cref="Output"/> resolved to the
+        /// result value of the provider plugin that returns a bag of properties with a single value that is returned.
+        /// <para/>
+        /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+        /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
+        /// </summary>
+        Output<T> InvokeSingle<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options,
+            RegisterPackageRequest? registerPackageRequest);
+
+        /// <summary>
+        /// Same as <see cref="InvokeAsync{T}(string, InvokeArgs, InvokeOptions)"/>, however the
+        /// return value is ignored.
+        /// </summary>
+        Task InvokeAsync(
+            string token,
+            InvokeArgs args,
+            InvokeOptions? options = null);
 
         /// <summary>
         /// Same as <see cref="InvokeAsync{T}(string, InvokeArgs, InvokeOptions, RegisterPackageRequest)"/>, however the
@@ -97,15 +166,15 @@ namespace Pulumi
         Task InvokeAsync(
             string token,
             InvokeArgs args,
-            InvokeOptions? options = null,
-            RegisterPackageRequest? registerPackageRequest = null);
+            InvokeOptions? options,
+            RegisterPackageRequest? registerPackageRequest);
 
         /// <summary>
         /// Dynamically calls the function '<paramref name="token"/>', which is offered by a
-        /// provider plugin. <see cref="Call{T}"/> returns immediately while the operation takes
+        /// provider plugin. <see cref="Call{T}(string, CallArgs, Resource, CallOptions)"/> returns immediately while the operation takes
         /// place asynchronously in the background, similar to Resource constructors.
         /// <para/>
-        /// The result of <see cref="Call{T}"/> will be a <see cref="Output{T}"/> resolved to the
+        /// The result of <see cref="Call{T}(string, CallArgs, Resource, CallOptions)"/> will be a <see cref="Output{T}"/> resolved to the
         /// result value of the provider plugin.
         /// <para/>
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
@@ -115,17 +184,43 @@ namespace Pulumi
             string token,
             CallArgs args,
             Resource? self = null,
-            CallOptions? options = null,
-            RegisterPackageRequest? registerPackageRequest = null);
+            CallOptions? options = null);
 
         /// <summary>
-        /// Same as <see cref="Call{T}"/>, however the return value is ignored.
+        /// Dynamically calls the function '<paramref name="token"/>', which is offered by a
+        /// provider plugin. <see cref="Call{T}(string, CallArgs, Resource, CallOptions, RegisterPackageRequest)"/> returns immediately while the operation takes
+        /// place asynchronously in the background, similar to Resource constructors.
+        /// <para/>
+        /// The result of <see cref="Call{T}(string, CallArgs, Resource, CallOptions, RegisterPackageRequest)"/> will be a <see cref="Output{T}"/> resolved to the
+        /// result value of the provider plugin.
+        /// <para/>
+        /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+        /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
+        /// </summary>
+        Output<T> Call<T>(
+            string token,
+            CallArgs args,
+            Resource? self,
+            CallOptions? options,
+            RegisterPackageRequest? registerPackageRequest);
+
+        /// <summary>
+        /// Same as <see cref="Call{T}(string, CallArgs, Resource, CallOptions)"/>, however the return value is ignored.
         /// </summary>
         void Call(
             string token,
             CallArgs args,
             Resource? self = null,
-            CallOptions? options = null,
-            RegisterPackageRequest? registerPackageRequest = null);
+            CallOptions? options = null);
+
+        /// <summary>
+        /// Same as <see cref="Call{T}(string, CallArgs, Resource, CallOptions, RegisterPackageRequest)"/>, however the return value is ignored.
+        /// </summary>
+        void Call(
+            string token,
+            CallArgs args,
+            Resource? self,
+            CallOptions? options,
+            RegisterPackageRequest? registerPackageRequest);
     }
 }

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -1383,58 +1383,28 @@
             </summary>
         </member>
         <member name="M:Pulumi.DeploymentInstance.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
-            <summary>
-            Dynamically invokes the function '<paramref name="token"/>', which is offered by a
-            provider plugin.
-            <para/>
-            The result of <see cref="M:Pulumi.DeploymentInstance.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
-            result value of the provider plugin.
-            <para/>
-            Similar to the earlier <see cref="M:Pulumi.DeploymentInstance.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/>, but supports passing input values
-            and returns an Output value.
-            <para/>
-            The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
-            <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
-            </summary>
+            <inheritdoc />
+        </member>
+        <member name="M:Pulumi.DeploymentInstance.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+            <inheritdoc />
         </member>
         <member name="M:Pulumi.DeploymentInstance.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
-            <summary>
-            Dynamically invokes the function '<paramref name="token"/>', which is offered by a
-            provider plugin.
-            <para/>
-            The result of <see cref="M:Pulumi.DeploymentInstance.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
-            result value of the provider plugin.
-            <para/>
-            Similar to the earlier <see cref="M:Pulumi.DeploymentInstance.InvokeSingleAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/>, but supports passing input values
-            and returns an Output value.
-            <para/>
-            The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
-            <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
-            </summary>
+            <inheritdoc />
+        </member>
+        <member name="M:Pulumi.DeploymentInstance.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+            <inheritdoc />
         </member>
         <member name="M:Pulumi.DeploymentInstance.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
-            <summary>
-            Dynamically invokes the function '<paramref name="token"/>', which is offered by a
-            provider plugin.
-            <para/>
-            The result of <see cref="M:Pulumi.DeploymentInstance.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:System.Threading.Tasks.Task"/> resolved to the
-            result value of the provider plugin.
-            <para/>
-            The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
-            <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
-            </summary>
+            <inheritdoc />
+        </member>
+        <member name="M:Pulumi.DeploymentInstance.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+            <inheritdoc />
         </member>
         <member name="M:Pulumi.DeploymentInstance.InvokeSingleAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
-            <summary>
-            Dynamically invokes the function '<paramref name="token"/>', which is offered by a
-            provider plugin.
-            <para/>
-            The result of <see cref="M:Pulumi.DeploymentInstance.InvokeSingleAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:System.Threading.Tasks.Task"/> resolved to the
-            result value of the provider plugin which is expected to be a dictionary with single value.
-            <para/>
-            The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
-            <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
-            </summary>
+            <inheritdoc />
+        </member>
+        <member name="M:Pulumi.DeploymentInstance.InvokeSingleAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+            <inheritdoc />
         </member>
         <member name="M:Pulumi.DeploymentInstance.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <summary>
@@ -1442,22 +1412,23 @@
             return value is ignored.
             </summary>
         </member>
-        <member name="M:Pulumi.DeploymentInstance.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,Pulumi.RegisterPackageRequest)">
+        <member name="M:Pulumi.DeploymentInstance.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
             <summary>
-            Dynamically calls the function '<paramref name="token"/>', which is offered by a
-            provider plugin.
-            <para/>
-            The result of <see cref="M:Pulumi.DeploymentInstance.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:Pulumi.Output`1"/> resolved to the
-            result value of the provider plugin.
-            <para/>
-            The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
-            <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
+            Same as <see cref="M:Pulumi.DeploymentInstance.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/>, however the
+            return value is ignored.
             </summary>
         </member>
+        <member name="M:Pulumi.DeploymentInstance.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,Pulumi.RegisterPackageRequest)">
+            <inheritdoc />
+        </member>
+        <member name="M:Pulumi.DeploymentInstance.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions)">
+            <inheritdoc />
+        </member>
         <member name="M:Pulumi.DeploymentInstance.Call(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,Pulumi.RegisterPackageRequest)">
-            <summary>
-            Same as <see cref="M:Pulumi.DeploymentInstance.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,Pulumi.RegisterPackageRequest)"/>, however the return value is ignored.
-            </summary>
+            <inheritdoc />
+        </member>
+        <member name="M:Pulumi.DeploymentInstance.Call(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions)">
+            <inheritdoc />
         </member>
         <member name="P:Pulumi.IDeployment.StackName">
             <summary>
@@ -1477,6 +1448,18 @@
         <member name="P:Pulumi.IDeployment.IsDryRun">
             <summary>
             Whether or not the application is currently being previewed or actually applied.
+            </summary>
+        </member>
+        <member name="M:Pulumi.IDeployment.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+            <summary>
+            Dynamically invokes the function '<paramref name="token"/>', which is offered by a
+            provider plugin.
+            <para/>
+            The result of <see cref="M:Pulumi.IDeployment.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/> will be a <see cref="T:System.Threading.Tasks.Task"/> resolved to the
+            result value of the provider plugin.
+            <para/>
+            The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+            <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
             </summary>
         </member>
         <member name="M:Pulumi.IDeployment.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
@@ -1503,6 +1486,30 @@
             <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
             </summary>
         </member>
+        <member name="M:Pulumi.IDeployment.InvokeSingleAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+            <summary>
+            Dynamically invokes the function '<paramref name="token"/>', which is offered by a
+            provider plugin.
+            <para/>
+            The result of <see cref="M:Pulumi.IDeployment.InvokeSingleAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/> will be a <see cref="T:System.Threading.Tasks.Task"/> resolved to the
+            result value of the provider plugin that returns a bag of properties with a single value that is returned.
+            <para/>
+            The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+            <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
+            </summary>
+        </member>
+        <member name="M:Pulumi.IDeployment.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+            <summary>
+            Dynamically invokes the function '<paramref name="token"/>', which is offered by a
+            provider plugin.
+            <para/>
+            The result of <see cref="M:Pulumi.IDeployment.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
+            result value of the provider plugin.
+            <para/>
+            The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+            <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
+            </summary>
+        </member>
         <member name="M:Pulumi.IDeployment.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <summary>
             Dynamically invokes the function '<paramref name="token"/>', which is offered by a
@@ -1510,6 +1517,18 @@
             <para/>
             The result of <see cref="M:Pulumi.IDeployment.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
             result value of the provider plugin.
+            <para/>
+            The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+            <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
+            </summary>
+        </member>
+        <member name="M:Pulumi.IDeployment.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+            <summary>
+            Dynamically invokes the function '<paramref name="token"/>', which is offered by a
+            provider plugin.
+            <para/>
+            The result of <see cref="M:Pulumi.IDeployment.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
+            result value of the provider plugin that returns a bag of properties with a single value that is returned.
             <para/>
             The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
             <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
@@ -1527,10 +1546,29 @@
             <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
             </summary>
         </member>
+        <member name="M:Pulumi.IDeployment.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+            <summary>
+            Same as <see cref="M:Pulumi.IDeployment.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/>, however the
+            return value is ignored.
+            </summary>
+        </member>
         <member name="M:Pulumi.IDeployment.InvokeAsync(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <summary>
             Same as <see cref="M:Pulumi.IDeployment.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/>, however the
             return value is ignored.
+            </summary>
+        </member>
+        <member name="M:Pulumi.IDeployment.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions)">
+            <summary>
+            Dynamically calls the function '<paramref name="token"/>', which is offered by a
+            provider plugin. <see cref="M:Pulumi.IDeployment.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions)"/> returns immediately while the operation takes
+            place asynchronously in the background, similar to Resource constructors.
+            <para/>
+            The result of <see cref="M:Pulumi.IDeployment.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions)"/> will be a <see cref="T:Pulumi.Output`1"/> resolved to the
+            result value of the provider plugin.
+            <para/>
+            The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+            <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
             </summary>
         </member>
         <member name="M:Pulumi.IDeployment.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,Pulumi.RegisterPackageRequest)">
@@ -1544,6 +1582,11 @@
             <para/>
             The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
             <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
+            </summary>
+        </member>
+        <member name="M:Pulumi.IDeployment.Call(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions)">
+            <summary>
+            Same as <see cref="M:Pulumi.IDeployment.Call``1(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions)"/>, however the return value is ignored.
             </summary>
         </member>
         <member name="M:Pulumi.IDeployment.Call(System.String,Pulumi.CallArgs,Pulumi.Resource,Pulumi.CallOptions,Pulumi.RegisterPackageRequest)">
@@ -1982,6 +2025,15 @@
             including the usual diffing and update semantics.
             </summary>
         </member>
+        <member name="M:Pulumi.ProviderResource.#ctor(System.String,System.String,Pulumi.ResourceArgs,Pulumi.CustomResourceOptions)">
+            <summary>
+            Creates and registers a new provider resource for a particular package.
+            </summary>
+            <param name="package">The package associated with this provider.</param>
+            <param name="name">The unique name of the provider.</param>
+            <param name="args">The configuration to use for this provider.</param>
+            <param name="options">A bag of options that control this provider's behavior.</param>
+        </member>
         <member name="M:Pulumi.ProviderResource.#ctor(System.String,System.String,Pulumi.ResourceArgs,Pulumi.CustomResourceOptions,Pulumi.RegisterPackageRequest)">
             <summary>
             Creates and registers a new provider resource for a particular package.
@@ -1990,7 +2042,7 @@
             <param name="name">The unique name of the provider.</param>
             <param name="args">The configuration to use for this provider.</param>
             <param name="options">A bag of options that control this provider's behavior.</param>
-            <param name="registerPackageRequest">Options for package parameterization</param>
+            <param name="registerPackageRequest">Options for package parameterization.</param>
         </member>
         <member name="M:Pulumi.ProviderResource.#ctor(System.String,System.String,Pulumi.ResourceArgs,Pulumi.CustomResourceOptions,System.Boolean,Pulumi.RegisterPackageRequest)">
             <summary>
@@ -2146,7 +2198,7 @@
             <param name="options">A bag of options that control this resource's behavior.</param>
             <param name="remote">True if this is a remote component resource.</param>
             <param name="dependency">True if this is a synthetic resource used internally for dependency tracking.</param>
-            <param name="registerPackageRequest">Options for package parameterization</param>
+            <param name="registerPackageRequest">Options for package parameterization.</param>
         </member>
         <member name="M:Pulumi.Resource.GetProvider(System.String)">
             <summary>

--- a/sdk/Pulumi/Resources/ProviderResource.cs
+++ b/sdk/Pulumi/Resources/ProviderResource.cs
@@ -23,6 +23,22 @@ namespace Pulumi
         /// <param name="name">The unique name of the provider.</param>
         /// <param name="args">The configuration to use for this provider.</param>
         /// <param name="options">A bag of options that control this provider's behavior.</param>
+        public ProviderResource(
+            string package,
+            string name,
+            ResourceArgs args,
+            CustomResourceOptions? options = null)
+            : this(package, name, args, options, dependency: false, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates and registers a new provider resource for a particular package.
+        /// </summary>
+        /// <param name="package">The package associated with this provider.</param>
+        /// <param name="name">The unique name of the provider.</param>
+        /// <param name="args">The configuration to use for this provider.</param>
+        /// <param name="options">A bag of options that control this provider's behavior.</param>
         /// <param name="registerPackageRequest">Options for package parameterization.</param>
         public ProviderResource(
             string package,


### PR DESCRIPTION
Fixes #317 

In #311 I introduced a new optional parameter for the constructor of `ProviderResource` so previously it was:
```cs
public ProviderResource(
            string package,
            string name,
            ResourceArgs args,
            CustomResourceOptions? options = null)
```
and it became:
```cs
public ProviderResource(
    string package,
    string name,
    ResourceArgs args,
    CustomResourceOptions? options = null,
    RegisterPackageRequest? registerPackageRequest = null)
```
Since the parameter is optional, I assumed that it is not a breaking change. However, when using provider SDKs built with an older version Pulumi (before v3.66.0) in combination with this new version (v3.66.0) it gives a _runtime_ error:
```
System.MissingMethodException: Method not found: 'Void Pulumi.ProviderResource..ctor(System.String, System.String, Pulumi.ResourceArgs, Pulumi.CustomResourceOptions)
```
Because the provider SDKs look for that _exact_ constructor signature, regardless of optionalness.

I was able to repro using the latest `Pulumi.Random` v4.16.3 (built with `Pulumi` v3.64.0) in combination with `Pulumi` v3.66.0, running this program (it builds correctly tho)
```cs
var randomProvider = new Random.Provider("random", new Random.ProviderArgs
{
    
});
var pet = new Random.RandomPet("pet", new ()
{
    Length = 12
}, new CustomResourceOptions
{
    Provider = randomProvider
});
```

This PR brings back that constructor signature to fix the problem