### PR TITLE
WIP: allow dotnet to emit better errors for component construct

### DIFF
--- a/integration_tests/construct_component_failures/dotnet/Component.cs
+++ b/integration_tests/construct_component_failures/dotnet/Component.cs
@@ -1,0 +1,50 @@
+using Pulumi;
+
+class Component : Pulumi.ComponentResource
+{
+    public Component(string name, ComponentArgs args, ComponentResourceOptions? opts = null)
+        : base("test:index:Test", name, args, opts, remote: true)
+    {
+    }
+
+    [Output("passwordResult")]
+    public Output<string> PasswordResult { get; private set; } = default!;
+
+    [Output("complexResult")]
+    public Output<ComplexType> ComplexResult { get; set; } = default!;
+}
+
+class ComponentArgs : ResourceArgs
+{
+    [Input("passwordLength")]
+    public Input<int> PasswordLength { get; set; } = null!;
+
+    [Input("complex")]
+    public Input<ComplexTypeArgs> Complex { get; set; } = null!;
+}
+
+public sealed class ComplexTypeArgs : global::Pulumi.ResourceArgs
+{
+    [Input("name", required: true)]
+    public string Name { get; set; } = null!;
+
+    [Input("intValue", required: true)]
+    public int IntValue { get; set; }
+}
+
+[OutputType]
+public sealed class ComplexType
+{
+    [Output("name")]
+    public string Name { get; set; }
+
+    [Output("intValue")]
+    public int IntValue { get; set; }
+
+    [OutputConstructor]
+    public ComplexType(string name, int intValue)
+    {
+        Name = name;
+        IntValue = intValue;
+    }
+}

--- a/integration_tests/construct_component_failures/dotnet/Program.cs
+++ b/integration_tests/construct_component_failures/dotnet/Program.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Pulumi;
+using Pulumi.Utilities;
+
+using Pulumi.IntegrationTests.Utils;
+
+class Program
+{
+    static async Task<int> Main(string[] args)
+    {
+        var returnCode = await Deployment.RunAsync(async () =>
+        {
+            var component10 = new Component("component10", new ComponentArgs());
+        });
+	return returnCode;
+    }
+
+}

--- a/integration_tests/construct_component_failures/dotnet/ProviderConstructFailure.csproj
+++ b/integration_tests/construct_component_failures/dotnet/ProviderConstructFailure.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\sdk\Pulumi\Pulumi.csproj"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+  </ItemGroup>
+</Project>

--- a/integration_tests/construct_component_failures/dotnet/Pulumi.yaml
+++ b/integration_tests/construct_component_failures/dotnet/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: provider_construct
+runtime: dotnet
+
+plugins:
+  providers:
+    - name: test
+      path: ../testcomponent-dotnet

--- a/integration_tests/construct_component_failures/testcomponent-dotnet/Component.cs
+++ b/integration_tests/construct_component_failures/testcomponent-dotnet/Component.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Pulumi;
+
+class ComponentArgs : ResourceArgs
+{
+}
+
+class Component : ComponentResource
+{
+    public Component(string name, ComponentArgs args, ComponentResourceOptions? opts = null)
+        : base("test:index:Test", name, args, opts)
+    {
+	    throw new InputPropertiesException(
+	    "failing for a reason",
+	    new[]
+	    {
+		new PropertyError("foo", "the failure reason"),
+	    });
+    }
+}

--- a/integration_tests/construct_component_failures/testcomponent-dotnet/Program.cs
+++ b/integration_tests/construct_component_failures/testcomponent-dotnet/Program.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using TestProvider;
+
+class Program
+{
+    public static Task Main(string []args) =>
+        Pulumi.Experimental.Provider.Provider.Serve(args, "0.0.1", host => new TestProviderImpl(), CancellationToken.None);
+}

--- a/integration_tests/construct_component_failures/testcomponent-dotnet/PulumiPlugin.yaml
+++ b/integration_tests/construct_component_failures/testcomponent-dotnet/PulumiPlugin.yaml
@@ -1,0 +1,1 @@
+runtime: dotnet

--- a/integration_tests/construct_component_failures/testcomponent-dotnet/TestProvider.csproj
+++ b/integration_tests/construct_component_failures/testcomponent-dotnet/TestProvider.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <AssemblyName>pulumi-resource-test</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\sdk\Pulumi\Pulumi.csproj"/>
+  </ItemGroup>
+</Project>

