### PR TITLE
[ci/publishing] Fix generating nuget packages on build for dev releases

### DIFF
--- a/build/Publish.fs
+++ b/build/Publish.fs
@@ -35,18 +35,15 @@ type PublishResult =
         | otherwise -> false
 
 let publishSdk (projectDir: string) (version: string) (nugetApiKey: string) : PublishResult =
-    let cmd (name: string) = String.concat " " [
-        name
+    let buildNugetCmd = String.concat " " [
+        "build"
         "--configuration Release"
         $"-p:Version={version}"
     ]
 
-    if Shell.Exec("dotnet", cmd "build", projectDir) <> 0 then
+    if Shell.Exec("dotnet", buildNugetCmd, projectDir) <> 0 then
         PublishResult.Failed(projectDir, $"failed to build the project at {projectDir}")
     else
-        if Shell.Exec("dotnet", cmd "pack", projectDir) <> 0 then
-            PublishResult.Failed(projectDir, $"failed to pack the project at {projectDir}")
-        else
         let releaseDir = Path.Combine(projectDir, "bin", "Release")
         let releaseArtifacts = Directory.EnumerateFiles(releaseDir)
         if not (releaseArtifacts.Any()) then

--- a/sdk/Directory.Build.props
+++ b/sdk/Directory.Build.props
@@ -3,6 +3,5 @@
     <Nullable>enable</Nullable>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Resolves #351 

The error message in the issue suggests that `dotnet build` isn't creating the nuget package even though we have a property `GeneratePackageOnBuild` set in the project settings. 

~~This PR fixes the problem by explicitly executing `dotnet pack` against the projects before trying to find the nuget package and publishing it~~

EDIT: removed `TargetFramework` property from directory build props