### PR TITLE
Extending Config class to support passing JsonSerializerOptions

### DIFF
--- a/.changes/unreleased/Improvements-370.yaml
+++ b/.changes/unreleased/Improvements-370.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Extending Config class to support passing JsonSerializerOptions
+time: 2024-11-08T21:31:30+01:00
+custom:
+    PR: "370"

--- a/sdk/Pulumi.Tests/ConfigTests.cs
+++ b/sdk/Pulumi.Tests/ConfigTests.cs
@@ -1,0 +1,125 @@
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Pulumi.Tests
+{
+    public class ConfigTests
+    {
+        private Config target = new Config("cfg");
+        private Mock<IDeploymentInternal> deploymentInternal = new Mock<IDeploymentInternal>();
+        private const string PascalCaseJson = "{ \"Value\":\"Value\" }";
+        private const string CamelCaseJson = "{ \"value\":\"Value\" }";
+        private static readonly JsonSerializerOptions CamelCaseSerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+
+        public ConfigTests()
+        {
+            var runner = new Mock<IRunner>();
+            deploymentInternal.Setup(x => x.Runner).Returns(runner.Object);
+            Deployment.Instance = new DeploymentInstance(deploymentInternal.Object);
+        }
+
+
+        private class TestConfig
+        {
+            public string? Value { get; set; }
+        }
+
+        [Fact]
+        public void GetObjectReturnsObject()
+        {
+            deploymentInternal.Setup(x => x.GetConfig("cfg:test")).Returns(PascalCaseJson);
+
+            var result = target.GetObject<TestConfig>("test");
+
+            Assert.NotNull(result);
+            Assert.Equal("Value", result?.Value);
+        }
+
+        [Fact]
+        public void GetObjectReturnsObjectWithCustomJsonSerializerOptions()
+        {
+            deploymentInternal.Setup(x => x.GetConfig("cfg:test")).Returns(CamelCaseJson);
+
+            var result = target.GetObject<TestConfig>("test", CamelCaseSerializerOptions);
+
+            Assert.NotNull(result);
+            Assert.Equal("Value", result?.Value);
+        }
+
+        [Fact]
+        public async Task GetSecretObjectReturnsObject()
+        {
+            deploymentInternal.Setup(x => x.GetConfig("cfg:test")).Returns(PascalCaseJson);
+
+            var output = target.GetSecretObject<TestConfig>("test");
+            var result = await output.GetValueAsync(new TestConfig());
+
+            Assert.Equal("Value", result.Value);
+        }
+
+        [Fact]
+        public async Task GetSecretObjectReturnsObjectWithCustomJsonSerializerOptions()
+        {
+            deploymentInternal.Setup(x => x.GetConfig("cfg:test")).Returns(CamelCaseJson);
+
+            var output = target.GetSecretObject<TestConfig>("test", CamelCaseSerializerOptions);
+            var result = await output.GetValueAsync(new TestConfig());
+
+            Assert.Equal("Value", result.Value);
+        }
+
+        [Fact]
+        public void RequireObjectReturnsObject()
+        {
+            deploymentInternal.Setup(x => x.GetConfig("cfg:test")).Returns(PascalCaseJson);
+
+            var result = target.RequireObject<TestConfig>("test");
+
+            Assert.NotNull(result);
+            Assert.Equal("Value", result?.Value);
+        }
+
+        [Fact]
+        public void RequireObjectReturnsObjectWithCustomJsonSerializerOptions()
+        {
+            deploymentInternal.Setup(x => x.GetConfig("cfg:test")).Returns(CamelCaseJson);
+
+            var result = target.RequireObject<TestConfig>("test", CamelCaseSerializerOptions);
+
+            Assert.NotNull(result);
+            Assert.Equal("Value", result?.Value);
+        }
+
+        [Fact]
+        public async Task RequireSecretObjectReturnsObject()
+        {
+            deploymentInternal.Setup(x => x.GetConfig("cfg:test")).Returns(PascalCaseJson);
+
+            var output = target.RequireSecretObject<TestConfig>("test");
+            var result = await output.GetValueAsync(new TestConfig());
+
+            Assert.Equal("Value", result.Value);
+        }
+
+        [Fact]
+        public async Task RequireSecretObjectReturnsObjectWithCustomJsonSerializerOptions()
+        {
+            deploymentInternal.Setup(x => x.GetConfig("cfg:test")).Returns(CamelCaseJson);
+
+            var output = target.RequireSecretObject<TestConfig>("test", CamelCaseSerializerOptions);
+            var result = await output.GetValueAsync(new TestConfig());
+
+            Assert.Equal("Value", result.Value);
+        }
+    }
+}

--- a/sdk/Pulumi.Tests/ConfigTests.cs
+++ b/sdk/Pulumi.Tests/ConfigTests.cs
@@ -62,6 +62,7 @@ namespace Pulumi.Tests
             deploymentInternal.Setup(x => x.GetConfig("cfg:test")).Returns(PascalCaseJson);
 
             var output = target.GetSecretObject<TestConfig>("test");
