### PR TITLE
Fix dotnet setup in release job

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -43,10 +43,18 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - name: Set up DotNet 6.0.x
+        id: setup-dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 6.0.x
           dotnet-quality: ga
+      - name: Create global.json
+        # This ensures that we use the matrix version instead of the runner's default version
+        # https://github.com/actions/setup-dotnet?tab=readme-ov-file#matrix-testing
+        run: |
+          echo '{"sdk":{"version": "${{ steps.setup-dotnet.outputs.dotnet-version }}"}}' > ./global.json
+      - name: Dotnet version
+        run: dotnet --version
       - name: Install Pulumi CLI
         uses: pulumi/actions@v5
         with:


### PR DESCRIPTION
Follow up to https://github.com/pulumi/pulumi-dotnet/pull/445, which fixed CI on the latest ubuntu runners, but missed the release job.
