### PR TITLE
add a test showing that unknown events are handled

### DIFF
--- a/sdk/Pulumi.Automation.Tests/EventLogWatcherTests.cs
+++ b/sdk/Pulumi.Automation.Tests/EventLogWatcherTests.cs
@@ -57,6 +57,15 @@ namespace Pulumi.Automation.Tests
         }
 
         [Fact]
+        public async Task IgnoresUnknownEvents()
+        {
+            using var fx = new Fixture();
+            await fx.Write("{\"unknown\": \"event\"}");
+            await fx.Watcher.Stop();
+            Assert.Equal(1, fx.EventCounter);
+        }
+
+        [Fact]
         public async Task PermitsUserInitiatedCancellation()
         {
             using var fx = new Fixture();


### PR DESCRIPTION
We want to make sure unknown events from the engine (e.g. events that are newly added) don't break the use of the automation API in dotnet.  Add a test to verify just that.