### PR TITLE
Wait for resources in the input property dependencies

### DIFF
--- a/.changes/unreleased/bug-fixes-444.yaml
+++ b/.changes/unreleased/bug-fixes-444.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Wait for resources in the input property dependencies
+time: 2025-01-09T16:16:01.580923+01:00
+custom:
+    PR: "444"

--- a/sdk/Pulumi.Tests/Deployment/DeploymentInvokeDependsOnTests.cs
+++ b/sdk/Pulumi.Tests/Deployment/DeploymentInvokeDependsOnTests.cs
@@ -63,8 +63,10 @@ namespace Pulumi.Tests
             var testOptions = new TestOptions();
             var (resources, outputs) = await Deployment.TestAsync(mocks, testOptions, () =>
             {
-                var resource = new MyCustomResource("some-resource", null, new CustomResourceOptions());
                 var deps = new InputList<Resource>();
+                var dep_remote = new DependencyResource("some:urn");
+                deps.Add(dep_remote);
+                var resource = new MyCustomResource("some-resource", null, new CustomResourceOptions());
                 deps.Add(resource);
 
                 var resultOutput = TestFunction.Invoke(new FunctionArgs(), new InvokeOutputOptions { DependsOn = deps });

--- a/sdk/Pulumi/Deployment/Deployment_Invoke.cs
+++ b/sdk/Pulumi/Deployment/Deployment_Invoke.cs
@@ -179,8 +179,10 @@ namespace Pulumi
             // Ensure that all resource IDs are known before proceeding.
             foreach (var resource in resourcesToWaitFor)
             {
-                // check if it's an instance of CustomResource
-                if (resource is CustomResource customResource)
+                // Check if it's an instance of CustomResource.
+                // DependencyResources inherit from CustomResource, but they
+                // don't set the id. Skip them.
+                if (resource is CustomResource customResource && customResource.Id != null)
                 {
                     var idData = await customResource.Id.DataTask.ConfigureAwait(false);
                     if (!idData.IsKnown)


### PR DESCRIPTION
Besides the explicitly provided resources from the `dependsOn` option, we need to also take into account the resource dependencies from the invoke’s arguments.

https://github.com/pulumi/pulumi/issues/17747