### PR TITLE
Add parameterisation feature flag

### DIFF
--- a/.changes/unreleased/Improvements-347.yaml
+++ b/.changes/unreleased/Improvements-347.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Parameterized providers are now considered stable
+time: 2024-09-13T21:11:49.714255+01:00
+custom:
+  PR: "347"

--- a/sdk/Pulumi/Deployment/Deployment.cs
+++ b/sdk/Pulumi/Deployment/Deployment.cs
@@ -228,6 +228,11 @@ namespace Pulumi
             return this._featureSupport[feature];
         }
 
+        internal Task<bool> MonitorSupportsParameterization()
+        {
+            return MonitorSupportsFeature("parameterization");
+        }
+
         internal Task<bool> MonitorSupportsResourceReferences()
         {
             return MonitorSupportsFeature("resourceReferences");

--- a/sdk/Pulumi/Deployment/Deployment_Prepare.cs
+++ b/sdk/Pulumi/Deployment/Deployment_Prepare.cs
@@ -336,6 +336,11 @@ namespace Pulumi
                 return await packagResolver.Value;
             }
 
+            if (!await MonitorSupportsParameterization().ConfigureAwait(false))
+            {
+                throw new Exception("The Pulumi CLI does not support parameterization. Please update the Pulumi CLI.");
+            }
+
             async Task<string?> CreateResolver()
             {
                 try


### PR DESCRIPTION
Adds the required bit to check for the parameterisation flag.

We'll also want to do a 3.68 release with this as soon as possible to match the sdk-gen changes that have gone into pulumi: https://github.com/pulumi/pulumi/pull/17153/files#diff-c44352515fd31f42be144a763ab5771fe41195a15c2c1213d41a8cbc94dd69d4R2318