### PR TITLE
Reduce binary size by stripping debug information

### DIFF
--- a/.changes/unreleased/Improvements-411.yaml
+++ b/.changes/unreleased/Improvements-411.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: Reduce binary size by stripping debug information
+time: 2024-11-26T17:25:44.252633+01:00
+custom:
+    PR: "411"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,8 +14,10 @@ builds:
     - amd64
     - arm64
   mod_timestamp: '{{ .CommitTimestamp }}'
+  flags:
+    - -trimpath
   ldflags:
-    - -X github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/version.Version={{.Tag}}
+    - -w -s -X github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/version.Version={{.Tag}}
 
 archives:
 - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"


### PR DESCRIPTION
Strip the symbol table and DWARF debug information from the production
and dev releases. Note that stack traces don't lose any information from this change.

See https://github.com/pulumi/pulumi/pull/17868