--- a/integration_tests/construct_component_failures/testcomponent-dotnet/TestProviderImpl.cs
+++ b/integration_tests/construct_component_failures/testcomponent-dotnet/TestProviderImpl.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Pulumi.Experimental.Provider;
+using Pulumi.IntegrationTests.Utils;
+
+namespace TestProvider;
+
+public class TestProviderImpl : ComponentResourceProviderBase
+{
+    public override Task<ConstructResponse> Construct(ConstructRequest request, CancellationToken ct)
+    {
+        return request.Type switch
+        {
+            "test:index:Test" => Construct<ComponentArgs, Component>(request,
+                (name, args, options) => Task.FromResult(new Component(name, args, options))),
+            _ => throw new NotImplementedException()
+        };
+    }
+}

--- a/proto/pulumi/errors.proto
+++ b/proto/pulumi/errors.proto
@@ -23,3 +23,16 @@ message ErrorCause {
     string stackTrace = 2;
 }
 
+// An error that can be returned from a component provider and includes details of the
+// error, which can be multiple properties.
+message InputPropertiesError {
+    // A single invalid input property.
+    message PropertyError {
+        // The path to the property that is invalid.
+        string property_path = 1;
+	// The reason the property is invalid.
+        string reason = 2;
+    }
+    // The list of invalid input properties.
+    repeated PropertyError errors = 1;
+}

