### PR TITLE
Allow the mocking of the host for provider tests

### DIFF
--- a/sdk/Pulumi.Tests/Provider/ProviderTests.cs
+++ b/sdk/Pulumi.Tests/Provider/ProviderTests.cs
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation
+// Copyright 2016-2024, Pulumi Corporation
 
 using Grpc.Net.Client;
 using Pulumi.Experimental.Provider;
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Pulumi.Tests.Provider
 {
-    public class ProviderServerTest : IClassFixture<ProviderServerTestHost<ProviderServerTest.TestConfigureProvider>>
+    public class ConfigureProviderServerTest : IClassFixture<ProviderServerTestHost<ConfigureProviderServerTest.TestConfigureProvider>>
     {
         private readonly ProviderServerTestHost<TestConfigureProvider> testHost;
 
@@ -50,7 +50,7 @@ namespace Pulumi.Tests.Provider
             }
         }
 
-        public ProviderServerTest(ProviderServerTestHost<TestConfigureProvider> testHost)
+        public ConfigureProviderServerTest(ProviderServerTestHost<TestConfigureProvider> testHost)
         {
             this.testHost = testHost;
         }
@@ -84,6 +84,69 @@ namespace Pulumi.Tests.Provider
             var exc = await Assert.ThrowsAsync<NotImplementedException>(() =>
                 provider.GetSchema(new GetSchemaRequest(0), CancellationToken.None));
             Assert.Contains("GetSchema", exc.Message);
+        }
+
+    }
+
+    public class ProviderServerTest
+    {
+        sealed class TestLoggingProvider : Experimental.Provider.Provider
+        {
+            readonly IHost Host;
+
+            public TestLoggingProvider(IHost host)
+            {
+                Host = host;
+            }
+
+            public override async Task<ConfigureResponse> Configure(ConfigureRequest request, CancellationToken ct)
+            {
+                await Host.LogAsync(new LogMessage(LogSeverity.Info, "Configure called"));
+
+                return new ConfigureResponse()
+                {
+                    AcceptSecrets = true,
+                };
+            }
+        }
+
+        sealed class TestHost : IHost
+        {
+            public List<LogMessage> LogMessages { get; } = new List<LogMessage>();
+            public Task LogAsync(LogMessage message)
+            {
+                LogMessages.Add(message);
+                return Task.CompletedTask;
+            }
+        }
+
+        [Fact]
+        public async Task CheckLoggingCanBeCalled()
+        {
+            var ihost = new TestHost();
+            IHost BuildHost(string address)
+            {
+                Assert.Equal("127.0.0.1:9999", address);
+                return ihost;
+            }
+
+            var args = new[] { "127.0.0.1:9999" };
+            var cts = new System.Threading.CancellationTokenSource();
+            var host = Experimental.Provider.Provider.BuildHost(args, "1.0", host => new TestLoggingProvider(host), BuildHost);
+            await host.StartAsync(cts.Token);
+            var hostUri = Experimental.Provider.Provider.GetHostUri(host);
+            var channel = GrpcChannel.ForAddress(hostUri, new GrpcChannelOptions
+            {
+                Credentials = Grpc.Core.ChannelCredentials.Insecure,
+            });
+            var client = new Pulumirpc.ResourceProvider.ResourceProviderClient(channel);
+
+            // Call configure and then check we got the expected log message
+            var configureResult = await client.ConfigureAsync(new Pulumirpc.ConfigureRequest() { });
+            Assert.True(configureResult.AcceptSecrets);
+            var message = Assert.Single(ihost.LogMessages);
+            Assert.Equal(LogSeverity.Info, message.Severity);
+            Assert.Equal("Configure called", message.Message);
         }
     }
 }


### PR DESCRIPTION
Adds a BuildHost overload that takes the factory function for building the engine `IHost` object. This allows a test to mock out that object and we write a test demonstrating this assert that a log message was sent.