### PR TITLE
Fix publishing SDKs to include required attribute for Pulumi.Automation

### DIFF
--- a/.changes/unreleased/bug-fixes-393.yaml
+++ b/.changes/unreleased/bug-fixes-393.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Fix publishing to set a required property used by the Automation Api to Install Pulumi cli
+time: 2024-11-18T17:27:24.3200139Z
+custom:
+    PR: "393"

--- a/Build.fsproj
+++ b/Build.fsproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Compile Include="build\GitSync.fs" />
     <Compile Include="build\Nuget.fs" />
+    <Compile Include="build\PulumiSdkVersion.fs" />
     <Compile Include="build\Publish.fs" />
     <Compile Include="build\Program.fs" />
   </ItemGroup>

--- a/build/GitSync.fs
+++ b/build/GitSync.fs
@@ -3,7 +3,6 @@ module GitSync
 open Fake.IO
 open Fake.Core
 open System.IO
-open System
 
 type SyncContent = {
     sourcePath: string list 

--- a/build/Nuget.fs
+++ b/build/Nuget.fs
@@ -1,7 +1,5 @@
 module Nuget
 
-open Newtonsoft
-open Newtonsoft.Json
 open Newtonsoft.Json.Linq
 open System.Net.Http
 

--- a/build/PulumiSdkVersion.fs
+++ b/build/PulumiSdkVersion.fs
@@ -1,0 +1,23 @@
+module PulumiSdkVersion
+
+open System.IO
+open System.Text.RegularExpressions
+
+// Find the version of the Pulumi Go SDK that we are using for the language plugin.
+let findGoSDKVersion (pulumiSdkPath: string) =
+    let goMod = Path.Combine(pulumiSdkPath, "go.mod")
+    try
+        let lines = File.ReadAllLines(goMod)
+        let patternRegex = new Regex("^\\s*github.com/pulumi/pulumi/sdk", RegexOptions.IgnoreCase)
+        match Array.tryFind (patternRegex.IsMatch) lines with
+        | Some(matchingLine) ->
+            let version = matchingLine.Split(' ')[1]
+            let version = version.TrimStart('v')
+            Some(version)
+        | None ->
+            None    
+    with
+    | ex ->
+        printfn "Error while trying to find the Go SDK version: %s" ex.Message
+
+        None

--- a/sdk/Pulumi.Automation/Commands/LocalPulumiCommand.cs
+++ b/sdk/Pulumi.Automation/Commands/LocalPulumiCommand.cs
@@ -108,9 +108,12 @@ namespace Pulumi.Automation.Commands
         {
             var sdkVersion = Assembly.GetExecutingAssembly()
                 .GetCustomAttributes(typeof(PulumiSdkVersionAttribute), false)
-                .Cast<PulumiSdkVersionAttribute>().First().Version;
+                .Cast<PulumiSdkVersionAttribute>().FirstOrDefault();
 
-            var version = options?.Version ?? sdkVersion;
+            var version = options?.Version
+                ?? sdkVersion?.Version
+                ?? throw new InvalidOperationException("No suitable Pulumi Cli version found to install.");
+
             var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             var optionsWithDefaults = new LocalPulumiCommandOptions
             {


### PR DESCRIPTION
Currently when publishing the Pulumi.Automation SDK there is an expected property PulumiSdkVersion which should be set when building the project

This property is set during buildSdk and testPulumiAutomationSdk but not the publishing targets which provide the resulting nuget package.

This means when a consumer references the Automation Api nuget package they have a version that does not have the required property set causing `LocalPulumiCommand.Install` to fail.

Refactored the F# code to ensure the version is set during publish as well

Fixes #392 