### PR TITLE
ci: Bump macos-12 runner to macos-13

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-12]
+        os: [ubuntu-latest, windows-latest, macos-13]
         dotnet-version: [6.0.x, 8.0.x]
     runs-on: ${{ matrix.os }}
     steps:
@@ -115,17 +115,17 @@ jobs:
         run: |
           scoop install netcoredbg
       - name: Install netcoredbg (MacOS)
-        if: matrix.os == 'macos-12'
+        if: matrix.os == 'macos-13'
         id: netcoredbg
         run: |
           curl -sSL https://github.com/Samsung/netcoredbg/releases/download/3.1.1-1042/netcoredbg-osx-amd64.tar.gz -o netcoredbg.tar.gz
           tar xzf netcoredbg.tar.gz
           echo "netcoredbgpath=$(pwd)/netcoredbg/" >> ${GITHUB_OUTPUT}
       - name: Integration tests
-        if: matrix.os == 'macos-12'
+        if: matrix.os == 'macos-13'
         run: PATH="${{ steps.netcoredbg.outputs.netcoredbgpath}}":"$PATH" make test_integration
       - name: Integration tests
-        if: matrix.os != 'macos-12'
+        if: matrix.os != 'macos-13'
         run: make test_integration
 
   info:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -77,6 +77,19 @@ jobs:
         dotnet-version: [6.0.x, 8.0.x]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Set TARGET_FRAMEWORK
+        shell: bash
+        run: |
+          if [[ "${{ matrix.dotnet-version }}" == "6.0.x" ]]; then
+            echo "TARGET_FRAMEWORK=net6.0" >> $GITHUB_ENV
+          elif [[ "${{ matrix.dotnet-version }}" == "8.0.x" ]]; then
+            echo "TARGET_FRAMEWORK=net8.0" >> $GITHUB_ENV
+          elif [[ "${{ matrix.dotnet-version }}" == "9.0.x" ]]; then
+            echo "TARGET_FRAMEWORK=net9.0" >> $GITHUB_ENV
+          else
+            echo "Unexpected dotnet-version: ${{ matrix.dotnet-version }}"
+            exit 1
+          fi
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup dotnet SDK v6.0

--- a/Build.fsproj
+++ b/Build.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/PulumiSdkVersion.fs
+++ b/build/PulumiSdkVersion.fs
@@ -9,7 +9,7 @@ let findGoSDKVersion (pulumiSdkPath: string) =
     try
         let lines = File.ReadAllLines(goMod)
         let patternRegex = new Regex("^\\s*github.com/pulumi/pulumi/sdk", RegexOptions.IgnoreCase)
-        match Array.tryFind (patternRegex.IsMatch) lines with
+        match Array.tryFind (fun (line: string) -> patternRegex.IsMatch(line)) lines with
         | Some(matchingLine) ->
             let version = matchingLine.Split(' ')[1]
             let version = version.TrimStart('v')

--- a/integration_tests/about/about-csharp.csproj
+++ b/integration_tests/about/about-csharp.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/aliases/adopt_into_component/step1/Aliases.csproj
+++ b/integration_tests/aliases/adopt_into_component/step1/Aliases.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/aliases/rename/step1/Aliases.csproj
+++ b/integration_tests/aliases/rename/step1/Aliases.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/aliases/rename_component/step1/Aliases.csproj
+++ b/integration_tests/aliases/rename_component/step1/Aliases.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/aliases/rename_component_and_child/step1/Aliases.csproj
+++ b/integration_tests/aliases/rename_component_and_child/step1/Aliases.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/aliases/retype_component/step1/Aliases.csproj
+++ b/integration_tests/aliases/retype_component/step1/Aliases.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/aliases/retype_parents/step1/Aliases.csproj
+++ b/integration_tests/aliases/retype_parents/step1/Aliases.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/config_basic/ConfigBasic.csproj
+++ b/integration_tests/config_basic/ConfigBasic.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/config_secrets_warn/ConfigSecrets.csproj
+++ b/integration_tests/config_secrets_warn/ConfigSecrets.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/construct_component/dotnet/ConstructComponent.csproj
+++ b/integration_tests/construct_component/dotnet/ConstructComponent.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/construct_component_methods/dotnet/ConstructComponent.csproj
+++ b/integration_tests/construct_component_methods/dotnet/ConstructComponent.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/construct_component_methods_errors/dotnet/ConstructComponent.csproj
+++ b/integration_tests/construct_component_methods_errors/dotnet/ConstructComponent.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/construct_component_methods_unknown/dotnet/ConstructComponent.csproj
+++ b/integration_tests/construct_component_methods_unknown/dotnet/ConstructComponent.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/construct_component_plain/dotnet/ConstructComponent.csproj
+++ b/integration_tests/construct_component_plain/dotnet/ConstructComponent.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/construct_component_provider/dotnet/ConstructComponent.csproj
+++ b/integration_tests/construct_component_provider/dotnet/ConstructComponent.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/construct_component_unknown/dotnet/ConstructComponent.csproj
+++ b/integration_tests/construct_component_unknown/dotnet/ConstructComponent.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/deleted_with/DeletedWith.csproj
+++ b/integration_tests/deleted_with/DeletedWith.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/dotnet_service_provider/StackComponent.csproj
+++ b/integration_tests/dotnet_service_provider/StackComponent.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/empty/Empty.csproj
+++ b/integration_tests/empty/Empty.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/integration_tests/failing_transformation_exits/failing_transformation_exits.csproj
+++ b/integration_tests/failing_transformation_exits/failing_transformation_exits.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/gather_plugin/test-provider-url-dotnet.csproj
+++ b/integration_tests/gather_plugin/test-provider-url-dotnet.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/get_resource/GetResource.csproj
+++ b/integration_tests/get_resource/GetResource.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/integration_tests/large_resource/large_resource_dotnet.csproj
+++ b/integration_tests/large_resource/large_resource_dotnet.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/printf/Printf.csproj
+++ b/integration_tests/printf/Printf.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/provider/Provider.csproj
+++ b/integration_tests/provider/Provider.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/provider_call/dotnet/ProviderCall.csproj
+++ b/integration_tests/provider_call/dotnet/ProviderCall.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/provider_call/testcomponent-dotnet/TestProvider.csproj
+++ b/integration_tests/provider_call/testcomponent-dotnet/TestProvider.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AssemblyName>pulumi-resource-test</AssemblyName>
   </PropertyGroup>

