### PR TITLE
Allow unknown operations in OperationTypeConverter

### DIFF
--- a/.changes/unreleased/Improvements-350.yaml
+++ b/.changes/unreleased/Improvements-350.yaml
@@ -1,0 +1,6 @@
+component: sdk/auto
+kind: Improvements
+body: Lessen the strictness of `OperationTypeConverter` to allow unknown operations
+time: 2024-09-18T15:46:33.308557-07:00
+custom:
+    PR: "350"

--- a/sdk/Pulumi.Automation/OperationType.cs
+++ b/sdk/Pulumi.Automation/OperationType.cs
@@ -4,6 +4,7 @@ namespace Pulumi.Automation
 {
     public enum OperationType
     {
+        Unknown = -1,
         Same,
         Create,
         Update,

--- a/sdk/Pulumi.Automation/PublicAPI.Shipped.txt
+++ b/sdk/Pulumi.Automation/PublicAPI.Shipped.txt
@@ -151,6 +151,7 @@ Pulumi.Automation.OperationType.Refresh = 9 -> Pulumi.Automation.OperationType
 Pulumi.Automation.OperationType.RemovePendingReplace = 12 -> Pulumi.Automation.OperationType
 Pulumi.Automation.OperationType.Replace = 4 -> Pulumi.Automation.OperationType
 Pulumi.Automation.OperationType.Same = 0 -> Pulumi.Automation.OperationType
+Pulumi.Automation.OperationType.Unknown = -1 -> Pulumi.Automation.OperationType
 Pulumi.Automation.OperationType.Update = 2 -> Pulumi.Automation.OperationType
 Pulumi.Automation.OutputValue
 Pulumi.Automation.OutputValue.IsSecret.get -> bool

--- a/sdk/Pulumi.Automation/Serialization/OperationTypeConverter.cs
+++ b/sdk/Pulumi.Automation/Serialization/OperationTypeConverter.cs
@@ -24,7 +24,7 @@ namespace Pulumi.Automation.Serialization
                 "remove-pending-replace" => OperationType.RemovePendingReplace,
                 "import" => OperationType.Import,
                 "import-replacement" => OperationType.ImportReplacement,
-                _ => throw new InvalidOperationException($"'{input}' is not valid {typeof(OperationType).FullName}"),
+                _ => OperationType.Unknown,
             };
     }
 }


### PR DESCRIPTION
Lessen the strictness of `OperationTypeConverter` to allow unknown operations. This is a postmortem follow-up after we added a new operation (`"output-changes"`) in the engine that the .NET Automation API couldn't handle, resulting in an `InvalidOperationException` being thrown. Now, when an unknown operation is encountered, `OperationType.Unknown` will be returned rather than throwing.

Fixes #292