### PR TITLE
Add Output to the PropertyValueType's enum

### DIFF
--- a/sdk/Pulumi/Provider/PropertyValue.cs
+++ b/sdk/Pulumi/Provider/PropertyValue.cs
@@ -23,6 +23,7 @@ namespace Pulumi.Experimental.Provider
         Archive,
         Secret,
         Resource,
+        Output,
         Computed,
     }
 
@@ -169,6 +170,10 @@ namespace Pulumi.Experimental.Provider
                 else if (ResourceValue != null)
                 {
                     return PropertyValueType.Resource;
+                }
+                else if (OutputValue != null)
+                {
+                    return PropertyValueType.Output;
                 }
                 else if (IsComputed)
                 {


### PR DESCRIPTION
Note sure why we missed this before, but one of the possible types for a property value is an `OutputReference`, or `Output`.