### PR TITLE
Always send a computed property value for unknown values

### DIFF
--- a/.changes/unreleased/bug-fixes-375.yaml
+++ b/.changes/unreleased/bug-fixes-375.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Always send a computed property value for unknown values
+time: 2024-11-11T11:59:17.1828021+01:00
+custom:
+    PR: "375"

--- a/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
+++ b/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
@@ -523,7 +523,7 @@ public class PropertyValueTests
         var unknownWithDeps = OutputUtilities.WithDependency(OutputUtilities.CreateUnknown(""), resource);
         serialized = await serializer.Serialize(unknownWithDeps);
         expected = new PropertyValue(new OutputReference(
-            null,
+            PropertyValue.Computed,
             ImmutableHashSet.Create(new Urn("urn:pulumi::stack::proj::type::name"))));
         Assert.Equal(expected, serialized);
     }

--- a/sdk/Pulumi/Provider/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Provider/PropertyValueSerializer.cs
@@ -290,10 +290,14 @@ namespace Pulumi.Experimental.Provider
             {
                 var data = await output.GetDataAsync().ConfigureAwait(false);
 
-                PropertyValue? element = null;
+                PropertyValue element;
                 if (data.IsKnown)
                 {
                     element = await Serialize(data.Value);
+                }
+                else
+                {
+                    element = PropertyValue.Computed;
                 }
 
                 var dependantResources = ImmutableHashSet.CreateBuilder<Urn>();
@@ -303,22 +307,10 @@ namespace Pulumi.Experimental.Provider
                     dependantResources.Add(new Urn(urn));
                 }
 
-                PropertyValue outputValue;
-                if (dependantResources.Count == 0)
+                var outputValue = element;
+                if (dependantResources.Count != 0)
                 {
-                    if (element != null)
-                    {
-                        outputValue = element;
-                    }
-                    else
-                    {
-                        outputValue = PropertyValue.Computed;
-                    }
-                }
-                else
-                {
-                    outputValue = new PropertyValue(new OutputReference(
-                        value: element,
+                    outputValue = new PropertyValue(new OutputReference(value: outputValue,
                         dependencies: dependantResources.ToImmutable()));
                 }
 


### PR DESCRIPTION
For some reason there was a difference between how an Unkown Output with Deps and without was serialized.

This causes  Unkown Outpust with Deps to be desearilized into null values if read back.

This pr fixes this.