### PR TITLE
Fix warning for Automation API inline programs

### DIFF
--- a/.changes/unreleased/bug-fixes-388.yaml
+++ b/.changes/unreleased/bug-fixes-388.yaml
@@ -1,0 +1,6 @@
+component: sdk/auto
+kind: bug-fixes
+body: Fix warning for inline programs
+time: 2024-11-14T23:34:52.002286-08:00
+custom:
+    PR: "388"

--- a/sdk/Pulumi.Automation/Runtime/LanguageRuntimeService.cs
+++ b/sdk/Pulumi.Automation/Runtime/LanguageRuntimeService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using Pulumirpc;
@@ -73,6 +74,15 @@ namespace Pulumi.Automation
             }
 
             return new RunResponse();
+        }
+
+        public override Task<Pulumirpc.PluginInfo> GetPluginInfo(Empty request, ServerCallContext context)
+        {
+            var response = new Pulumirpc.PluginInfo
+            {
+                Version = "1.0.0",
+            };
+            return Task.FromResult(response);
         }
 
         public class CallerContext


### PR DESCRIPTION
When using Automation API inline programs with Pulumi CLI v3.132.0 and later, a warning is emitted because the language host for .NET inline programs does not implement the `GetPluginInfo` RPC (from https://github.com/pulumi/pulumi/pull/17216).

This change adds an implementation for `GetPluginInfo`, which avoids the warning. The implementation returns `"1.0.0"` for the version, which matches [Node.js](https://github.com/pulumi/pulumi/blob/7461bddd65033ba6972e8404b711fd02c1bd5c20/sdk/nodejs/automation/server.ts#L140) and [Go](https://github.com/pulumi/pulumi/blob/7461bddd65033ba6972e8404b711fd02c1bd5c20/sdk/go/auto/stack.go#L1596) (though, [Python](https://github.com/pulumi/pulumi/blob/7461bddd65033ba6972e8404b711fd02c1bd5c20/sdk/python/lib/pulumi/automation/_server.py#L127-L128) returns an empty string).

Separately, we should consider updating the CLI to not emit the warning to users when the language host does not implement `GetPluginInfo`.

Fixes #369