### PR TITLE
Allow specifying dependencies for output invokes

### DIFF
--- a/.changes/unreleased/Improvements-412.yaml
+++ b/.changes/unreleased/Improvements-412.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Allow specifiying dependencies for output invokes
+time: 2024-11-27T14:37:33.985033+01:00
+custom:
+    PR: "412"

--- a/.changes/unreleased/Improvements-412.yaml
+++ b/.changes/unreleased/Improvements-412.yaml
@@ -1,6 +1,6 @@
 component: sdk
 kind: Improvements
-body: Allow specifiying dependencies for output invokes
+body: Allow specifying dependencies for output invokes
 time: 2024-11-27T14:37:33.985033+01:00
 custom:
     PR: "412"

--- a/sdk/Pulumi.Tests/Deployment/DeploymentInvokeDependsOnTests.cs
+++ b/sdk/Pulumi.Tests/Deployment/DeploymentInvokeDependsOnTests.cs
@@ -1,0 +1,110 @@
+// Copyright 2016-2021, Pulumi Corporation
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+using Pulumi.Testing;
+using Pulumi.Tests.Mocks;
+
+namespace Pulumi.Tests
+{
+    public class DeploymentInvokeDependsOnTests
+    {
+        [Fact]
+        public async Task DeploymentInvokeDependsOn()
+        {
+
+            var mocks = new InvokeMocks();
+            var testOptions = new TestOptions();
+            var (resources, outputs) = await Deployment.TestAsync(mocks, testOptions, () =>
+            {
+                var resource = new MyCustomResource("some-resource", null, new CustomResourceOptions());
+                var deps = new InputList<Resource>();
+                deps.Add(resource);
+
+                var resultOutput = TestFunction.Invoke(new FunctionArgs(), new InvokeOutputOptions { DependsOn = deps }).Apply(result =>
+                {
+                    Assert.Equal("my value", result.TestValue);
+                    Assert.True(mocks.Resolved); // The resource should have been awaited
+                    return result;
+                });
+
+                return new Dictionary<string, object?>
+                {
+                    ["functionResult"] = resultOutput,
+                };
+            });
+
+            if (outputs["functionResult"] is Output<FunctionResult> functionResult)
+            {
+
+                // functionResult
+
+                var value = await functionResult.GetValueAsync(new FunctionResult(""));
+                Assert.Equal("my value", value.TestValue);
+            }
+            else
+            {
+                throw new Exception($"Expected result to be of type Output<FunctionResult>");
+            }
+        }
+
+        public sealed class MyArgs : ResourceArgs { }
+
+        [ResourceType("test:DeploymentInvokeDependsOnTests:resource", null)]
+        private class MyCustomResource : CustomResource
+        {
+            public MyCustomResource(string name, MyArgs? args, CustomResourceOptions? options = null)
+                : base("test:DeploymentInvokeDependsOnTests:resource", name, args ?? new MyArgs(), options)
+            {
+            }
+        }
+
+        public sealed class FunctionArgs : global::Pulumi.InvokeArgs { }
+
+        [OutputType]
+        public sealed class FunctionResult
+        {
+            [Output("testValue")]
+            public string TestValue { get; set; }
+
+            [OutputConstructor]
+            public FunctionResult(string testValue)
+            {
+                TestValue = testValue;
+            }
+        }
+
+        public static class TestFunction
+        {
+            public static Output<FunctionResult> Invoke(FunctionArgs args, InvokeOptions? options = null)
+                => global::Pulumi.Deployment.Instance.Invoke<FunctionResult>("mypkg::func", args ?? new FunctionArgs(), options);
+        }
+
+        class InvokeMocks : IMocks
+        {
+            public bool Resolved = false;
+
+
+            public Task<object> CallAsync(MockCallArgs args)
+            {
+                return Task.FromResult<object>(new Dictionary<string, object>()
+                {
+                    ["testValue"] = "my value"
+                });
+            }
+
+            public async Task<(string? id, object state)> NewResourceAsync(MockResourceArgs args)
+            {
+                await Task.Delay(3000);
+                Resolved = true;
+                return ("id", new Dictionary<string, object>());
+            }
+        }
+    }
+}

