### PR TITLE
improve the detection of project files when in debug mode

### DIFF
--- a/.changes/unreleased/Bug Fixes-355.yaml
+++ b/.changes/unreleased/Bug Fixes-355.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Bug Fixes
+body: Improve the detections of project files when attaching a debugger
+time: 2024-09-27T14:28:28.811538233+02:00
+custom:
+  PR: "255"

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -10,6 +10,7 @@ kinds:
   auto: minor
 - label: Bug Fixes
   auto: patch
+  key: bug-fixes
 # Custom fragment file format because we use / in the component name.
 fragmentFileFormat: '{{.Kind}}-{{.Custom.PR}}'
 components:

--- a/pulumi-language-dotnet/main.go
+++ b/pulumi-language-dotnet/main.go
@@ -559,7 +559,9 @@ func (w *logWriter) LogToUser(val string) (int, error) {
 	return len(val), nil
 }
 
-func (host *dotnetLanguageHost) buildDll(entryPoint string) (string, error) {
+// When debugging, we need to build the project, as the debugger does not support running using `dotnet run`.
+// This function will build the project and return the path to the built DLL.
+func (host *dotnetLanguageHost) buildDebuggingDLL(entryPoint string) (string, error) {
 	// If we are running from source, we need to build the project.
 	// Run the `dotnet build` command.  Importantly, report the output of this to the user
 	// (ephemerally) as it is happening so they're aware of what's going on and can see the progress
@@ -597,7 +599,7 @@ func (host *dotnetLanguageHost) buildDll(entryPoint string) (string, error) {
 			binaryPath = filepath.Join("bin", "pulumi-debugging", name+".dll")
 			return filepath.SkipAll
 		}
-		if name, ok := strings.CutSuffix(d.Name(), ".vsproj"); ok {
+		if name, ok := strings.CutSuffix(d.Name(), ".vbproj"); ok {
 			binaryPath = filepath.Join("bin", "pulumi-debugging", name+".dll")
 			return filepath.SkipAll
 		}
@@ -613,7 +615,7 @@ func (host *dotnetLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 
 	if req.GetAttachDebugger() && host.binary == "" {
 		var err error
-		binaryPath, err = host.buildDll(req.GetInfo().GetEntryPoint())
+		binaryPath, err = host.buildDebuggingDLL(req.GetInfo().GetEntryPoint())
 		if err != nil {
 			return nil, err
 		}

--- a/pulumi-language-dotnet/main.go
+++ b/pulumi-language-dotnet/main.go
@@ -567,7 +567,7 @@ func (host *dotnetLanguageHost) buildDebuggingDLL(entryPoint string) (string, er
 	// (ephemerally) as it is happening so they're aware of what's going on and can see the progress
 	// of things.
 	args := []string{"build", "-nologo", "-o", "bin/pulumi-debugging"}
-	if entryPoint != "" {
+	if entryPoint != "." {
 		args = append(args, entryPoint)
 	}
 
@@ -577,7 +577,7 @@ func (host *dotnetLanguageHost) buildDebuggingDLL(entryPoint string) (string, er
 		return "", errors.Wrapf(err, "failed to build project: %v, output: %v", err, string(out))
 	}
 
-	if entryPoint != "" {
+	if entryPoint != "." {
 		lastDot := strings.LastIndex(entryPoint, ".")
 		if lastDot == -1 {
 			return "", errors.New("entry point must have a file extension")

--- a/pulumi-language-dotnet/main_test.go
+++ b/pulumi-language-dotnet/main_test.go
@@ -21,9 +21,11 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDeterminePluginDependency(t *testing.T) {
@@ -141,13 +143,13 @@ func TestDeterminePluginDependency(t *testing.T) {
 
 			cwd := t.TempDir()
 			artifactPath := filepath.Join(cwd, strings.ToLower(c.PackageName), c.PackageVersion, "content")
-			err := os.MkdirAll(artifactPath, 0700)
+			err := os.MkdirAll(artifactPath, 0o700)
 			assert.NoError(t, err)
 
 			// Setup testing environment
 			if c.VersionTxt != "" {
 				path := filepath.Join(artifactPath, "version.txt")
-				err := os.WriteFile(path, []byte(c.VersionTxt), 0600)
+				err := os.WriteFile(path, []byte(c.VersionTxt), 0o600)
 				assert.NoError(t, err)
 				t.Logf("Wrote version.txt file to %q", path)
 			}
@@ -155,7 +157,7 @@ func TestDeterminePluginDependency(t *testing.T) {
 				path := filepath.Join(artifactPath, "pulumi-plugin.json")
 				bytes, err := c.PulumiPlugin.JSON()
 				assert.NoError(t, err)
-				err = os.WriteFile(path, bytes, 0600)
+				err = os.WriteFile(path, bytes, 0o600)
 				assert.NoError(t, err)
 				t.Logf("Wrote pulumi-plugin.json file to %q", path)
 			}
@@ -174,6 +176,97 @@ func TestDeterminePluginDependency(t *testing.T) {
 				t.Logf("No error expected")
 				assert.NoError(t, err)
 				assert.Equal(t, c.Expected, actual)
+			}
+		})
+	}
+}
+
+func TestBuildDll(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Name       string
+		EntryPoint string
+		ExtraSetup func(t *testing.T, e *ptesting.Environment)
+
+		ExpectedErrorContains string
+		ExpectedBinaryPath    string
+	}{
+		{
+			Name:               "regular case works",
+			EntryPoint:         "",
+			ExpectedBinaryPath: filepath.Join("bin", "pulumi-debugging", "Empty.dll"),
+		},
+		{
+			Name:               "entrypoint specified",
+			EntryPoint:         "Empty.csproj",
+			ExpectedBinaryPath: filepath.Join("bin", "pulumi-debugging", "Empty.dll"),
+		},
+		{
+			Name:                  "entrypoint not found",
+			EntryPoint:            "Wrong.csproj",
+			ExpectedErrorContains: "Project file does not exist",
+		},
+		{
+			Name:       "fsproj works",
+			EntryPoint: "",
+			ExtraSetup: func(t *testing.T, e *ptesting.Environment) {
+				os.Rename(filepath.Join(e.RootPath, "Empty.csproj"), filepath.Join(e.RootPath, "Empty.fsproj"))
+			},
+			ExpectedBinaryPath: filepath.Join("bin", "pulumi-debugging", "Empty.dll"),
+		},
+		{
+			Name:       "vbproj works",
+			EntryPoint: "",
+			ExtraSetup: func(t *testing.T, e *ptesting.Environment) {
+				os.Rename(filepath.Join(e.RootPath, "Empty.csproj"), filepath.Join(e.RootPath, "Empty.vbproj"))
+			},
+			ExpectedErrorContains: "'Sub Main' was not found in 'Empty'.",
+		},
+		{
+			Name:       "multiple projects with entrypoint",
+			EntryPoint: "Empty.csproj",
+			ExtraSetup: func(t *testing.T, e *ptesting.Environment) {
+				data, err := os.ReadFile("Empty.csproj")
+				assert.NoError(t, err)
+				err = os.WriteFile("Another.fsproj", data, 0o644)
+				assert.NoError(t, err)
+			},
+			ExpectedBinaryPath: filepath.Join("bin", "pulumi-debugging", "Empty.dll"),
+		},
+		{
+			Name:                  "incorrect entry point name",
+			EntryPoint:            "Another",
+			ExpectedErrorContains: "Project file does not exist",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			e := ptesting.NewEnvironment(t)
+			e.ImportDirectory("testdata/build-dll")
+
+			pwd, err := os.Getwd()
+			require.NoError(t, err)
+			os.Chdir(e.RootPath)
+			defer os.Chdir(pwd)
+
+			if c.ExtraSetup != nil {
+				c.ExtraSetup(t, e)
+			}
+
+			host := &dotnetLanguageHost{
+				exec: "dotnet",
+			}
+
+			binaryPath, err := host.buildDll(c.EntryPoint)
+
+			if c.ExpectedErrorContains != "" {
+				assert.ErrorContains(t, err, c.ExpectedErrorContains)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, c.ExpectedBinaryPath, binaryPath)
 			}
 		})
 	}

--- a/pulumi-language-dotnet/main_test.go
+++ b/pulumi-language-dotnet/main_test.go
@@ -260,7 +260,7 @@ func TestBuildDll(t *testing.T) {
 				exec: "dotnet",
 			}
 
-			binaryPath, err := host.buildDll(c.EntryPoint)
+			binaryPath, err := host.buildDebuggingDLL(c.EntryPoint)
 
 			if c.ExpectedErrorContains != "" {
 				assert.ErrorContains(t, err, c.ExpectedErrorContains)


### PR DESCRIPTION
When attaching a debugger, we first need to build the binary, and then run it, because the debugger doesn't work properly when just using `dotnet run`.  This currently has two bugs:

1) it doesn't respect the entry point the user specifies in the Pulumi.yaml 

2) it only detects .csproj projects, not .fsproj or .vbproj projects,
   so it doesn't work out of the box for F# or VB projects.  This is
   made worse by the bug above, since the user has no workaround for
   it.

This PR fixes both of those issues, by respecting the entry point if it is given, and if it is not, by also looking at project files with a .fsproj or .vbproj extension.

Fixes https://github.com/pulumi/pulumi-dotnet/issues/352