+            Assert.NotNull(output);
             var result = await output.GetValueAsync(new TestConfig());
 
             Assert.Equal("Value", result.Value);
@@ -73,6 +74,7 @@ namespace Pulumi.Tests
             deploymentInternal.Setup(x => x.GetConfig("cfg:test")).Returns(CamelCaseJson);
 
             var output = target.GetSecretObject<TestConfig>("test", CamelCaseSerializerOptions);
+            Assert.NotNull(output);
             var result = await output.GetValueAsync(new TestConfig());
 
             Assert.Equal("Value", result.Value);

--- a/sdk/Pulumi/Config.cs
+++ b/sdk/Pulumi/Config.cs
@@ -174,7 +174,7 @@ namespace Pulumi
         /// it to <see cref="JsonSerializer.Deserialize{TValue}(string, JsonSerializerOptions)"/>.
         /// </summary>
         [return: MaybeNull]
-        public T GetObject<T>(string key, JsonSerializerOptions? options)
+        public T GetObject<T>(string key, JsonSerializerOptions options)
             => GetObjectImpl<T>(key, nameof(GetSecretObject), options: options);
 
         /// <summary>
@@ -193,11 +193,11 @@ namespace Pulumi
         /// </summary>
         public Output<T>? GetSecretObject<T>(string key, JsonSerializerOptions options)
         {
-            var v = GetImpl(key);
+            var v = GetObjectImpl<T>(key, options: options);
             if (v == null)
                 return null;
 
-            return Output.CreateSecret(GetObjectImpl<T>(key, options: options)!);
+            return Output.CreateSecret(v);
         }
 
         /// <summary>

--- a/sdk/Pulumi/Config.cs
+++ b/sdk/Pulumi/Config.cs
@@ -155,12 +155,12 @@ namespace Pulumi
             => MakeStructSecret(GetDoubleImpl(key));
 
         [return: MaybeNull]