--- a/sdk/Pulumi.Tests/Deployment/DeploymentInvokeDependsOnTests.cs
+++ b/sdk/Pulumi.Tests/Deployment/DeploymentInvokeDependsOnTests.cs
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation
+// Copyright 2024, Pulumi Corporation
 
 using System;
 using System.Collections.Generic;

--- a/sdk/Pulumi/Deployment/DeploymentInstance.cs
+++ b/sdk/Pulumi/Deployment/DeploymentInstance.cs
@@ -46,7 +46,22 @@ namespace Pulumi
         public Output<T> Invoke<T>(
             string token,
             InvokeArgs args,
+            InvokeOutputOptions? options,
+            RegisterPackageRequest? registerPackageRequest)
+            => _deployment.Invoke<T>(token, args, options, registerPackageRequest);
+
+        /// <inheritdoc />
+        public Output<T> Invoke<T>(
+            string token,
+            InvokeArgs args,
             InvokeOptions? options = null)
+            => _deployment.Invoke<T>(token, args, options, null);
+
+        /// <inheritdoc />
+        public Output<T> Invoke<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOutputOptions? options = null)
             => _deployment.Invoke<T>(token, args, options, null);
 
         /// <inheritdoc />
@@ -61,7 +76,22 @@ namespace Pulumi
         public Output<T> InvokeSingle<T>(
             string token,
             InvokeArgs args,
+            InvokeOutputOptions? options,
+            RegisterPackageRequest? registerPackageRequest)
+            => _deployment.InvokeSingle<T>(token, args, options, registerPackageRequest);
+
+        /// <inheritdoc />
+        public Output<T> InvokeSingle<T>(
+            string token,
+            InvokeArgs args,
             InvokeOptions? options = null)
+            => _deployment.InvokeSingle<T>(token, args, options, null);
+
+        /// <inheritdoc />
+        public Output<T> InvokeSingle<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOutputOptions? options = null)
             => _deployment.InvokeSingle<T>(token, args, options, null);
 
         /// <inheritdoc />

--- a/sdk/Pulumi/Deployment/DeploymentInstance.cs
+++ b/sdk/Pulumi/Deployment/DeploymentInstance.cs
@@ -46,7 +46,7 @@ namespace Pulumi
         public Output<T> Invoke<T>(
             string token,
             InvokeArgs args,
-            InvokeOutputOptions? options,
+            InvokeOutputOptions options,
             RegisterPackageRequest? registerPackageRequest)
             => _deployment.Invoke<T>(token, args, options, registerPackageRequest);
 
@@ -61,7 +61,7 @@ namespace Pulumi
         public Output<T> Invoke<T>(
             string token,
             InvokeArgs args,
-            InvokeOutputOptions? options = null)
+            InvokeOutputOptions options)
             => _deployment.Invoke<T>(token, args, options, null);
 
         /// <inheritdoc />
@@ -76,7 +76,7 @@ namespace Pulumi
         public Output<T> InvokeSingle<T>(
             string token,
             InvokeArgs args,
-            InvokeOutputOptions? options,
+            InvokeOutputOptions options,
             RegisterPackageRequest? registerPackageRequest)
             => _deployment.InvokeSingle<T>(token, args, options, registerPackageRequest);
 
@@ -91,7 +91,7 @@ namespace Pulumi
         public Output<T> InvokeSingle<T>(
             string token,
             InvokeArgs args,
-            InvokeOutputOptions? options = null)
+            InvokeOutputOptions options)
             => _deployment.InvokeSingle<T>(token, args, options, null);
 
         /// <inheritdoc />

--- a/sdk/Pulumi/Deployment/Deployment_Invoke.cs
+++ b/sdk/Pulumi/Deployment/Deployment_Invoke.cs
@@ -57,14 +57,14 @@ namespace Pulumi
         Output<T> IDeployment.Invoke<T>(
             string token,
             InvokeArgs args,
-            InvokeOutputOptions? options,
+            InvokeOutputOptions options,
             RegisterPackageRequest? registerPackageRequest)
             => new Output<T>(RawInvoke<T>(token, args, options, registerPackageRequest));
 
         Output<T> IDeployment.Invoke<T>(string token, InvokeArgs args, InvokeOptions? options)
             => new Output<T>(RawInvoke<T>(token, args, options, registerPackageRequest: null));
 
