### PR TITLE
feat(#203): RunException access modifier set to public. Docs updated

### DIFF
--- a/.changes/unreleased/Improvements-364.yaml
+++ b/.changes/unreleased/Improvements-364.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Pulumi.RunException is public
+time: 2024-10-16T12:40:31.206421+02:00
+custom:
+    PR: "364"

--- a/.changes/unreleased/Improvements-364.yaml
+++ b/.changes/unreleased/Improvements-364.yaml
@@ -1,6 +1,6 @@
 component: sdk
 kind: Improvements
-body: Pulumi.RunException is public
+body: Make Pulumi.RunException public
 time: 2024-10-16T12:40:31.206421+02:00
 custom:
     PR: "364"

--- a/sdk/Pulumi/Exceptions/RunException.cs
+++ b/sdk/Pulumi/Exceptions/RunException.cs
@@ -8,11 +8,12 @@ namespace Pulumi
     /// <summary>
     /// RunException can be used for terminating a program abruptly, but resulting in a clean exit
     /// rather than the usual verbose unhandled error logic which emits the source program text and
-    /// complete stack trace.  This type should be rarely used.  Ideally <see
+    /// complete stack trace.  This type should be rarely used and not be used by developers.
+    /// The reason to make it public is for it to be assertable by testing frameworks. Ideally <see
     /// cref="ResourceException"/> should always be used so that as many errors as possible can be
     /// associated with a Resource.
     /// </summary>
-    internal class RunException : Exception
+    public class RunException : Exception
     {
         public RunException(string message)
             : base(message)


### PR DESCRIPTION
As per discussion in #203 . This is a simple improvement in order to make the exception assertable by testing frameworks such as `FluentAssertions` using:

```csharp
var action = () => 
{
  // (...) // provision failing pulumi resources here
};

action.Should().Throw<Pulumi.RunException>();
```

This will significantly improve testing scenarios where exceptions are being thrown, as everything gets wrapped in an internal `Pulumi.RunException` while testing:

```csharp
// Disassembled code
internal static async Task<(ImmutableArray<Resource> Resources, Exception? Exception)> TryTestAsync(
            IMocks mocks, Func<IRunner, Task<int>> runAsync, TestOptions? options = null)
        {
            var engine = new MockEngine();
            var monitor = new MockMonitor(mocks);
            await CreateRunnerAndRunAsync(() => new Deployment(engine, monitor, options), runAsync).ConfigureAwait(false);
            Exception? err = engine.Errors.Count switch
            {
                1 => new RunException(engine.Errors.Single()), // <-- wrapping takes place here
                var v when v > 1 => new AggregateException(engine.Errors.Select(e => new RunException(e))),
                _ => null
            };
            return (Resources: monitor.Resources.ToImmutableArray(), Exception: err);
        }
```