### PR TITLE
Add `--refresh` to Automation Api lifecycle commands

### DIFF
--- a/.changes/unreleased/Improvements-431.yaml
+++ b/.changes/unreleased/Improvements-431.yaml
@@ -1,0 +1,6 @@
+component: sdk/auto
+kind: Improvements
+body: Add `--refresh` to preview, up and destroy commands
+time: 2024-12-12T22:57:21.215812898Z
+custom:
+    PR: "431"

--- a/sdk/Pulumi.Automation/DestroyOptions.cs
+++ b/sdk/Pulumi.Automation/DestroyOptions.cs
@@ -18,5 +18,10 @@ namespace Pulumi.Automation
         /// Continue to perform the destroy operation despite the occurrence of errors.
         /// </summary>
         public bool? ContinueOnError { get; set; }
+
+        /// <summary>
+        /// Refresh the state of the stack's resources before this destroy.
+        /// </summary>
+        public bool? Refresh { get; set; }
     }
 }

--- a/sdk/Pulumi.Automation/PreviewOptions.cs
+++ b/sdk/Pulumi.Automation/PreviewOptions.cs
@@ -30,5 +30,10 @@ namespace Pulumi.Automation
         /// if <see cref="Program"/> is also provided.
         /// </summary>
         public ILogger? Logger { get; set; }
+
+        /// <summary>
+        /// Refresh the state of the stack's resources before this preview.
+        /// </summary>
+        public bool? Refresh { get; set; }
     }
 }

--- a/sdk/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/Pulumi.Automation/Pulumi.Automation.xml
@@ -70,6 +70,11 @@
             Continue to perform the destroy operation despite the occurrence of errors.
             </summary>
         </member>
+        <member name="P:Pulumi.Automation.DestroyOptions.Refresh">
+            <summary>
+            Refresh the state of the stack's resources before this destroy.
+            </summary>
+        </member>
         <member name="T:Pulumi.Automation.Events.CancelEvent">
             <summary>
             <see cref="T:Pulumi.Automation.Events.CancelEvent"/> is emitted when the user initiates a cancellation of the update in progress, or
@@ -909,6 +914,11 @@
             if <see cref="P:Pulumi.Automation.PreviewOptions.Program"/> is also provided.
             </summary>
         </member>
+        <member name="P:Pulumi.Automation.PreviewOptions.Refresh">
+            <summary>
+            Refresh the state of the stack's resources before this preview.
+            </summary>
+        </member>
         <member name="T:Pulumi.Automation.ProjectBackend">
             <summary>
             Configuration for the project's Pulumi state storage backend.
@@ -1487,6 +1497,11 @@
         <member name="P:Pulumi.Automation.UpOptions.ContinueOnError">
             <summary>
             Continue to perform the update operation despite the occurrence of errors.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.UpOptions.Refresh">
+            <summary>
+            Refresh the state of the stack's resources before this update.
             </summary>
         </member>
         <member name="T:Pulumi.Automation.Workspace">

--- a/sdk/Pulumi.Automation/UpOptions.cs
+++ b/sdk/Pulumi.Automation/UpOptions.cs
@@ -40,5 +40,10 @@ namespace Pulumi.Automation
         /// Continue to perform the update operation despite the occurrence of errors.
         /// </summary>
         public bool? ContinueOnError { get; set; }
+
+        /// <summary>
+        /// Refresh the state of the stack's resources before this update.
+        /// </summary>
+        public bool? Refresh { get; set; }
     }
 }

--- a/sdk/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/Pulumi.Automation/WorkspaceStack.cs
@@ -356,6 +356,9 @@ namespace Pulumi.Automation
                 if (options.ContinueOnError is true)
                     args.Add("--continue-on-error");
 
+                if (options.Refresh is true)
+                    args.Add("--refresh");
+
                 ApplyUpdateOptions(options, args);
             }
 
@@ -465,6 +468,8 @@ namespace Pulumi.Automation
                 if (options.TargetDependents is true)
                     args.Add("--target-dependents");
 
+                if (options.Refresh is true)
+                    args.Add("--refresh");
 
                 ApplyUpdateOptions(options, args);
             }
@@ -626,6 +631,9 @@ namespace Pulumi.Automation
 
                 if (options.ContinueOnError is true)
                     args.Add("--continue-on-error");
+
+                if (options.Refresh is true)
+                    args.Add("--refresh");
 
                 ApplyUpdateOptions(options, args);
             }


### PR DESCRIPTION
Fixes #327

- Add `--refresh` preview, up and destroy commands
- Add tests to validate behaviour