-        Output<T> IDeployment.Invoke<T>(string token, InvokeArgs args, InvokeOutputOptions? options)
+        Output<T> IDeployment.Invoke<T>(string token, InvokeArgs args, InvokeOutputOptions options)
         => new Output<T>(RawInvoke<T>(token, args, options, registerPackageRequest: null));
 
 
@@ -81,7 +81,7 @@ namespace Pulumi
         Output<T> IDeployment.InvokeSingle<T>(
             string token,
             InvokeArgs args,
-            InvokeOutputOptions? options,
+            InvokeOutputOptions options,
             RegisterPackageRequest? registerPackageRequest)
         {
             var outputResult = new Output<Dictionary<string, T>>(RawInvoke<Dictionary<string, T>>(token, args, options, registerPackageRequest));
@@ -95,7 +95,7 @@ namespace Pulumi
             return outputResult.Apply(outputs => outputs.Values.First());
         }
 
-        Output<T> IDeployment.InvokeSingle<T>(string token, InvokeArgs args, InvokeOutputOptions? options)
+        Output<T> IDeployment.InvokeSingle<T>(string token, InvokeArgs args, InvokeOutputOptions options)
         {
             var outputResult = new Output<Dictionary<string, T>>(
                 RawInvoke<Dictionary<string, T>>(token, args, options, registerPackageRequest: null));

--- a/sdk/Pulumi/Deployment/IDeployment.cs
+++ b/sdk/Pulumi/Deployment/IDeployment.cs
@@ -116,7 +116,7 @@ namespace Pulumi
         Output<T> Invoke<T>(
             string token,
             InvokeArgs args,
-            InvokeOutputOptions? options = null);
+            InvokeOutputOptions options);
 
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace Pulumi
         Output<T> Invoke<T>(
             string token,
             InvokeArgs args,
-            InvokeOutputOptions? options,
+            InvokeOutputOptions options,
             RegisterPackageRequest? registerPackageRequest);
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace Pulumi
         Output<T> InvokeSingle<T>(
             string token,
             InvokeArgs args,
-            InvokeOutputOptions? options = null);
+            InvokeOutputOptions options);
 
         /// <summary>
         /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
@@ -210,7 +210,7 @@ namespace Pulumi
         Output<T> InvokeSingle<T>(
             string token,
             InvokeArgs args,
-            InvokeOutputOptions? options,
+            InvokeOutputOptions options,
             RegisterPackageRequest? registerPackageRequest);
 
         /// <summary>

--- a/sdk/Pulumi/Deployment/IDeployment.cs
+++ b/sdk/Pulumi/Deployment/IDeployment.cs
@@ -107,6 +107,22 @@ namespace Pulumi
         /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
         /// provider plugin.
         /// <para/>
+        /// The result of <see cref="Invoke{T}(string, InvokeArgs, InvokeOptions)"/> will be a <see cref="Output"/> resolved to the
+        /// result value of the provider plugin.
+        /// <para/>
+        /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+        /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
+        /// </summary>
+        Output<T> Invoke<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOutputOptions? options = null);
+
+
+        /// <summary>
+        /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
+        /// provider plugin.
+        /// <para/>
         /// The result of <see cref="Invoke{T}(string, InvokeArgs, InvokeOptions, RegisterPackageRequest)"/> will be a <see cref="Output"/> resolved to the
         /// result value of the provider plugin.
         /// <para/>
@@ -117,6 +133,22 @@ namespace Pulumi
             string token,
             InvokeArgs args,
             InvokeOptions? options,
+            RegisterPackageRequest? registerPackageRequest);
+
+        /// <summary>
+        /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
+        /// provider plugin.
+        /// <para/>
+        /// The result of <see cref="Invoke{T}(string, InvokeArgs, InvokeOutputOptions, RegisterPackageRequest)"/> will be a <see cref="Output"/> resolved to the
+        /// result value of the provider plugin.
+        /// <para/>
+        /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+        /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
+        /// </summary>
+        Output<T> Invoke<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOutputOptions? options,
             RegisterPackageRequest? registerPackageRequest);
 
         /// <summary>
@@ -138,6 +170,21 @@ namespace Pulumi
         /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
         /// provider plugin.
         /// <para/>
