### PR TITLE
Tolerate plugins with warnings

### DIFF
--- a/.changes/unreleased/Improvements-437.yaml
+++ b/.changes/unreleased/Improvements-437.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: Plugins with msbuild warnings can still be run
+time: 2024-12-20T22:28:08.41871359Z
+custom:
+  PR: "437"

--- a/integration_tests/integration_dotnet_test.go
+++ b/integration_tests/integration_dotnet_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -462,7 +461,7 @@ func TestAboutDotnet(t *testing.T) {
 	languagePluginPath, err := filepath.Abs("../pulumi-language-dotnet")
 	require.NoError(t, err)
 
-	e := ptesting.NewEnvironment(t)
+	e := newEnvironmentDotnet(t)
 	defer e.DeleteIfNotFailed()
 	e.ImportDirectory("about")
 
@@ -536,7 +535,7 @@ func TestProvider(t *testing.T) {
 			assert.Equal(t, []interface{}{float64(1), "goodbye", true}, stack.Outputs["echoC"])
 		},
 		PrePrepareProject: func(info *engine.Projinfo) error {
-			e := ptesting.NewEnvironment(t)
+			e := newEnvironmentDotnet(t)
 			e.CWD = info.Root
 			path := info.Proj.Plugins.Providers[0].Path
 			_, _ = e.RunCommand("pulumi", "package", "gen-sdk", path, "--language", "dotnet")
@@ -636,7 +635,7 @@ func TestDebuggerAttachDotnet(t *testing.T) {
 	languagePluginPath, err := filepath.Abs("../pulumi-language-dotnet")
 	require.NoError(t, err)
 
-	e := ptesting.NewEnvironment(t)
+	e := newEnvironmentDotnet(t)
 	defer e.DeleteIfNotFailed()
 	e.ImportDirectory("printf")
 
@@ -695,7 +694,7 @@ func TestParameterized(t *testing.T) {
 		Dir:            filepath.Join("parameterized"),
 		LocalProviders: []integration.LocalDependency{{Package: "testprovider", Path: "testprovider"}},
 		PrePrepareProject: func(info *engine.Projinfo) error {
-			e := ptesting.NewEnvironment(t)
+			e := newEnvironmentDotnet(t)
 			e.CWD = info.Root
 			path := info.Proj.Plugins.Providers[0].Path
 			_, _ = e.RunCommand("pulumi", "package", "gen-sdk", path, "pkg", "--language", "dotnet")

--- a/integration_tests/integration_util_test.go
+++ b/integration_tests/integration_util_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -136,6 +137,14 @@ func getProviderPath(providerDir string) string {
 		}
 	}
 	return fmt.Sprintf("PATH=%s", providerDir)
+}
+
+func newEnvironmentDotnet(t *testing.T) *ptesting.Environment {
+	languagePluginPath, err := filepath.Abs("../pulumi-language-dotnet")
+	assert.NoError(t, err)
+	e := ptesting.NewEnvironment(t)
+	e.Env = append(e.Env, getProviderPath(languagePluginPath))
+	return e
 }
 
 func testDotnetProgram(t *testing.T, options *integration.ProgramTestOptions) {

--- a/integration_tests/testprovider/TestProvider.csproj
+++ b/integration_tests/testprovider/TestProvider.csproj
@@ -11,4 +11,8 @@
   <ItemGroup>
     <ProjectReference Include="../../sdk/Pulumi/Pulumi.csproj" />
   </ItemGroup>
+
+  <Target Name="Warning" AfterTargets="Build">
+      <Warning Text="Warning to test plugin run still reads the port number with warnings." Condition="'true'" />
+  </Target>
 </Project>


### PR DESCRIPTION
Found this while on my adventures with dotnet plugins. If your plugin project has any warnings it's unusable in shimless mode (i.e. `RunPlugin`) because msbuild would first print the warning then start the plugin and print the port number. This lead to errors like:
```
error:  plugin [E:\VisualStudio\Projects\pulumi\jsonschema\Provider\pulumi-resource-Provider] wrote an invalid port to stdout: could not parse port: strconv.Atoi: parsing "E:\\VisualStudio\\Projects\\pulumi\\jsonschema\\Provider\\Provider.fsproj : warning NU1903: Package 'System.Text.Json' 6.0.2 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4": invalid syntax
```

When running shimless these warnings don't really matter. So this PR rewrites `RunPlugin` to do the build separately, and then invoke `dotnet run` with the `--no-build` flag. I would have preferred to _just_ use `dotnet run` but there doesn't seem to be anyway to pass it flags to silence the msbuild output from it. 

This is tested by adding a warning to the testprovider project that always triggers. As we use the testprovider project in shimless mode in the integration tests this shows that a project with warnings can still be used.