### PR TITLE
Generalize InputList<> serialization to maps and other Input<> subtypes

### DIFF
--- a/.changes/unreleased/bug-fixes-368.yaml
+++ b/.changes/unreleased/bug-fixes-368.yaml
@@ -1,6 +1,6 @@
 component: sdk
 kind: bug-fixes
-body: Support input lists in JsonSerializer.SerializeAsync
-time: 2024-10-29T11:38:30.532438+01:00
+body: Support input lists and maps in JsonSerializer.SerializeAsync
+time: 2024-10-30T11:38:30.532438+01:00
 custom:
     PR: "368"

--- a/sdk/Pulumi.Tests/Core/OutputTests.cs
+++ b/sdk/Pulumi.Tests/Core/OutputTests.cs
@@ -43,9 +43,12 @@ namespace Pulumi.Tests.Core
         {
             public InputList<int> Ints { get; set; }
 
-            public Item(InputList<int> ints)
+            public InputMap<int> IntMap { get; set; }
+
+            public Item(InputList<int> ints, InputMap<int> intMap)
             {
                 Ints = ints;
+                IntMap = intMap;
             }
         }
     }
@@ -691,15 +694,17 @@ namespace Pulumi.Tests.Core
             public Task JsonSerializeNestedLists()
                 => RunInNormal(async () =>
                 {
+                    var listv = new InputList<int> { 1, 2, 3 };
+                    var mapv = new InputMap<int> { { "K1", 4 } };
                     var v = new TestListStructure(
-                        new InputList<TestListStructure.Item> { new TestListStructure.Item(new InputList<int> { 1, 2, 3 }) }
+                        new InputList<TestListStructure.Item> { new TestListStructure.Item(listv, mapv) }
                     );
                     var o1 = CreateOutput(v, true);
                     var o2 = Output.JsonSerialize(o1);
                     var data = await o2.DataTask.ConfigureAwait(false);
                     Assert.True(data.IsKnown);
                     Assert.False(data.IsSecret);
-                    var expected = "{\"Items\":[{\"Ints\":[1,2,3]}]}";
+                    var expected = "{\"Items\":[{\"Ints\":[1,2,3],\"IntMap\":{\"K1\":4}}]}";
                     Assert.Equal(expected, data.Value);
                 });
 


### PR DESCRIPTION
#368 fixed `OutputJsonConverter` for `InputList<T>` but it still fails for `InputMap<T>`, so any input maps nested in a serialized data structure causes serialization to fail. Reported by a customer trying to serialize Azure Native dashboard data types.

The fix expands `OutputJsonConverter` to support any type that inherits from `Input<T>`, which includes both `InputList` and `InputMap`. It piggybacks on the existing `InputJsonConverterInner` implementation by passing the right generic argument to it.

Fixes https://github.com/pulumi/pulumi-dotnet/issues/367

Generalizes #368