### PR TITLE
Updating YamlDotNet to latest version

### DIFF
--- a/.changes/unreleased/Improvements-354.yaml
+++ b/.changes/unreleased/Improvements-354.yaml
@@ -1,0 +1,6 @@
+component: sdk/auto
+kind: Improvements
+body: Updating YamlDotNet to v16.1.2
+time: 2024-09-26T11:55:37.551918+02:00
+custom:
+    PR: "354"

--- a/sdk/Pulumi.Automation/Pulumi.Automation.csproj
+++ b/sdk/Pulumi.Automation/Pulumi.Automation.csproj
@@ -42,7 +42,7 @@
     </PackageReference>
     <PackageReference Include="CliWrap" Version="3.3.2" />
     <PackageReference Include="Grpc.AspNetCore.Server" version="2.63.0" />
-    <PackageReference Include="YamlDotNet" Version="11.1.1" />
+    <PackageReference Include="YamlDotNet" Version="16.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/Pulumi.Automation/Serialization/Yaml/ProjectRuntimeOptionsYamlConverter.cs
+++ b/sdk/Pulumi.Automation/Serialization/Yaml/ProjectRuntimeOptionsYamlConverter.cs
@@ -23,7 +23,7 @@ namespace Pulumi.Automation.Serialization.Yaml
 
         public bool Accepts(Type type) => type == _type;
 
-        public object ReadYaml(IParser parser, Type type)
+        public object ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
         {
             if (!parser.TryConsume<MappingStart>(out _))
                 throw new YamlException($"Unable to deserialize [{type.FullName}]. Expecting object.");
@@ -54,7 +54,7 @@ namespace Pulumi.Automation.Serialization.Yaml
             };
         }
 
-        public void WriteYaml(IEmitter emitter, object? value, Type type)
+        public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)
         {
             if (!(value is ProjectRuntimeOptions options))
                 return;

--- a/sdk/Pulumi.Automation/Serialization/Yaml/ProjectRuntimeYamlConverter.cs
+++ b/sdk/Pulumi.Automation/Serialization/Yaml/ProjectRuntimeYamlConverter.cs
@@ -16,7 +16,7 @@ namespace Pulumi.Automation.Serialization.Yaml
 
         public bool Accepts(Type type) => type == _type;
 
-        public object ReadYaml(IParser parser, Type type)
+        public object ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
         {
             if (parser.TryConsume<Scalar>(out var nameValueScalar))
             {
@@ -50,7 +50,7 @@ namespace Pulumi.Automation.Serialization.Yaml
             if (!parser.Accept<MappingStart>(out _))
                 throw new YamlException($"Unable to deserialize [{type.FullName}]. Runtime options property should be an object.");
 
-            var runtimeOptionsObj = this._optionsConverter.ReadYaml(parser, _optionsType);
+            var runtimeOptionsObj = this._optionsConverter.ReadYaml(parser, _optionsType, rootDeserializer);
             if (!(runtimeOptionsObj is ProjectRuntimeOptions runtimeOptions))
                 throw new YamlException("There was an issue deserializing the runtime options object.");
 
@@ -69,7 +69,7 @@ namespace Pulumi.Automation.Serialization.Yaml
             }
         }
 
-        public void WriteYaml(IEmitter emitter, object? value, Type type)
+        public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)
         {
             if (!(value is ProjectRuntime runtime))
                 return;
@@ -86,7 +86,7 @@ namespace Pulumi.Automation.Serialization.Yaml
                 emitter.Emit(new Scalar(runtime.Name.ToString().ToLower()));
 
                 emitter.Emit(new Scalar("options"));
-                this._optionsConverter.WriteYaml(emitter, runtime.Options, _optionsType);
+                this._optionsConverter.WriteYaml(emitter, runtime.Options, _optionsType, serializer);
 
                 emitter.Emit(new MappingEnd());
             }

--- a/sdk/Pulumi.Automation/Serialization/Yaml/StackSettingsConfigValueYamlConverter.cs
+++ b/sdk/Pulumi.Automation/Serialization/Yaml/StackSettingsConfigValueYamlConverter.cs
@@ -15,7 +15,7 @@ namespace Pulumi.Automation.Serialization.Yaml
 
         public bool Accepts(Type type) => type == _type;
 
-        public object ReadYaml(IParser parser, Type type)
+        public object ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
         {
             // check if plain string
             if (parser.Accept<Scalar>(out var stringValue))
@@ -64,7 +64,7 @@ namespace Pulumi.Automation.Serialization.Yaml
             return new StackSettingsConfigValue(serializedToJson, false);
         }
 
-        public void WriteYaml(IEmitter emitter, object? value, Type type)
+        public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)
         {
             if (!(value is StackSettingsConfigValue configValue))
                 return;


### PR DESCRIPTION
Fixes #353

YamlDotNet added new parameters to the `IYamlTypeConverter` methods in [v16.0](https://github.com/aaubry/YamlDotNet/releases/tag/v16.0.0).

This PR updates the `YamlDotNet` package to latest version (v16.1.2) and adapts custom converters to this breaking change.