### PR TITLE
Support input lists in JsonSerializer.SerializeAsync

### DIFF
--- a/.changes/unreleased/bug-fixes-368.yaml
+++ b/.changes/unreleased/bug-fixes-368.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Support input lists in JsonSerializer.SerializeAsync
+time: 2024-10-29T11:38:30.532438+01:00
+custom:
+    PR: "368"


### PR DESCRIPTION
Our `OutputJsonConverter` fails to account for `InputList<T>`, so any input lists nested in a serialized data structure causes serialization to fail. Reported by a customer trying to serialize Azure Native dashboard data types.

The fix expands `OutputJsonConverter` to support `InputList<T>`. It piggybacks on the existing `InputJsonConverterInner` implementation by passing an `ImmurableArray<T>` generic argument to it.

Fixes https://github.com/pulumi/pulumi-dotnet/issues/367