### PR TITLE
Make Null and Computed readonly values

### DIFF
--- a/sdk/Pulumi/Provider/PropertyValue.cs
+++ b/sdk/Pulumi/Provider/PropertyValue.cs
@@ -532,8 +532,8 @@ namespace Pulumi.Experimental.Provider
             IsComputed,
         }
 
-        public static PropertyValue Null = new PropertyValue(SpecialType.IsNull);
-        public static PropertyValue Computed = new PropertyValue(SpecialType.IsComputed);
+        public static readonly PropertyValue Null = new PropertyValue(SpecialType.IsNull);
+        public static readonly PropertyValue Computed = new PropertyValue(SpecialType.IsComputed);
 
         public PropertyValue(bool value)
         {


### PR DESCRIPTION
Small fix that these two special values should have been marked readonly so users don't mutate them.