+        /// The result of <see cref="InvokeSingle{T}(string, InvokeArgs, InvokeOutputOptions)"/> will be a <see cref="Output"/> resolved to the
+        /// result value of the provider plugin that returns a bag of properties with a single value that is returned.
+        /// <para/>
+        /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+        /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
+        /// </summary>
+        Output<T> InvokeSingle<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOutputOptions? options = null);
+
+        /// <summary>
+        /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
+        /// provider plugin.
+        /// <para/>
         /// The result of <see cref="InvokeSingle{T}(string, InvokeArgs, InvokeOptions, RegisterPackageRequest)"/> will be a <see cref="Output"/> resolved to the
         /// result value of the provider plugin that returns a bag of properties with a single value that is returned.
         /// <para/>
@@ -148,6 +195,22 @@ namespace Pulumi
             string token,
             InvokeArgs args,
             InvokeOptions? options,
+            RegisterPackageRequest? registerPackageRequest);
+
+        /// <summary>
+        /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
+        /// provider plugin.
+        /// <para/>
+        /// The result of <see cref="InvokeSingle{T}(string, InvokeArgs, InvokeOutputOptions, RegisterPackageRequest)"/> will be a <see cref="Output"/> resolved to the
+        /// result value of the provider plugin that returns a bag of properties with a single value that is returned.
+        /// <para/>
+        /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+        /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
+        /// </summary>
+        Output<T> InvokeSingle<T>(
+            string token,
+            InvokeArgs args,
+            InvokeOutputOptions? options,
             RegisterPackageRequest? registerPackageRequest);
 
         /// <summary>

--- a/sdk/Pulumi/Deployment/InvokeOptions.cs
+++ b/sdk/Pulumi/Deployment/InvokeOptions.cs
@@ -33,7 +33,7 @@ namespace Pulumi
     }
 
     /// <summary>
-    /// Options to help control the behavior of <see cref="IDeployment.InvokeAsync{T}(string, InvokeArgs, InvokeOutputOptions, RegisterPackageRequest)"/>.
+    /// Options to help control the behavior of <see cref="IDeployment.Invoke{T}(string, InvokeArgs, InvokeOutputOptions, RegisterPackageRequest)"/>.
     /// </summary>
     public class InvokeOutputOptions : InvokeOptions
     {

--- a/sdk/Pulumi/Deployment/InvokeOptions.cs
+++ b/sdk/Pulumi/Deployment/InvokeOptions.cs
@@ -32,6 +32,9 @@ namespace Pulumi
         public string? PluginDownloadURL { get; set; }
     }
 
+    /// <summary>
+    /// Options to help control the behavior of <see cref="IDeployment.InvokeAsync{T}(string, InvokeArgs, InvokeOutputOptions, RegisterPackageRequest)"/>.
+    /// </summary>
     public class InvokeOutputOptions : InvokeOptions
     {
         private InputList<Resource>? _dependsOn;

--- a/sdk/Pulumi/Deployment/InvokeOptions.cs
+++ b/sdk/Pulumi/Deployment/InvokeOptions.cs
@@ -31,4 +31,18 @@ namespace Pulumi
         /// </summary>
         public string? PluginDownloadURL { get; set; }
     }
+
+    public class InvokeOutputOptions : InvokeOptions
+    {
+        private InputList<Resource>? _dependsOn;
+
+        /// <summary>
+        /// Optional additional explicit dependencies on resources.
+        /// </summary>
+        public InputList<Resource> DependsOn
+        {
+            get => _dependsOn ??= new InputList<Resource>();
+            set => _dependsOn = value;
+        }
+    }
 }

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -1719,6 +1719,11 @@
             used when performing this invoke.
             </summary>
         </member>
+        <member name="T:Pulumi.InvokeOutputOptions">
+            <summary>
+            Options to help control the behavior of <see cref="M:Pulumi.IDeployment.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOutputOptions,Pulumi.RegisterPackageRequest)"/>.
+            </summary>
+        </member>
         <member name="P:Pulumi.InvokeOutputOptions.DependsOn">
             <summary>
             Optional additional explicit dependencies on resources.

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -1421,13 +1421,25 @@
         <member name="M:Pulumi.DeploymentInstance.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <inheritdoc />
         </member>
+        <member name="M:Pulumi.DeploymentInstance.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOutputOptions,Pulumi.RegisterPackageRequest)">
+            <inheritdoc />
+        </member>
         <member name="M:Pulumi.DeploymentInstance.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+            <inheritdoc />
