### PR TITLE
add missing build-dll directory

### DIFF
--- a/pulumi-language-dotnet/testdata/build-dll/.gitignore
+++ b/pulumi-language-dotnet/testdata/build-dll/.gitignore
@@ -1,0 +1,5 @@
+/.pulumi/
+[Bb]in/
+[Oo]bj/
+
+

--- a/pulumi-language-dotnet/testdata/build-dll/Empty.csproj
+++ b/pulumi-language-dotnet/testdata/build-dll/Empty.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/pulumi-language-dotnet/testdata/build-dll/Program.cs
+++ b/pulumi-language-dotnet/testdata/build-dll/Program.cs
@@ -1,0 +1,8 @@
+// Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
+
+class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}

--- a/pulumi-language-dotnet/testdata/build-dll/Pulumi.yaml
+++ b/pulumi-language-dotnet/testdata/build-dll/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: emptydotnet
+description: An empty .NET Pulumi program.
+runtime: dotnet


### PR DESCRIPTION
This should fix the TestBuildDll test.

We should still make sure this test is acutually running in CI.

Replaces https://github.com/pulumi/pulumi-dotnet/pull/429

/cc @Zaid-Ajaj 