### PR TITLE
Fix RunPlugin

### DIFF
--- a/.changes/unreleased/Bug Fixes-395.yaml
+++ b/.changes/unreleased/Bug Fixes-395.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Bug Fixes
+body: Fix RunPlugin with new versions of the pulumi cli
+time: 2024-11-20T08:26:38.629389Z
+custom:
+  PR: "395"

--- a/pulumi-language-dotnet/main.go
+++ b/pulumi-language-dotnet/main.go
@@ -960,9 +960,12 @@ func (host *dotnetLanguageHost) RunPlugin(
 	default:
 		// Run from source.
 		args = append(args, "run")
-		if req.Program != "" {
-			args = append(args, "--project", req.Program)
+
+		project := req.Info.ProgramDirectory
+		if req.Info.EntryPoint != "" {
+			project = filepath.Join(project, req.Info.EntryPoint)
 		}
+		args = append(args, "--project", project)
 	}
 
 	// Add on all the request args to start this plugin
@@ -978,7 +981,7 @@ func (host *dotnetLanguageHost) RunPlugin(
 	cmd.Dir = req.Pwd
 	cmd.Env = req.Env
 	cmd.Stdout, cmd.Stderr = stdout, stderr
-	if err := cmd.Run(); err != nil {
+	if err = cmd.Run(); err != nil {
 		if exiterr, ok := err.(*exec.ExitError); ok {
 			// If the program ran, but exited with a non-zero error code.  This will happen often, since user
 			// errors will trigger this.  So, the error message should look as nice as possible.


### PR DESCRIPTION
Since https://github.com/pulumi/pulumi/pull/17763 the `pwd` property is the working directory, not the program directory. We need to fix up RunPlugin to use both directories correctly, loading the csproj from the program directory, but then setting the working directory to `pwd`.