### PR TITLE
Fix dotnet version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,6 +31,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup dotnet SDK
         uses: actions/setup-dotnet@v4
+      - name: Setup dotnet SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          # Install 6.0 for Build.fsproj
+          dotnet-version: 6.0.x
       - name: Format Pulumi SDK
         run: dotnet run format-sdk verify
 
@@ -48,9 +53,24 @@ jobs:
         with:
           submodules: recursive
       - name: Setup dotnet SDK
+        id: setup-dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          # Install 6.0 for Build.fsproj and the matrix version.
+          # `outputs.dotnet-version` is the latest version among the installed
+          # versions. Since Build.fsproj targets the lowest version we support,
+          # this works out ok for the matrix.
+          # https://github.com/actions/setup-dotnet?tab=readme-ov-file#dotnet-version
+          dotnet-version: |
+            6.0.x
+            ${{ matrix.dotnet-version }}
+      - name: Create global.json
+        # This ensures that we use the matrix version instead of the runner's default version
+        # https://github.com/actions/setup-dotnet?tab=readme-ov-file#matrix-testing
+        run: |
+          echo '{"sdk":{"version": "${{ steps.setup-dotnet.outputs.dotnet-version }}"}}' > ./global.json
+      - name: Dotnet version
+        run: dotnet --version
       - name: Install Pulumi CLI
         uses: pulumi/actions@v5
         with:
@@ -59,6 +79,8 @@ jobs:
         run: dotnet run build-sdk
       - name: Workspace clean (are xml doc file updates committed?)
         uses: pulumi/git-status-check-action@v1
+        with:
+          allowed-changes: ./global.json
       - name: Test Pulumi SDK
         run: dotnet run test-sdk coverage
       - name: Test Pulumi Automation SDK
@@ -97,9 +119,17 @@ jobs:
         with:
           submodules: recursive
       - name: Setup dotnet SDK
+        id: setup-dotnet
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
+      - name: Create global.json
+        # This ensures that we use the matrix version instead of the runner's default version
+        # https://github.com/actions/setup-dotnet?tab=readme-ov-file#matrix-testing
+        run: |
+          echo '{"sdk":{"version": "${{ steps.setup-dotnet.outputs.dotnet-version }}"}}' > ./global.json
+      - name: Dotnet version
+        run: dotnet --version
       - name: Set up Go 1.22.x
         uses: actions/setup-go@v5
         with:
@@ -170,9 +200,17 @@ jobs:
         with:
           submodules: recursive
       - name: Setup dotnet SDK
+        id: setup-dotnet
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
+      - name: Create global.json
+        # This ensures that we use the matrix version instead of the runner's default version
+        # https://github.com/actions/setup-dotnet?tab=readme-ov-file#matrix-testing
+        run: |
+          echo '{"sdk":{"version": "${{ steps.setup-dotnet.outputs.dotnet-version }}"}}' > ./global.json
+      - name: Dotnet version
+        run: dotnet --version
       - name: Set up Go 1.22.x
         uses: actions/setup-go@v5
         with:

--- a/Build.fsproj
+++ b/Build.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/integration_tests/testprovider/TestProvider.cs
+++ b/integration_tests/testprovider/TestProvider.cs
@@ -46,40 +46,40 @@ public class TestProvider : Provider
 
     public override Task<GetSchemaResponse> GetSchema(GetSchemaRequest request, CancellationToken ct)
     {
-        var schema = """
+        var schema = @"
 {
-    "name": "NAME",
-    "version": "1.0.0",
-    "resources": {
-        "NAME:index:Echo": {
-            "description": "A test resource that echoes its input.",
-            "properties": {
-                "value": {
-                    "$ref": "pulumi.json#/Any",
-                    "description": "Input to echo."
+    ""name"": ""NAME"",
+    ""version"": ""1.0.0"",
+    ""resources"": {
+        ""NAME:index:Echo"": {
+            ""description"": ""A test resource that echoes its input."",
+            ""properties"": {
+                ""value"": {
+                    ""$ref"": ""pulumi.json#/Any"",
+                    ""description"": ""Input to echo.""
                 }
             },
-            "inputProperties": {
-                "value": {
-                    "$ref": "pulumi.json#/Any",
-                    "description": "Input to echo."
+            ""inputProperties"": {
+                ""value"": {
+                    ""$ref"": ""pulumi.json#/Any"",
+                    ""description"": ""Input to echo.""
                 }
             },
-            "type": "object"
+            ""type"": ""object""
         }
     }PARAM
 }
-""";
-        var parameterization = """
+";
+        var parameterization = @"
 ,
-    "parameterization": {
-        "baseProvider": {
-            "name": "testprovider",
-            "version": "0.0.1"
+    ""parameterization"": {
+        ""baseProvider"": {
+            ""name"": ""testprovider"",
+            ""version"": ""0.0.1""
         },
-        "parameter": "UTFBYTES"
+        ""parameter"": ""UTFBYTES""
     }
-""";
+";
 
 
 

--- a/integration_tests/testprovider/TestProvider.csproj
+++ b/integration_tests/testprovider/TestProvider.csproj
@@ -4,9 +4,8 @@
     <OutputType>Exe</OutputType>
     <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
     <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net6.0</TargetFramework>
-    <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
-    <LangVersion>11</LangVersion>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
With the update to Ubuntu 24.04 for the runners, the preinstalled .NET versions have changed. This revealed some issues with how we select the .NET version to use in the matrix tests. The `actions/setup-dotnet` action does install the version we want, but the dotnet command still use the runner’s default version.

We have to create a `global.json` to make it use the desired version.

https://github.com/actions/setup-dotnet?tab=readme-ov-file#matrix-testing