--- a/integration_tests/provider_construct/dotnet/ProviderConstruct.csproj
+++ b/integration_tests/provider_construct/dotnet/ProviderConstruct.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/provider_construct/testcomponent-dotnet/TestProvider.csproj
+++ b/integration_tests/provider_construct/testcomponent-dotnet/TestProvider.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AssemblyName>pulumi-resource-test</AssemblyName>
   </PropertyGroup>

--- a/integration_tests/provider_construct_dependencies/dotnet/ProviderConstructDependencies.csproj
+++ b/integration_tests/provider_construct_dependencies/dotnet/ProviderConstructDependencies.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/provider_construct_dependencies/testcomponent-dotnet/TestProvider.csproj
+++ b/integration_tests/provider_construct_dependencies/testcomponent-dotnet/TestProvider.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AssemblyName>pulumi-resource-test</AssemblyName>
   </PropertyGroup>

--- a/integration_tests/provider_construct_unknown/dotnet/ProviderConstructUnknown.csproj
+++ b/integration_tests/provider_construct_unknown/dotnet/ProviderConstructUnknown.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/provider_construct_unknown/testcomponent-dotnet/TestProvider.csproj
+++ b/integration_tests/provider_construct_unknown/testcomponent-dotnet/TestProvider.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AssemblyName>pulumi-resource-test</AssemblyName>
   </PropertyGroup>

--- a/integration_tests/resource_refs_get_resource/ResourceRefsGetResource.csproj
+++ b/integration_tests/resource_refs_get_resource/ResourceRefsGetResource.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/sln/Sln.csproj
+++ b/integration_tests/sln/Sln.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/sln_multiple_nested/Library/Libary.csproj
+++ b/integration_tests/sln_multiple_nested/Library/Libary.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/sln_multiple_nested/Program/Program.csproj
+++ b/integration_tests/sln_multiple_nested/Program/Program.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/stack_component/StackComponent.csproj
+++ b/integration_tests/stack_component/StackComponent.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/stack_outputs/StackOutputs.csproj
+++ b/integration_tests/stack_outputs/StackOutputs.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/integration_tests/stack_reference/StackReference.csproj
+++ b/integration_tests/stack_reference/StackReference.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/integration_tests/stack_reference_secrets/step1/StackReference.csproj
+++ b/integration_tests/stack_reference_secrets/step1/StackReference.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/integration_tests/testprovider/TestProvider.csproj
+++ b/integration_tests/testprovider/TestProvider.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/transformations_remote/Transformations.csproj
+++ b/integration_tests/transformations_remote/Transformations.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/transformations_simple/Transformations.csproj
+++ b/integration_tests/transformations_simple/Transformations.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/integration_tests/utils/Pulumi.IntegrationTests.Utils.csproj
+++ b/integration_tests/utils/Pulumi.IntegrationTests.Utils.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/10721:

> GitHub Actions is starting the deprecation process for `macOS 12`. While the image is being deprecated, You may experience longer queue times during peak usage hours. Deprecation will begin on 10/7/24 and the image will be fully unsupported by 12/3/24
>
> To raise awareness of the upcoming removal, we will temporarily fail jobs using `macOS 12`. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
>
> * November 4, 14:00 UTC - November 5, 00:00 UTC
> * November 11, 14:00 UTC - November 12, 00:00 UTC
> * November 18, 14:00 UTC - November 19, 00:00 UTC
> * November 25, 14:00 UTC - November 26, 00:00 UTC
>
> ### Target date
> December 3rd, 2024