### PR TITLE
Fix a bug with unknown secret deseralisation

### DIFF
--- a/.changes/unreleased/Bug Fixes-378.yaml
+++ b/.changes/unreleased/Bug Fixes-378.yaml
@@ -1,0 +1,6 @@
+component: sdk/provider
+kind: Bug Fixes
+body: Fix a bug deserialising unknown secrets
+time: 2024-11-11T16:45:34.030668345Z
+custom:
+  PR: "378"

--- a/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
+++ b/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
@@ -353,11 +353,24 @@ public class PropertyValueTests
     public async Task DeserializingUnknownInputsWorks()
     {
         var serializer = CreateSerializer();
-        var x = Output.Create("");
         var deserialized = await serializer.Deserialize<Input<string>>(PropertyValue.Computed);
         var output = deserialized.ToOutput();
-        var known = await OutputUtilities.GetIsKnownAsync(output);
-        Assert.False(known);
+        var data = await output.DataTask;
+        Assert.Null(data.Value);
+        Assert.False(data.IsSecret);
+        Assert.False(data.IsKnown);
+    }
+
+    [Fact]
+    public async Task DeserializingSecretUnknownInputsWorks()
+    {
+        var serializer = CreateSerializer();
+        var deserialized = await serializer.Deserialize<Input<string>>(new PropertyValue(PropertyValue.Computed));
+        var output = deserialized.ToOutput();
+        var data = await output.DataTask;
+        Assert.Null(data.Value);
+        Assert.True(data.IsSecret);
+        Assert.False(data.IsKnown);
     }
 
     [Fact]

--- a/sdk/Pulumi/Provider/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Provider/PropertyValueSerializer.cs
@@ -527,19 +527,15 @@ namespace Pulumi.Experimental.Provider
                     return newInputCtor.Invoke(new[] { CreateOutput(outputData) });
                 }
 
-                var unknownOutputData = createOutputData.Invoke(new object?[]
-                {
-                    ImmutableHashSet<Resource>.Empty, // resources
-                    null, // value
-                    false, // isKnown
-                    false // isSecret
-                });
-
-                var unknownOutput = CreateInput(unknownOutputData);
-
                 if (value.IsComputed)
                 {
-                    return unknownOutput;
+                    return CreateInput(createOutputData.Invoke(new object?[]
+                    {
+                        ImmutableHashSet<Resource>.Empty, // resources
+                        null, // value
+                        false, // isKnown
+                        false // isSecret
+                    }));
                 }
 
                 object GetOutputData(ImmutableHashSet<Resource>.Builder resources, PropertyValue propertyValue, bool isSecret)
@@ -566,7 +562,13 @@ namespace Pulumi.Experimental.Provider
                 {
                     if (secretValue.IsComputed)
                     {
-                        return unknownOutput;
+                        return CreateInput(createOutputData.Invoke(new object?[]
+                        {
+                            ImmutableHashSet<Resource>.Empty, // resources
+                            null, // value
+                            false, // isKnown
+                            true // isSecret
+                        }));
                     }
 
                     if (secretValue.TryGetOutput(out var secretOutput) && secretOutput.Value != null)


### PR DESCRIPTION
When deserializing a Secret property value if its inner value was `Unknown` we would return an input value without `isSecret` set because we reused a `unknownOutput` variable from higher up.

This removes that variable and replaces the two use sites with calls to create the output value directly, one without `isSecret` set  and one with it set.