--- a/proto/pulumi/language.proto
+++ b/proto/pulumi/language.proto
@@ -91,8 +91,8 @@ message AboutResponse {
 
 message GetProgramDependenciesRequest {
     string project = 1 [deprecated = true]; // the project name, the engine always sets this to "deprecated" now.
-    string pwd = 2 [deprecated = true];     // the program's working directory.
-    string program = 3 [deprecated = true]; // the path to the program.
+    string pwd = 2 [deprecated = true];     // the program's working directory. Deprecated, use info.program_directory instead.
+    string program = 3 [deprecated = true]; // the path to the program. Deprecated, use info.entry_point instead.
     bool transitiveDependencies = 4; // if transitive dependencies should be included in the result.
     ProgramInfo info = 5; // the program info to use to calculate dependencies.
 }
@@ -108,8 +108,8 @@ message GetProgramDependenciesResponse {
 
 message GetRequiredPluginsRequest {
     string project = 1 [deprecated = true]; // the project name, the engine always sets this to "deprecated" now.
-    string pwd = 2 [deprecated = true];     // the program's working directory.
-    string program = 3 [deprecated = true]; // the path to the program.
+    string pwd = 2 [deprecated = true];     // the program's working directory. Deprecated, use info.program_directory instead.
+    string program = 3 [deprecated = true]; // the path to the program. Deprecated, use info.entry_point instead.
     ProgramInfo info = 4; // the program info to use to calculate plugins.
 }
 
@@ -122,7 +122,7 @@ message RunRequest {
     string project = 1;             // the project name.
     string stack = 2;               // the name of the stack being deployed into.
     string pwd = 3;                 // the program's working directory.
-    string program = 4 [deprecated = true];             // the path to the program to execute.
+    string program = 4 [deprecated = true];             // the path to the program to execute. Deprecated, use info.entry_point instead.
     repeated string args = 5;       // any arguments to pass to the program.
     map<string, string> config = 6; // the configuration variables to apply before running.
     bool dryRun = 7;                // true if we're only doing a dryrun (preview).
@@ -150,7 +150,7 @@ message RunResponse {
 }
 
 message InstallDependenciesRequest {
-    string directory = 1 [deprecated = true]; // the program's working directory.
+    string directory = 1 [deprecated = true]; // the program's working directory. Deprecated, use info.program_directory instead.
     bool is_terminal = 2; // if we are running in a terminal and should use ANSI codes
     ProgramInfo info = 3; // the program info to use to execute the plugin.
     bool use_language_version_tools = 4; // if we should use language version tools like pyenv or
@@ -192,7 +192,7 @@ message RuntimeOptionsResponse {
 
 message RunPluginRequest{
     string pwd = 1; // the program's working directory.
-    string program = 2 [deprecated = true]; // the path to the program to execute.
+    string program = 2 [deprecated = true]; // the path to the program to execute. Deprecated, use info.entry_point instead.
     repeated string args = 3; // any arguments to pass to the program.
     repeated string env = 4; // any environment variables to set as part of the program.
     ProgramInfo info = 5; // the program info to use to execute the plugin.

--- a/proto/pulumi/provider.proto
+++ b/proto/pulumi/provider.proto
@@ -48,7 +48,14 @@ service ResourceProvider {
     rpc CheckConfig(CheckRequest) returns (CheckResponse) {}
     // DiffConfig checks the impact a hypothetical change to this provider's configuration will have on the provider.
     rpc DiffConfig(DiffRequest) returns (DiffResponse) {}
+
     // Configure configures the resource provider with "globals" that control its behavior.
+    //
+    // :::{warning}
+    // ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
+    // ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
+    // ConfigureRequest.args.
+    // :::
     rpc Configure(ConfigureRequest) returns (ConfigureResponse) {}
 
     // Invoke dynamically executes a built-in function in the provider.
@@ -249,6 +256,9 @@ message CheckRequest {
     reserved "sequenceNumber";
 
     bytes randomSeed = 5;            // a deterministically random hash, primarily intended for global unique naming.
+
+    string name = 6; // the Pulumi name for this resource.
+    string type = 7; // the Pulumi type for this resource.
 }
 
 message CheckResponse {
@@ -271,6 +281,8 @@ message DiffRequest {
 
     repeated string ignoreChanges = 5; // a set of property paths that should be treated as unchanged.
     google.protobuf.Struct old_inputs = 6;   // the old input values of the resource to diff.
+    string name = 7; // the Pulumi name for this resource.
+    string type = 8; // the Pulumi type for this resource.
 }
 
 message PropertyDiff {
@@ -342,6 +354,8 @@ message CreateRequest {
     google.protobuf.Struct properties = 2; // the provider inputs to set during creation.
     double timeout = 3;                    // the create request timeout represented in seconds.
     bool preview = 4;                      // true if this is a preview and the provider should not actually create the resource.
+    string name = 5; // the Pulumi name for this resource.
+    string type = 6; // the Pulumi type for this resource.
 }
 
 message CreateResponse {
@@ -356,6 +370,8 @@ message ReadRequest {
     string urn = 2;                        // the Pulumi URN for this resource.
     google.protobuf.Struct properties = 3; // the current state (sufficiently complete to identify the resource).
     google.protobuf.Struct inputs = 4;     // the current inputs, if any (only populated during refresh).
+    string name = 5; // the Pulumi name for this resource.
+    string type = 6; // the Pulumi type for this resource.
 }
 
 message ReadResponse {
@@ -378,6 +394,8 @@ message UpdateRequest {
     repeated string ignoreChanges = 6; // a set of property paths that should be treated as unchanged.
     bool preview = 7;                   // true if this is a preview and the provider should not actually create the resource.
     google.protobuf.Struct old_inputs = 8; // the old input values of the resource to diff.
+    string name = 9; // the Pulumi name for this resource.
+    string type = 10; // the Pulumi type for this resource.
 }
 
 message UpdateResponse {
@@ -390,6 +408,8 @@ message DeleteRequest {
     google.protobuf.Struct properties = 3; // the current properties on the resource.
     double timeout = 4;                    // the delete request timeout represented in seconds.
     google.protobuf.Struct old_inputs = 5; // the old input values of the resource to delete.
+    string name = 6; // the Pulumi name for this resource.
+    string type = 7; // the Pulumi type for this resource.
 }
 
 message ConstructRequest {

--- a/proto/pulumi/testing/language.proto
+++ b/proto/pulumi/testing/language.proto
@@ -54,6 +54,11 @@ message PrepareLanguageTestsRequest {
     string core_sdk_directory = 5;
     string core_sdk_version = 6;
     repeated Replacement snapshot_edits = 7;
+
+    // a JSON string that will be inserted into every schema loaded (for both GeneratePackage and GenerateProject) in
+    // the "Languages[language_plugin_name]" field. This can be used to test language specific options such as
+    // inputTypes in python.
+    string language_info = 8;
 }
 
 message PrepareLanguageTestsResponse {

--- a/sdk/Pulumi/Exceptions/InputPropertiesException.cs
+++ b/sdk/Pulumi/Exceptions/InputPropertiesException.cs
@@ -1,0 +1,51 @@
+// Copyright 2016-2024, Pulumi Corporation
+
+using System;
+using System.Collections.Generic;
+using Grpc.Core;
+using Pulumirpc;
+
+namespace Pulumi
+{
+	public class PropertyError {
+		public string PropertyPath { get; set; }
+		public string Reason { get; set; }
+
+		public PropertyError(string propertyPath, string reason) {
+			PropertyPath = propertyPath;
+			Reason = reason;
+		}
+	}
+
+	public class InputPropertiesException : RpcException
+	{
+		public InputPropertiesException(String message, IList<PropertyError> propertyErrors)
+			: base(new Grpc.Core.Status(StatusCode.InvalidArgument, ""), constructTrailers(message, propertyErrors), message)		{
+		}
+
+		public static Metadata constructTrailers(String message, IList<PropertyError> propertyErrors)
+		{
+			var errorDetails = new InputPropertiesError();
+			foreach (var propertyError in propertyErrors)
+			{
+				var error = new InputPropertiesError.Types.PropertyError();
+				error.PropertyPath = propertyError.PropertyPath;
+				error.Reason = propertyError.Reason;
+				errorDetails.Errors.Add(error);
+			}
+			var status = new Google.Rpc.Status {
+				Code = (int)StatusCode.Unknown,
+				Message = "Bad request",
+				Details = { Google.Protobuf.WellKnownTypes.Any.Pack(errorDetails) }
+			};
+
+//			throw new RpcException(new Grpc.Core.Status(StatusCode.InvalidArgument, "wtf"), "failing for a reason");
+
+			// var details = Google.Protobuf.WellKnownTypes.Any.Pack(status);
+			var metadata = new Metadata();
+			metadata.Add("grpc-status-details-bin", Google.Protobuf.MessageExtensions.ToByteArray(status));
+			Console.WriteLine("metadata: " + metadata.GetAll("grpc-status-details-bin"));
+			return metadata;
+        }
+	}
+}

--- a/sdk/Pulumi/Pulumi.csproj
+++ b/sdk/Pulumi/Pulumi.csproj
@@ -30,10 +30,10 @@
 
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.63.0" />
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.63.0" />
-    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.63.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.63.0">
+    <PackageReference Include="Grpc.Net.Client" Version="2.66.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.66.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.66.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.66.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -44,10 +44,10 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="OneOf" Version="3.0.216" />
-    <!-- 
+    <!--
     Note: Pulumi maintains a fork of Google.Protobuf package, to increase the recursion limit.
     The Pulumi.Protobuf package contains an assembly called Google.Protobuf.dll, as does the Google.Protobuf package
-    that is a transitive dependency of some of the gRPC packages. The forked assembly takes precedence 
+    that is a transitive dependency of some of the gRPC packages. The forked assembly takes precedence
     because it has a higher version number.
     see: https://github.com/pulumi/pulumi-dotnet/issues/322
     -->

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -4901,6 +4901,44 @@
         <member name="F:Pulumirpc.ErrorCause.StackTraceFieldNumber">
             <summary>Field number for the "stackTrace" field.</summary>
         </member>
+        <member name="T:Pulumirpc.InputPropertiesError">
+            <summary>
+            An error that can be returned from a component provider and includes details of the
+            error, which can be multiple properties.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.InputPropertiesError.ErrorsFieldNumber">
+            <summary>Field number for the "errors" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.InputPropertiesError.Errors">
+            <summary>
+            The list of invalid input properties.
+            </summary>
+        </member>
+        <member name="T:Pulumirpc.InputPropertiesError.Types">
+            <summary>Container for nested types declared in the InputPropertiesError message type.</summary>
+        </member>
+        <member name="T:Pulumirpc.InputPropertiesError.Types.PropertyError">
+            <summary>
+            A single invalid input property.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.InputPropertiesError.Types.PropertyError.PropertyPathFieldNumber">
+            <summary>Field number for the "property_path" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.InputPropertiesError.Types.PropertyError.PropertyPath">
+            <summary>
+            The path to the property that is invalid.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.InputPropertiesError.Types.PropertyError.ReasonFieldNumber">
+            <summary>Field number for the "reason" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.InputPropertiesError.Types.PropertyError.Reason">
+            <summary>
+            The reason the property is invalid.
+            </summary>
+        </member>
         <member name="T:Pulumirpc.LanguageReflection">
             <summary>Holder for reflection information generated from pulumi/language.proto</summary>
         </member>
@@ -4999,7 +5037,7 @@
         </member>
         <member name="P:Pulumirpc.GetProgramDependenciesRequest.Pwd">
             <summary>
-            the program's working directory.
+            the program's working directory. Deprecated, use info.program_directory instead.
             </summary>
         </member>
         <member name="F:Pulumirpc.GetProgramDependenciesRequest.ProgramFieldNumber">
@@ -5007,7 +5045,7 @@
         </member>
         <member name="P:Pulumirpc.GetProgramDependenciesRequest.Program">
             <summary>
-            the path to the program.
+            the path to the program. Deprecated, use info.entry_point instead.
             </summary>
         </member>
         <member name="F:Pulumirpc.GetProgramDependenciesRequest.TransitiveDependenciesFieldNumber">
@@ -5063,7 +5101,7 @@
         </member>
         <member name="P:Pulumirpc.GetRequiredPluginsRequest.Pwd">
             <summary>
-            the program's working directory.
+            the program's working directory. Deprecated, use info.program_directory instead.
             </summary>
         </member>
         <member name="F:Pulumirpc.GetRequiredPluginsRequest.ProgramFieldNumber">
@@ -5071,7 +5109,7 @@
         </member>
         <member name="P:Pulumirpc.GetRequiredPluginsRequest.Program">
             <summary>
-            the path to the program.
+            the path to the program. Deprecated, use info.entry_point instead.
             </summary>
         </member>
         <member name="F:Pulumirpc.GetRequiredPluginsRequest.InfoFieldNumber">
@@ -5124,7 +5162,7 @@
         </member>
         <member name="P:Pulumirpc.RunRequest.Program">
             <summary>
-            the path to the program to execute.
+            the path to the program to execute. Deprecated, use info.entry_point instead.
             </summary>
         </member>
         <member name="F:Pulumirpc.RunRequest.ArgsFieldNumber">
@@ -5251,7 +5289,7 @@
         </member>
         <member name="P:Pulumirpc.InstallDependenciesRequest.Directory">
             <summary>
-            the program's working directory.
+            the program's working directory. Deprecated, use info.program_directory instead.
             </summary>
         </member>
         <member name="F:Pulumirpc.InstallDependenciesRequest.IsTerminalFieldNumber">
@@ -5353,7 +5391,7 @@
         </member>
         <member name="P:Pulumirpc.RunPluginRequest.Program">
             <summary>
-            the path to the program to execute.
+            the path to the program to execute. Deprecated, use info.entry_point instead.
             </summary>
         </member>
         <member name="F:Pulumirpc.RunPluginRequest.ArgsFieldNumber">
@@ -6663,6 +6701,22 @@
             a deterministically random hash, primarily intended for global unique naming.
             </summary>
         </member>
+        <member name="F:Pulumirpc.CheckRequest.NameFieldNumber">
+            <summary>Field number for the "name" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.CheckRequest.Name">
+            <summary>
+            the Pulumi name for this resource.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.CheckRequest.TypeFieldNumber">
+            <summary>Field number for the "type" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.CheckRequest.Type">
+            <summary>
+            the Pulumi type for this resource.
+            </summary>
+        </member>
         <member name="F:Pulumirpc.CheckResponse.InputsFieldNumber">
             <summary>Field number for the "inputs" field.</summary>
         </member>
@@ -6741,6 +6795,22 @@
         <member name="P:Pulumirpc.DiffRequest.OldInputs">
             <summary>
             the old input values of the resource to diff.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.DiffRequest.NameFieldNumber">
+            <summary>Field number for the "name" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.DiffRequest.Name">
+            <summary>
+            the Pulumi name for this resource.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.DiffRequest.TypeFieldNumber">
+            <summary>Field number for the "type" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.DiffRequest.Type">
+            <summary>
+            the Pulumi type for this resource.
             </summary>
         </member>
         <member name="F:Pulumirpc.PropertyDiff.KindFieldNumber">
@@ -6928,6 +6998,22 @@
             true if this is a preview and the provider should not actually create the resource.
             </summary>
         </member>
+        <member name="F:Pulumirpc.CreateRequest.NameFieldNumber">
+            <summary>Field number for the "name" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.CreateRequest.Name">
+            <summary>
+            the Pulumi name for this resource.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.CreateRequest.TypeFieldNumber">
+            <summary>Field number for the "type" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.CreateRequest.Type">
+            <summary>
+            the Pulumi type for this resource.
+            </summary>
+        </member>
         <member name="T:Pulumirpc.CreateResponse">
             <summary>
             NOTE: The partial-update-error equivalent of this message is `ErrorResourceInitFailed`.
@@ -6979,6 +7065,22 @@
         <member name="P:Pulumirpc.ReadRequest.Inputs">
             <summary>
             the current inputs, if any (only populated during refresh).
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.ReadRequest.NameFieldNumber">
+            <summary>Field number for the "name" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ReadRequest.Name">
+            <summary>
+            the Pulumi name for this resource.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.ReadRequest.TypeFieldNumber">
+            <summary>Field number for the "type" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.ReadRequest.Type">
+            <summary>
+            the Pulumi type for this resource.
             </summary>
         </member>
         <member name="F:Pulumirpc.ReadResponse.IdFieldNumber">
@@ -7074,6 +7176,22 @@
             the old input values of the resource to diff.
             </summary>
         </member>
+        <member name="F:Pulumirpc.UpdateRequest.NameFieldNumber">
+            <summary>Field number for the "name" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.UpdateRequest.Name">
+            <summary>
+            the Pulumi name for this resource.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.UpdateRequest.TypeFieldNumber">
+            <summary>Field number for the "type" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.UpdateRequest.Type">
+            <summary>
+            the Pulumi type for this resource.
+            </summary>
+        </member>
         <member name="F:Pulumirpc.UpdateResponse.PropertiesFieldNumber">
             <summary>Field number for the "properties" field.</summary>
         </member>
@@ -7120,6 +7238,22 @@
         <member name="P:Pulumirpc.DeleteRequest.OldInputs">
             <summary>
             the old input values of the resource to delete.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.DeleteRequest.NameFieldNumber">
+            <summary>Field number for the "name" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.DeleteRequest.Name">
+            <summary>
+            the Pulumi name for this resource.
+            </summary>
+        </member>
+        <member name="F:Pulumirpc.DeleteRequest.TypeFieldNumber">
+            <summary>Field number for the "type" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.DeleteRequest.Type">
+            <summary>
+            the Pulumi type for this resource.
             </summary>
         </member>
         <member name="F:Pulumirpc.ConstructRequest.ProjectFieldNumber">
@@ -7580,12 +7714,18 @@
             <returns>The response to send back to the client (wrapped by a task).</returns>
         </member>
         <member name="M:Pulumirpc.ResourceProvider.ResourceProviderBase.Configure(Pulumirpc.ConfigureRequest,Grpc.Core.ServerCallContext)">
-            <summary>
-            Configure configures the resource provider with "globals" that control its behavior.
-            </summary>
-            <param name="request">The request received from the client.</param>
-            <param name="context">The context of the server-side call handler being invoked.</param>
-            <returns>The response to send back to the client (wrapped by a task).</returns>
+             <summary>
+             Configure configures the resource provider with "globals" that control its behavior.
+            
+             :::{warning}
+             ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
+             ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
+             ConfigureRequest.args.
+             :::
+             </summary>
+             <param name="request">The request received from the client.</param>
+             <param name="context">The context of the server-side call handler being invoked.</param>
+             <returns>The response to send back to the client (wrapped by a task).</returns>
         </member>
         <member name="M:Pulumirpc.ResourceProvider.ResourceProviderBase.Invoke(Pulumirpc.InvokeRequest,Grpc.Core.ServerCallContext)">
             <summary>
@@ -7933,40 +8073,64 @@
             <returns>The call object.</returns>
         </member>
         <member name="M:Pulumirpc.ResourceProvider.ResourceProviderClient.Configure(Pulumirpc.ConfigureRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
-            <summary>
-            Configure configures the resource provider with "globals" that control its behavior.
-            </summary>
-            <param name="request">The request to send to the server.</param>
-            <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
-            <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
-            <param name="cancellationToken">An optional token for canceling the call.</param>
-            <returns>The response received from the server.</returns>
+             <summary>
+             Configure configures the resource provider with "globals" that control its behavior.
+            
+             :::{warning}
+             ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
+             ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
+             ConfigureRequest.args.
+             :::
+             </summary>
+             <param name="request">The request to send to the server.</param>
+             <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+             <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+             <param name="cancellationToken">An optional token for canceling the call.</param>
+             <returns>The response received from the server.</returns>
         </member>
         <member name="M:Pulumirpc.ResourceProvider.ResourceProviderClient.Configure(Pulumirpc.ConfigureRequest,Grpc.Core.CallOptions)">
-            <summary>
-            Configure configures the resource provider with "globals" that control its behavior.
-            </summary>
-            <param name="request">The request to send to the server.</param>
-            <param name="options">The options for the call.</param>
-            <returns>The response received from the server.</returns>
+             <summary>
+             Configure configures the resource provider with "globals" that control its behavior.
+            
+             :::{warning}
+             ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
+             ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
+             ConfigureRequest.args.
+             :::
+             </summary>
+             <param name="request">The request to send to the server.</param>
+             <param name="options">The options for the call.</param>
+             <returns>The response received from the server.</returns>
         </member>
         <member name="M:Pulumirpc.ResourceProvider.ResourceProviderClient.ConfigureAsync(Pulumirpc.ConfigureRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
-            <summary>
-            Configure configures the resource provider with "globals" that control its behavior.
-            </summary>
-            <param name="request">The request to send to the server.</param>
-            <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
-            <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
-            <param name="cancellationToken">An optional token for canceling the call.</param>
-            <returns>The call object.</returns>
+             <summary>
+             Configure configures the resource provider with "globals" that control its behavior.
+            
+             :::{warning}
+             ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
+             ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
+             ConfigureRequest.args.
+             :::
+             </summary>
+             <param name="request">The request to send to the server.</param>
+             <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+             <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+             <param name="cancellationToken">An optional token for canceling the call.</param>
+             <returns>The call object.</returns>
         </member>
         <member name="M:Pulumirpc.ResourceProvider.ResourceProviderClient.ConfigureAsync(Pulumirpc.ConfigureRequest,Grpc.Core.CallOptions)">
-            <summary>
-            Configure configures the resource provider with "globals" that control its behavior.
-            </summary>
-            <param name="request">The request to send to the server.</param>
-            <param name="options">The options for the call.</param>
-            <returns>The call object.</returns>
+             <summary>
+             Configure configures the resource provider with "globals" that control its behavior.
+            
+             :::{warning}
+             ConfigureRequest.args may include secrets. Because ConfigureRequest is sent before
+             ConfigureResponse can specify acceptSecrets: false, providers *must* handle secrets from
+             ConfigureRequest.args.
+             :::
+             </summary>
+             <param name="request">The request to send to the server.</param>
+             <param name="options">The options for the call.</param>
+             <returns>The call object.</returns>
         </member>
         <member name="M:Pulumirpc.ResourceProvider.ResourceProviderClient.Invoke(Pulumirpc.InvokeRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">
             <summary>
@@ -9763,6 +9927,16 @@
         </member>
         <member name="F:Pulumirpc.Testing.PrepareLanguageTestsRequest.SnapshotEditsFieldNumber">
             <summary>Field number for the "snapshot_edits" field.</summary>
+        </member>
+        <member name="F:Pulumirpc.Testing.PrepareLanguageTestsRequest.LanguageInfoFieldNumber">
+            <summary>Field number for the "language_info" field.</summary>
+        </member>
+        <member name="P:Pulumirpc.Testing.PrepareLanguageTestsRequest.LanguageInfo">
+            <summary>
+            a JSON string that will be inserted into every schema loaded (for both GeneratePackage and GenerateProject) in
+            the "Languages[language_plugin_name]" field. This can be used to test language specific options such as
+            inputTypes in python.
+            </summary>
         </member>
         <member name="T:Pulumirpc.Testing.PrepareLanguageTestsRequest.Types">
             <summary>Container for nested types declared in the PrepareLanguageTestsRequest message type.</summary>


### PR DESCRIPTION
Introduce a new InputPropertiesError that allows users to return more error details from a component construct.