### PR TITLE
Add `pulumi stack change-secrets-provider` to automation api

### DIFF
--- a/.changes/unreleased/Improvements-383.yaml
+++ b/.changes/unreleased/Improvements-383.yaml
@@ -1,0 +1,6 @@
+component: sdk/auto
+kind: Improvements
+body: Add pulumi stack change-secrets-provider to automation api
+time: 2024-11-13T00:01:07.4649013Z
+custom:
+    PR: "383"

--- a/sdk/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -2331,5 +2331,34 @@ namespace Pulumi.Automation.Tests
                 Assert.NotEqual("", whoAmI.Url);
             }
         }
+
+        [Fact]
+        public async Task ChangeSecretsProvider()
+        {
+            var projectName = "change_secrets_provider_test";
+            var projectSettings = new ProjectSettings(projectName, ProjectRuntimeName.NodeJS);
+            var stackName = RandomStackName();
+
+            using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
+            {
+                ProjectSettings = projectSettings,
+                SecretsProvider = "passphrase",
+                EnvironmentVariables = new Dictionary<string, string?>
+                {
+                    ["PULUMI_CONFIG_PASSPHRASE"] = "test"
+                },
+            });
+
+            try
+            {
+                var stack = await WorkspaceStack.CreateAsync(stackName, workspace);
+                await Assert.ThrowsAsync<ArgumentNullException>(() => stack.ChangeSecretsProviderAsync("passphrase"));
+                await stack.ChangeSecretsProviderAsync("passphrase", new SecretsProviderOptions { NewPassphrase = "test2" });
+            }
+            finally
+            {
+                await workspace.RemoveStackAsync(stackName);
+            }
+        }
     }
 }

--- a/sdk/Pulumi.Automation/Commands/PulumiCommand.cs
+++ b/sdk/Pulumi.Automation/Commands/PulumiCommand.cs
@@ -24,5 +24,15 @@ namespace Pulumi.Automation.Commands
             Action<string>? onStandardError = null,
             Action<EngineEvent>? onEngineEvent = null,
             CancellationToken cancellationToken = default);
+
+        public abstract Task<CommandResult> RunInputAsync(
+            IList<string> args,
+            string workingDir,
+            IDictionary<string, string?> additionalEnv,
+            Action<string>? onStandardOutput = null,
+            Action<string>? onStandardError = null,
+            string? stdIn = null,
+            Action<EngineEvent>? onEngineEvent = null,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/sdk/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/Pulumi.Automation/LocalWorkspace.cs
@@ -849,6 +849,23 @@ namespace Pulumi.Automation
             return output.ToImmutableDictionary();
         }
 
+        public override Task ChangeSecretsProviderAsync(string stackName, string newSecretsProvider, SecretsProviderOptions? secretsProviderOptions, CancellationToken cancellationToken = default)
+        {
+            var args = new[] { "stack", "change-secrets-provider", "--stack", stackName, newSecretsProvider };
+
+            if (newSecretsProvider == "passphrase")
+            {
+                if (string.IsNullOrEmpty(secretsProviderOptions?.NewPassphrase))
+                {
+                    throw new ArgumentNullException(nameof(secretsProviderOptions), "New passphrase must be set when using passphrase provider.");
+                }
+
+                return this.RunInputCommandAsync(args, secretsProviderOptions.NewPassphrase, cancellationToken);
+            }
+
+            return this.RunCommandAsync(args, cancellationToken);
+        }
+
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);

--- a/sdk/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/Pulumi.Automation/Pulumi.Automation.xml
@@ -1348,6 +1348,16 @@
             supported for local backends.
             </summary>
         </member>
+        <member name="T:Pulumi.Automation.SecretsProviderOptions">
+            <summary>
+            Options to pass into <see cref="M:Pulumi.Automation.WorkspaceStack.ChangeSecretsProviderAsync(System.String,Pulumi.Automation.SecretsProviderOptions,System.Threading.CancellationToken)"/>.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.SecretsProviderOptions.NewPassphrase">
+            <summary>
+            The new Passphrase to use in the passphrase provider
+            </summary>
+        </member>
         <member name="T:Pulumi.Automation.StackDeployment">
             <summary>
             Represents the state of a stack deployment as used by
@@ -1834,6 +1844,15 @@
             Gets the current set of Stack outputs from the last <see cref="M:Pulumi.Automation.WorkspaceStack.UpAsync(Pulumi.Automation.UpOptions,System.Threading.CancellationToken)"/>.
             </summary>
             <param name="stackName">The name of the stack.</param>
+            <param name="cancellationToken">A cancellation token.</param>
+        </member>
+        <member name="M:Pulumi.Automation.Workspace.ChangeSecretsProviderAsync(System.String,System.String,Pulumi.Automation.SecretsProviderOptions,System.Threading.CancellationToken)">
+            <summary>
+            Change the secrets provider for a stack.
+            </summary>
+            <param name="stackName">The name of the stack.</param>
+            <param name="newSecretsProvider">The new secrets provider.</param>
+            <param name="secretsProviderOptions">The options to change the secrets provider.</param>
             <param name="cancellationToken">A cancellation token.</param>
         </member>
         <member name="T:Pulumi.Automation.WorkspaceStack">

--- a/sdk/Pulumi.Automation/SecretsProviderOptions.cs
+++ b/sdk/Pulumi.Automation/SecretsProviderOptions.cs
@@ -1,0 +1,15 @@
+// Copyright 2016-2021, Pulumi Corporation
+
+namespace Pulumi.Automation
+{
+    /// <summary>
+    /// Options to pass into <see cref="WorkspaceStack.ChangeSecretsProviderAsync(string, SecretsProviderOptions, System.Threading.CancellationToken)"/>.
+    /// </summary>
+    public class SecretsProviderOptions
+    {
+        /// <summary>
+        /// The new Passphrase to use in the passphrase provider
+        /// </summary>
+        public string? NewPassphrase { get; set; }
+    }
+}

--- a/sdk/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/Pulumi.Automation/WorkspaceStack.cs
@@ -295,6 +295,9 @@ namespace Pulumi.Automation
         public Task RemoveEnvironmentAsync(string environment, CancellationToken cancellationToken = default)
             => this.Workspace.RemoveEnvironmentAsync(this.Name, environment, cancellationToken);
 
+        public Task ChangeSecretsProviderAsync(string newSecretsProvider, SecretsProviderOptions? secretsProviderOptions = null, CancellationToken cancellationToken = default)
+            => this.Workspace.ChangeSecretsProviderAsync(this.Name, newSecretsProvider, secretsProviderOptions, cancellationToken);
+
         /// <summary>
         /// Creates or updates the resources in a stack by executing the program in the Workspace.
         /// <para/>


### PR DESCRIPTION
fixes #382 to add the command `pulumi stack change-secrets-provider` to the Automation API.

based on the go implementation https://github.com/pulumi/pulumi/pull/14039.

