### PR TITLE
Fix output serialisation in the provider library

### DIFF
--- a/.changes/unreleased/Bug Fixes-337.yaml
+++ b/.changes/unreleased/Bug Fixes-337.yaml
@@ -1,0 +1,6 @@
+component: sdk/provider
+kind: Bug Fixes
+body: Fix output value serialization.
+time: 2024-09-06T23:06:09.346266+01:00
+custom:
+  PR: "337"

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -832,6 +832,12 @@
             </summary>
             <param name="valueFactory">The value factory.</param>
         </member>
+        <member name="M:Pulumi.Utilities.OutputUtilities.WithDependency``1(Pulumi.Output{``0},Pulumi.Resource)">
+            <summary>
+            Create an output with the given dependency.
+            Note: generally this should never be used in normal programs, it is exposed for tests.
+            </summary>
+        </member>
         <member name="M:Pulumi.Utilities.OutputUtilities.GetIsKnownAsync``1(Pulumi.Output{``0})">
             <summary>
             Retrieve the known status of the given output.


### PR DESCRIPTION
Prompted by reviewing https://github.com/pulumi/pulumi-dotnet/pull/335, found a number of issues in the serialisation of output values.

This also fixes one of the issues fixed in https://github.com/pulumi/pulumi-dotnet/pull/335 where `IInput` values weren't serialised correctly.

To help support testing this I've added a new helper to `OutputUtilities` to add a dependency to an output. Similar to `OutputUtilities.CreateUnknown` this isn't expected to be used in normal programs, but its useful for tests.