### PR TITLE
Normalize Computed in OutputReferences to null

### DIFF
--- a/.changes/unreleased/Improvements-381.yaml
+++ b/.changes/unreleased/Improvements-381.yaml
@@ -1,0 +1,6 @@
+component: sdk/provider
+kind: Improvements
+body: OutputReference.Value will normalize to null for Computed values
+time: 2024-11-12T16:17:32.507153545Z
+custom:
+  PR: "381"

--- a/sdk/Pulumi/Core/Output.cs
+++ b/sdk/Pulumi/Core/Output.cs
@@ -437,6 +437,22 @@ namespace Pulumi
             }
         }
 
+        /// <summary>
+        /// This returns a new <see cref="Output{T}"/> that represents the same value as this output, but with
+        /// the extra dependencies specified.
+        /// </summary>
+        internal Output<T> WithDependencies(ImmutableHashSet<Resource> resources)
+        {
+            async Task<OutputData<T>> GetData()
+            {
+                var data = await DataTask.ConfigureAwait(false);
+                var combinedResources = data.Resources.Union(resources);
+                return new OutputData<T>(combinedResources, data.Value, data.IsKnown, data.IsSecret);
+            }
+
+            return new Output<T>(GetData());
+        }
+
         internal async Task<T> GetValueAsync(T whenUnknown)
         {
             var data = await DataTask.ConfigureAwait(false);

--- a/sdk/Pulumi/Provider/PropertyValue.cs
+++ b/sdk/Pulumi/Provider/PropertyValue.cs
@@ -72,11 +72,20 @@ namespace Pulumi.Experimental.Provider
 
     public readonly struct OutputReference : IEquatable<OutputReference>
     {
+        /// <summary>
+        /// The value of the output, if it is known. This will never be a `Computed` value as that's
+        /// equivilent to unknown and thus null.
+        /// </summary>
         public readonly PropertyValue? Value;
         public readonly ImmutableHashSet<Urn> Dependencies;
 
         public OutputReference(PropertyValue? value, ImmutableHashSet<Urn> dependencies)
         {
+            // Normalise `Computed` to null
+            if (value != null && value.IsComputed)
+            {
+                value = null;
+            }
             Value = value;
             Dependencies = dependencies;
         }


### PR DESCRIPTION
This changes the `PropertyValue` field (`Value`) in `OutputReferences` to normalize `Computed` values to `null` as we use that to represent _unknowns_.

As part of this I overhauled the serialisation logic for `Output<T>`/`Input<T>` to better handle nested property values (e.g. a secret in an output, or an output in a secret).