### PR TITLE
Temporarily skip flaky TestDebuggerAttachDotnet test

### DIFF
--- a/integration_tests/integration_dotnet_test.go
+++ b/integration_tests/integration_dotnet_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -626,6 +627,11 @@ func readUpdateEventLog(logfile string) ([]apitype.EngineEvent, error) {
 
 func TestDebuggerAttachDotnet(t *testing.T) {
 	t.Parallel()
+
+	// TODO[pulumi/pulumi-dotnet#403]: Fix flaky test.
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		t.Skip("Temporarily skipping flaky test on macOS and Windows - pulumi/pulumi-dotnet#403")
+	}
 
 	languagePluginPath, err := filepath.Abs("../pulumi-language-dotnet")
 	require.NoError(t, err)


### PR DESCRIPTION
We're still seeing this test fail on macOS and it looks like it may be affecting Windows as well. Temporarily skip it for now.

Going to see if skipping also removes the flakes on Windows.

#403 tracks fixing the test for real / unskipping.

Fixes #419