### PR TITLE
Fix stdout tests

### DIFF
--- a/integration_tests/integration_dotnet_test.go
+++ b/integration_tests/integration_dotnet_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -39,10 +38,6 @@ import (
 
 // TestPrintfDotNet tests that we capture stdout and stderr streams properly, even when the last line lacks an \n.
 func TestPrintfDotNet(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("https://github.com/pulumi/pulumi-dotnet/issues/399")
-	}
-
 	testDotnetProgram(t, &integration.ProgramTestOptions{
 		Dir:                    "printf",
 		Quick:                  true,
@@ -487,15 +482,11 @@ func TestResourceRefsGetResourceDotnet(t *testing.T) {
 
 // TestSln tests that we run a program with a .sln file next to it.
 func TestSln(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("https://github.com/pulumi/pulumi-dotnet/issues/399")
-	}
-
 	validation := func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 		var foundStdout int
 		for _, ev := range stack.Events {
 			if de := ev.DiagnosticEvent; de != nil {
-				if strings.HasPrefix(de.Message, "With sln") {
+				if strings.Contains(de.Message, "With sln") {
 					foundStdout++
 				}
 			}
@@ -511,15 +502,11 @@ func TestSln(t *testing.T) {
 
 // TestSlnMultiple tests that we run a .sln file with multiple nested projects by setting the "main" option.
 func TestSlnMultipleNested(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("https://github.com/pulumi/pulumi-dotnet/issues/399")
-	}
-
 	validation := func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 		var foundStdout int
 		for _, ev := range stack.Events {
 			if de := ev.DiagnosticEvent; de != nil {
-				if strings.HasPrefix(de.Message, "With sln") {
+				if strings.Contains(de.Message, "With sln") {
 					foundStdout++
 				}
 			}

--- a/integration_tests/integration_util_test.go
+++ b/integration_tests/integration_util_test.go
@@ -378,9 +378,9 @@ func printfTestValidation(t *testing.T, stack integration.RuntimeValidationStack
 	var foundStderr int
 	for _, ev := range stack.Events {
 		if de := ev.DiagnosticEvent; de != nil {
-			if strings.HasPrefix(de.Message, fmt.Sprintf("Line %d", foundStdout)) {
+			if strings.Contains(de.Message, fmt.Sprintf("Line %d", foundStdout)) {
 				foundStdout++
-			} else if strings.HasPrefix(de.Message, fmt.Sprintf("Errln %d", foundStderr+10)) {
+			} else if strings.Contains(de.Message, fmt.Sprintf("Errln %d", foundStderr+10)) {
 				foundStderr++
 			}
 		}


### PR DESCRIPTION
Workaround for https://github.com/dotnet/sdk/issues/44610 In .NET 9.0 `dotnet run` will print progress indicators to the terminal, even though it should not do this when the output is redirected.

To allow the tests to continue passing we check for the expected substrings anywhere in the stdout messages, not just at the start.