-        private T GetObjectImpl<T>(string key, string? use = null, [CallerMemberName] string? insteadOf = null)
+        private T GetObjectImpl<T>(string key, string? use = null, [CallerMemberName] string? insteadOf = null, JsonSerializerOptions? options = null)
         {
             var v = GetImpl(key, use, insteadOf);
             try
             {
-                return v == null ? default : JsonSerializer.Deserialize<T>(v);
+                return v == null ? default : JsonSerializer.Deserialize<T>(v, options);
             }
             catch (JsonException ex)
             {
@@ -174,8 +174,31 @@ namespace Pulumi
         /// it to <see cref="JsonSerializer.Deserialize{TValue}(string, JsonSerializerOptions)"/>.
         /// </summary>
         [return: MaybeNull]
+        public T GetObject<T>(string key, JsonSerializerOptions? options)
+            => GetObjectImpl<T>(key, nameof(GetSecretObject), options: options);
+
+        /// <summary>
+        /// Loads an optional configuration value, as an object, by its key, or null if it doesn't
+        /// exist. This works by taking the value associated with <paramref name="key"/> and passing
+        /// it to <see cref="JsonSerializer.Deserialize{TValue}(string, JsonSerializerOptions)"/>.
+        /// </summary>
+        [return: MaybeNull]
         public T GetObject<T>(string key)
             => GetObjectImpl<T>(key, nameof(GetSecretObject));
+
+        /// <summary>
+        /// Loads an optional configuration value, as an object, by its key, marking it as a secret
+        /// or null if it doesn't exist. This works by taking the value associated with <paramref
+        /// name="key"/> and passing it to <see cref="JsonSerializer.Deserialize{TValue}(string, JsonSerializerOptions)"/>.
+        /// </summary>
+        public Output<T>? GetSecretObject<T>(string key, JsonSerializerOptions options)
+        {
+            var v = GetImpl(key);
+            if (v == null)
+                return null;
+
+            return Output.CreateSecret(GetObjectImpl<T>(key, options: options)!);
+        }
 
         /// <summary>
         /// Loads an optional configuration value, as an object, by its key, marking it as a secret
@@ -258,14 +281,23 @@ namespace Pulumi
         public Output<double> RequireSecretDouble(string key)
             => MakeStructSecret(RequireDoubleImpl(key));
 
-        private T RequireObjectImpl<T>(string key, string? use = null, [CallerMemberName] string? insteadOf = null)
+        private T RequireObjectImpl<T>(string key, string? use = null, [CallerMemberName] string? insteadOf = null, JsonSerializerOptions? options = null)
         {
             var v = GetImpl(key);
             if (v == null)
                 throw new ConfigMissingException(FullKey(key));
 
-            return GetObjectImpl<T>(key, use, insteadOf)!;
+            return GetObjectImpl<T>(key, use, insteadOf, options)!;
         }
+
+        /// <summary>
+        /// Loads a configuration value as a JSON string and deserializes the JSON into an object.
+        /// object. If it doesn't exist, or the configuration value cannot be converted using <see
+        /// cref="JsonSerializer.Deserialize{TValue}(string, JsonSerializerOptions)"/>, an error is
+        /// thrown.
+        /// </summary>
+        public T RequireObject<T>(string key, JsonSerializerOptions options)
+            => RequireObjectImpl<T>(key, nameof(RequireSecretObject), options: options);
 
         /// <summary>
         /// Loads a configuration value as a JSON string and deserializes the JSON into an object.
@@ -275,6 +307,15 @@ namespace Pulumi
         /// </summary>
         public T RequireObject<T>(string key)
             => RequireObjectImpl<T>(key, nameof(RequireSecretObject));
+
+        /// <summary>
+        /// Loads a configuration value as a JSON string and deserializes the JSON into a JavaScript
+        /// object, marking it as a secret. If it doesn't exist, or the configuration value cannot
+        /// be converted using <see cref="JsonSerializer.Deserialize{TValue}(string, JsonSerializerOptions)"/>,
+        /// an error is thrown.
+        /// </summary>
+        public Output<T> RequireSecretObject<T>(string key, JsonSerializerOptions options)
+            => Output.CreateSecret(RequireObjectImpl<T>(key, options: options));
 
         /// <summary>
         /// Loads a configuration value as a JSON string and deserializes the JSON into a JavaScript

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -78,11 +78,25 @@
             function will throw an error.
             </summary>
         </member>
+        <member name="M:Pulumi.Config.GetObject``1(System.String,System.Text.Json.JsonSerializerOptions)">
+            <summary>
+            Loads an optional configuration value, as an object, by its key, or null if it doesn't
+            exist. This works by taking the value associated with <paramref name="key"/> and passing
+            it to <see cref="M:System.Text.Json.JsonSerializer.Deserialize``1(System.String,System.Text.Json.JsonSerializerOptions)"/>.
+            </summary>
+        </member>
         <member name="M:Pulumi.Config.GetObject``1(System.String)">
             <summary>
             Loads an optional configuration value, as an object, by its key, or null if it doesn't
             exist. This works by taking the value associated with <paramref name="key"/> and passing
             it to <see cref="M:System.Text.Json.JsonSerializer.Deserialize``1(System.String,System.Text.Json.JsonSerializerOptions)"/>.
+            </summary>
+        </member>
+        <member name="M:Pulumi.Config.GetSecretObject``1(System.String,System.Text.Json.JsonSerializerOptions)">
+            <summary>
+            Loads an optional configuration value, as an object, by its key, marking it as a secret
+            or null if it doesn't exist. This works by taking the value associated with <paramref
+            name="key"/> and passing it to <see cref="M:System.Text.Json.JsonSerializer.Deserialize``1(System.String,System.Text.Json.JsonSerializerOptions)"/>.
             </summary>
         </member>
         <member name="M:Pulumi.Config.GetSecretObject``1(System.String)">
@@ -139,12 +153,28 @@
             If it doesn't exist, or the configuration value is not a legal number, an error is thrown.
             </summary>
         </member>
+        <member name="M:Pulumi.Config.RequireObject``1(System.String,System.Text.Json.JsonSerializerOptions)">
+            <summary>
+            Loads a configuration value as a JSON string and deserializes the JSON into an object.
+            object. If it doesn't exist, or the configuration value cannot be converted using <see
+            cref="M:System.Text.Json.JsonSerializer.Deserialize``1(System.String,System.Text.Json.JsonSerializerOptions)"/>, an error is
+            thrown.
+            </summary>
+        </member>
         <member name="M:Pulumi.Config.RequireObject``1(System.String)">
             <summary>
             Loads a configuration value as a JSON string and deserializes the JSON into an object.
             object. If it doesn't exist, or the configuration value cannot be converted using <see
             cref="M:System.Text.Json.JsonSerializer.Deserialize``1(System.String,System.Text.Json.JsonSerializerOptions)"/>, an error is
             thrown.
+            </summary>
+        </member>
+        <member name="M:Pulumi.Config.RequireSecretObject``1(System.String,System.Text.Json.JsonSerializerOptions)">
+            <summary>
+            Loads a configuration value as a JSON string and deserializes the JSON into a JavaScript
+            object, marking it as a secret. If it doesn't exist, or the configuration value cannot
+            be converted using <see cref="M:System.Text.Json.JsonSerializer.Deserialize``1(System.String,System.Text.Json.JsonSerializerOptions)"/>,
+            an error is thrown.
             </summary>
         </member>
         <member name="M:Pulumi.Config.RequireSecretObject``1(System.String)">


### PR DESCRIPTION
This PR address #370 

Extends `Config` class by providing `JsonSerializerOptions` overload to methods: GetObject, RequireObject, GetSecretObject, RequireSecretObject