### PR TITLE
Fix debugger support

### DIFF
--- a/.changes/unreleased/Bug Fixes-343.yaml
+++ b/.changes/unreleased/Bug Fixes-343.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Bug Fixes
+body: Fix debugger support
+time: 2024-09-13T01:17:20.134577-07:00
+custom:
+    PR: "343"

--- a/pulumi-language-dotnet/main.go
+++ b/pulumi-language-dotnet/main.go
@@ -592,7 +592,8 @@ func (host *dotnetLanguageHost) buildDll() (string, error) {
 func (host *dotnetLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest) (*pulumirpc.RunResponse, error) {
 	binaryPath := host.binary
 	if req.GetAttachDebugger() && host.binary == "" {
-		binaryPath, err := host.buildDll()
+		var err error
+		binaryPath, err = host.buildDll()
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/Pulumi/Deployment/Deployment_Run.cs
+++ b/sdk/Pulumi/Deployment/Deployment_Run.cs
@@ -337,7 +337,7 @@ namespace Pulumi
                 while (!System.Diagnostics.Debugger.IsAttached)
                 {
                     // keep waiting until the debugger is attached
-                    await Task.Delay(1000).ConfigureAwait(false);
+                    await Task.Delay(100).ConfigureAwait(false);
                 }
             }
 

--- a/sdk/Pulumi/Deployment/Deployment_Run.cs
+++ b/sdk/Pulumi/Deployment/Deployment_Run.cs
@@ -18,15 +18,6 @@ namespace Pulumi
         public static Task<int> RunAsync(Action action)
             => RunAsync(() =>
             {
-                var value = System.Environment.GetEnvironmentVariable("PULUMI_ATTACH_DEBUGGER");
-                if (value != null && value == "true")
-                {
-                    while (!System.Diagnostics.Debugger.IsAttached)
-                    {
-                        // keep waiting until the debugger is attached
-                        System.Threading.Thread.Sleep(1);
-                    }
-                }
                 action();
                 return ImmutableDictionary<string, object?>.Empty;
             });
@@ -341,6 +332,15 @@ namespace Pulumi
             Func<Deployment> deploymentFactory,
             Func<IRunner, Task<int>> runAsync)
         {
+            if (Environment.GetEnvironmentVariable("PULUMI_ATTACH_DEBUGGER") == "true")
+            {
+                while (!System.Diagnostics.Debugger.IsAttached)
+                {
+                    // keep waiting until the debugger is attached
+                    await Task.Delay(1000).ConfigureAwait(false);
+                }
+            }
+
             var deployment = deploymentFactory();
             Instance = new DeploymentInstance(deployment);
             return await runAsync(deployment._runner).ConfigureAwait(false);


### PR DESCRIPTION
Two fixes for debugger support:

1. Fix unintentional shadowing of the `binaryPath` variable in the langhost's `Run` method. It's currently being shadowed, which means we won't run `dotnet <name>.dll` needed to be able to attach a debugger. (This "regressed" when addressing PR feedback in #332).

2. Fix where we're waiting for the debugger to be attached in the SDK. Right now, we're only waiting in a single overload of `Deployment.RunAsync`. If your Pulumi program is calling another overload, it won't wait for the debugger to attach. This change moves the logic to a centralized place that all `RunAsync` overloads call through to. It also converts the logic back into be async by awaiting `Task.Delay` with a one second delay, since it can now be async in this new location.

Fixes #344