+        </member>
+        <member name="M:Pulumi.DeploymentInstance.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOutputOptions)">
             <inheritdoc />
         </member>
         <member name="M:Pulumi.DeploymentInstance.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <inheritdoc />
         </member>
+        <member name="M:Pulumi.DeploymentInstance.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOutputOptions,Pulumi.RegisterPackageRequest)">
+            <inheritdoc />
+        </member>
         <member name="M:Pulumi.DeploymentInstance.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)">
+            <inheritdoc />
+        </member>
+        <member name="M:Pulumi.DeploymentInstance.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOutputOptions)">
             <inheritdoc />
         </member>
         <member name="M:Pulumi.DeploymentInstance.InvokeAsync``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
@@ -1546,12 +1558,36 @@
             <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
             </summary>
         </member>
+        <member name="M:Pulumi.IDeployment.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOutputOptions)">
+            <summary>
+            Dynamically invokes the function '<paramref name="token"/>', which is offered by a
+            provider plugin.
+            <para/>
+            The result of <see cref="M:Pulumi.IDeployment.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
+            result value of the provider plugin.
+            <para/>
+            The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+            <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
+            </summary>
+        </member>
         <member name="M:Pulumi.IDeployment.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <summary>
             Dynamically invokes the function '<paramref name="token"/>', which is offered by a
             provider plugin.
             <para/>
             The result of <see cref="M:Pulumi.IDeployment.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
+            result value of the provider plugin.
+            <para/>
+            The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+            <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
+            </summary>
+        </member>
+        <member name="M:Pulumi.IDeployment.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOutputOptions,Pulumi.RegisterPackageRequest)">
+            <summary>
+            Dynamically invokes the function '<paramref name="token"/>', which is offered by a
+            provider plugin.
+            <para/>
+            The result of <see cref="M:Pulumi.IDeployment.Invoke``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOutputOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
             result value of the provider plugin.
             <para/>
             The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
@@ -1570,12 +1606,36 @@
             <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
             </summary>
         </member>
+        <member name="M:Pulumi.IDeployment.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOutputOptions)">
+            <summary>
+            Dynamically invokes the function '<paramref name="token"/>', which is offered by a
+            provider plugin.
+            <para/>
+            The result of <see cref="M:Pulumi.IDeployment.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOutputOptions)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
+            result value of the provider plugin that returns a bag of properties with a single value that is returned.
+            <para/>
+            The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+            <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
+            </summary>
+        </member>
         <member name="M:Pulumi.IDeployment.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)">
             <summary>
             Dynamically invokes the function '<paramref name="token"/>', which is offered by a
             provider plugin.
             <para/>
             The result of <see cref="M:Pulumi.IDeployment.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
+            result value of the provider plugin that returns a bag of properties with a single value that is returned.
+            <para/>
+            The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
+            <see cref="T:System.Threading.Tasks.Task`1"/>s, <see cref="T:Pulumi.Output`1"/>s etc.).
+            </summary>
+        </member>
+        <member name="M:Pulumi.IDeployment.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOutputOptions,Pulumi.RegisterPackageRequest)">
+            <summary>
+            Dynamically invokes the function '<paramref name="token"/>', which is offered by a
+            provider plugin.
+            <para/>
+            The result of <see cref="M:Pulumi.IDeployment.InvokeSingle``1(System.String,Pulumi.InvokeArgs,Pulumi.InvokeOutputOptions,Pulumi.RegisterPackageRequest)"/> will be a <see cref="T:Pulumi.Output"/> resolved to the
             result value of the provider plugin that returns a bag of properties with a single value that is returned.
             <para/>
             The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
@@ -1657,6 +1717,11 @@
             <summary>
             An optional URL, corresponding to the download URL of the provider plugin that should be
             used when performing this invoke.
+            </summary>
+        </member>
+        <member name="P:Pulumi.InvokeOutputOptions.DependsOn">
+            <summary>
+            Optional additional explicit dependencies on resources.
             </summary>
         </member>
         <member name="T:Pulumi.TaskMonitoringHelper">


### PR DESCRIPTION
Provider functions that take inputs as arguments, and return an output (aka output form invokes), now allow specifying a depends_on option. This allows programs to ensure that invokes are executed after things they depend on, similar to the depdends_on resource option.

Fixes https://github.com/pulumi/pulumi/issues/17753
