### PR TITLE
DeferredOutput<T> 

### DIFF
--- a/.changes/unreleased/Improvements-385.yaml
+++ b/.changes/unreleased/Improvements-385.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Add `DeferredOutput` for resolving some output/input cycles
+time: 2024-11-19T08:28:36.110409Z
+custom:
+  PR: "385"

--- a/sdk/Pulumi.Tests/Core/OutputTests.cs
+++ b/sdk/Pulumi.Tests/Core/OutputTests.cs
@@ -918,6 +918,38 @@ namespace Pulumi.Tests.Core
                 Assert.False(data.IsSecret);
                 Assert.Equal("{ pip pip", data.Value);
             });
+
+
+            [Fact]
+            public Task DeferredOutput()
+                => RunInNormal(async () =>
+                {
+                    var defO = new DeferredOutput<int>();
+                    var o1 = CreateOutput(0, isKnown: true);
+
+                    Assert.False(defO.Output.DataTask.IsCompleted);
+                    defO.Resolve(o1);
+
+                    var data = await defO.Output.DataTask.ConfigureAwait(false);
+                    Assert.True(data.IsKnown);
+                    Assert.Equal(0, data.Value);
+                });
+
+            [Fact]
+            public Task DeferredOutputOnlySetOnce()
+                => RunInNormal(async () =>
+                {
+                    var defO = new DeferredOutput<int>();
+                    var o1 = CreateOutput(0, isKnown: true);
+                    defO.Resolve(o1);
+
+                    var o2 = CreateOutput(1, isKnown: true);
+                    Assert.Throws<System.InvalidOperationException>(() => defO.Resolve(o2));
+
+                    var data = await defO.Output.DataTask.ConfigureAwait(false);
+                    Assert.True(data.IsKnown);
+                    Assert.Equal(0, data.Value);
+                });
         }
     }
 }

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -779,6 +779,24 @@
              then).
              </summary>
         </member>
+        <member name="T:Pulumi.DeferredOutput`1">
+            <summary>
+            Represents the producer side of an <see cref="T:Pulumi.Output`1"/> value, providing access to the consumer side through
+            the Output property.
+            </summary>
+        </member>
+        <member name="P:Pulumi.DeferredOutput`1.Output">
+            <summary>
+            The <see cref="T:Pulumi.Output`1"/> that represents the consumer side of this <see cref="T:Pulumi.DeferredOutput`1"/>.
+            </summary>
+        </member>
+        <member name="M:Pulumi.DeferredOutput`1.Resolve(Pulumi.Output{`0})">
+            <summary>
+            Resolves the value of the <see cref="T:Pulumi.Output`1"/> represented by this <see
+            cref="T:Pulumi.DeferredOutput`1"/> to the same eventually resolved result as the provided <see
+            cref="T:Pulumi.Output`1"/>.
+            </summary>
+        </member>
         <member name="T:Pulumi.OutputExtensions">
             <summary>
             Extension methods for <see cref="T:Pulumi.Output`1"/>.


### PR DESCRIPTION
Adds `DeferredOutput<T>` that allows the creation of an `Output<T>` that can later be resolved to the final result of a different `Output<T>`.

This can be used to solve partial circular reference problems. For example given two components that create multiple resources and return some results from that, you would normally have to have all the inputs for one component available to call it and then afterwards call the other component. With an `DeferredOutput<T>` you can instead set up a circular reference:
```csharp
var ocs = new DeferredOutput<int>()
var (resultA1, resultA2) = MakeComponentA(ocs.Output);
var resultB = MakeComponentB(resultA1);
ocs.Resolve(resultB);
```
As long as `MakeComponentA` can resolve its A1 result without needing the incoming output resolved then the above will work.

Note that it's possible to deadlock the program with this feature. If resultA1 above can't resolve until the input is resolved, and resultB can't resolve till its input is resolved then both will end up stuck waiting for the other. Users can already deadlock their programs with other dotnet constructs (for example doing a similar thing with `TaskCompletionSource<T>`).
