### PR TITLE
Don't flatten outputs to top level for InputList and InputMap

### DIFF
--- a/.changes/unreleased/Improvements-449.yaml
+++ b/.changes/unreleased/Improvements-449.yaml
@@ -1,0 +1,7 @@
+component: sdk
+kind: Improvements
+body: InputMap and InputList no longer flatten nested unknowns/secrets to apply to
+  the whole object.
+time: 2025-01-29T14:14:44.986465684Z
+custom:
+  PR: "449"

--- a/sdk/Pulumi.Tests/Serialization/MarshalOutputTests.cs
+++ b/sdk/Pulumi.Tests/Serialization/MarshalOutputTests.cs
@@ -91,6 +91,21 @@ namespace Pulumi.Tests.Serialization
             },
             new object[]
             {
+                new InputList<string> { "hello" },
+                ImmutableArray<object>.Empty.Add("hello")
+            },
+            new object[]
+            {
+                new InputList<string> { Output.Create("hello") },
+                ImmutableArray<object>.Empty.Add("hello")
+            },
+            new object[]
+            {
+                new InputList<string> { Output.CreateSecret("hello") },
+                ImmutableArray<object>.Empty.Add(CreateOutputValue("hello", isSecret: true))
+            },
+            new object[]
+            {
                 new Dictionary<string, Input<string>> { { "foo", "hello" } },
                 ImmutableDictionary<string, object>.Empty.Add("foo", "hello")
             },

--- a/sdk/Pulumi.Tests/Serialization/MarshalOutputTests.cs
+++ b/sdk/Pulumi.Tests/Serialization/MarshalOutputTests.cs
@@ -102,7 +102,7 @@ namespace Pulumi.Tests.Serialization
             new object[]
             {
                 new InputList<string> { Output.CreateSecret("hello") },
-                ImmutableArray<object>.Empty.Add(CreateOutputValue("hello", isSecret: true))
+                ImmutableArray<object>.Empty.Add(CreateSecretValue("hello"))
             },
             new object[]
             {
@@ -169,6 +169,14 @@ namespace Pulumi.Tests.Serialization
             if (isKnown) b.Add(Constants.ValueName, value);
             if (isSecret) b.Add(Constants.SecretName, isSecret);
             if (deps.Length > 0) b.Add(Constants.DependenciesName, deps.ToImmutableArray());
+            return b.ToImmutableDictionary();
+        }
+
+        private static ImmutableDictionary<string, object?> CreateSecretValue(object? value)
+        {
+            var b = ImmutableDictionary.CreateBuilder<string, object?>();
+            b.Add(Constants.SpecialSigKey, Constants.SpecialSecretSig);
+            b.Add(Constants.ValueName, value);
             return b.ToImmutableDictionary();
         }
     }

--- a/sdk/Pulumi.Tests/Serialization/MarshalOutputTests.cs
+++ b/sdk/Pulumi.Tests/Serialization/MarshalOutputTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Pulumi.Serialization;
+using Pulumi.Utilities;
 using Xunit;
 
 namespace Pulumi.Tests.Serialization
@@ -106,6 +107,11 @@ namespace Pulumi.Tests.Serialization
             },
             new object[]
             {
+                new InputList<string> { OutputUtilities.CreateUnknown("") },
+                ImmutableArray<object>.Empty.Add(Constants.UnknownValue)
+            },
+            new object[]
+            {
                 new Dictionary<string, Input<string>> { { "foo", "hello" } },
                 ImmutableDictionary<string, object>.Empty.Add("foo", "hello")
             },
@@ -132,7 +138,12 @@ namespace Pulumi.Tests.Serialization
             new object[]
             {
                 new InputMap<string> { { "foo", Output.CreateSecret("hello") } },
-                ImmutableDictionary<string, object>.Empty.Add("foo", CreateOutputValue("hello", isSecret: true))
+                ImmutableDictionary<string, object>.Empty.Add("foo", CreateSecretValue("hello"))
+            },
+            new object[]
+            {
+                new InputMap<string> { { "foo", OutputUtilities.CreateUnknown("") } },
+                ImmutableDictionary<string, object>.Empty.Add("foo", Constants.UnknownValue)
             },
             new object[]
             {

--- a/sdk/Pulumi.Tests/Serialization/MarshalOutputTests.cs
+++ b/sdk/Pulumi.Tests/Serialization/MarshalOutputTests.cs
@@ -121,6 +121,21 @@ namespace Pulumi.Tests.Serialization
             },
             new object[]
             {
+                new InputMap<string> { { "foo", "hello" } },
+                ImmutableDictionary<string, object>.Empty.Add("foo", "hello")
+            },
+            new object[]
+            {
+                new InputMap<string> { { "foo", Output.Create("hello") } },
+                ImmutableDictionary<string, object>.Empty.Add("foo", "hello")
+            },
+            new object[]
+            {
+                new InputMap<string> { { "foo", Output.CreateSecret("hello") } },
+                ImmutableDictionary<string, object>.Empty.Add("foo", CreateOutputValue("hello", isSecret: true))
+            },
+            new object[]
+            {
                 new BarArgs { Foo = new FooArgs { Foo = "hello" } },
                 ImmutableDictionary<string, object>.Empty.Add("foo",
                     ImmutableDictionary<string, object>.Empty.Add("foo", "hello"))

--- a/sdk/Pulumi/Core/InputList.cs
+++ b/sdk/Pulumi/Core/InputList.cs
@@ -47,6 +47,14 @@ namespace Pulumi
     public sealed class InputList<T> : Input<ImmutableArray<T>>, IEnumerable, IAsyncEnumerable<Input<T>>
     {
         Input<ImmutableArray<Input<T>>> _inputValue;
+        /// <summary>
+        /// InputList externally has to behave as an <c>Input{ImmutableArray{T}}</c>, but we actually want to
+        /// keep nested Input/Output values separate, so that we can serialise the overall list shape even if one of the
+        /// inner elements is an unknown value.
+        ///
+        /// To do that we keep a separate value of the form <c>Input{ImmutableArray{Input{T}}}</c>/> which each
+        /// time we set syncs the flattened value to the base <c>Input{ImmutableArray{T}}</c>. 
+        /// </summary>
         Input<ImmutableArray<Input<T>>> Value
         {
             get => _inputValue;

--- a/sdk/Pulumi/Core/InputList.cs
+++ b/sdk/Pulumi/Core/InputList.cs
@@ -47,9 +47,11 @@ namespace Pulumi
     public sealed class InputList<T> : Input<ImmutableArray<T>>, IEnumerable, IAsyncEnumerable<Input<T>>
     {
         Input<ImmutableArray<Input<T>>> _inputValue;
-        Input<ImmutableArray<Input<T>>> Value {
+        Input<ImmutableArray<Input<T>>> Value
+        {
             get => _inputValue;
-            set {
+            set
+            {
                 _inputValue = value;
                 _outputValue = _inputValue.Apply(inputs => Output.All(inputs));
             }
@@ -87,9 +89,11 @@ namespace Pulumi
         /// Concatenates the values in this list with the values in <paramref name="other"/>,
         /// returning the concatenated sequence in a new <see cref="InputList{T}"/>.
         /// </summary>
-        public InputList<T> Concat(InputList<T> other) {
+        public InputList<T> Concat(InputList<T> other)
+        {
             var list = new InputList<T>();
-            list.Value = Output.Tuple(Value, other.Value).Apply(t => {
+            list.Value = Output.Tuple(Value, other.Value).Apply(t =>
+            {
                 var (first, second) = t;
                 return first.AddRange(second);
             });
@@ -163,7 +167,8 @@ namespace Pulumi
             => values.Apply(ImmutableArray.CreateRange);
 
         public static implicit operator InputList<T>(Output<ImmutableArray<T>> values)
-            => new InputList<T>(values.Apply(values => {
+            => new InputList<T>(values.Apply(values =>
+            {
                 var builder = ImmutableArray.CreateBuilder<Input<T>>(values.Length);
                 foreach (var value in values)
                 {

--- a/sdk/Pulumi/Core/InputMap.cs
+++ b/sdk/Pulumi/Core/InputMap.cs
@@ -44,9 +44,11 @@ namespace Pulumi
     {
         private static Input<ImmutableDictionary<string, V>> Flatten(Input<ImmutableDictionary<string, Input<V>>> inputs)
         {
-            return inputs.Apply(inputs => {
+            return inputs.Apply(inputs =>
+            {
                 var list = inputs.Select(kv => kv.Value.Apply(value => KeyValuePair.Create(kv.Key, value)));
-                return Output.All(list).Apply(kvs => {
+                return Output.All(list).Apply(kvs =>
+                {
                     var result = ImmutableDictionary.CreateBuilder<string, V>();
                     foreach (var (k, v) in kvs)
                     {
@@ -58,9 +60,11 @@ namespace Pulumi
         }
 
         Input<ImmutableDictionary<string, Input<V>>> _inputValue;
-        Input<ImmutableDictionary<string, Input<V>>> Value {
+        Input<ImmutableDictionary<string, Input<V>>> Value
+        {
             get => _inputValue;
-            set {
+            set
+            {
                 _inputValue = value;
                 _outputValue = Flatten(_inputValue);
             }
@@ -116,13 +120,13 @@ namespace Pulumi
             var output = Output.Tuple(first.Value, second.Value)
                                .Apply(dicts =>
                                {
-                                    var builder = ImmutableDictionary.CreateBuilder<string, Input<V>>();
-                                    foreach (var (k, v) in dicts.Item1)
-                                        builder[k] = v;
-                                    // Overwrite keys if duplicates are found
-                                    foreach (var (k, v) in dicts.Item2)
-                                        builder[k] = v;
-                                    return builder.ToImmutable();
+                                   var builder = ImmutableDictionary.CreateBuilder<string, Input<V>>();
+                                   foreach (var (k, v) in dicts.Item1)
+                                       builder[k] = v;
+                                   // Overwrite keys if duplicates are found
+                                   foreach (var (k, v) in dicts.Item2)
+                                       builder[k] = v;
+                                   return builder.ToImmutable();
                                });
             return new InputMap<V>(output);
         }
@@ -142,7 +146,8 @@ namespace Pulumi
             => values.Apply(ImmutableDictionary.CreateRange);
 
         public static implicit operator InputMap<V>(Output<ImmutableDictionary<string, V>> values)
-            => new InputMap<V>(values.Apply(values => {
+            => new InputMap<V>(values.Apply(values =>
+            {
                 var builder = ImmutableDictionary.CreateBuilder<string, Input<V>>();
                 foreach (var value in values)
                 {

--- a/sdk/Pulumi/Core/InputMap.cs
+++ b/sdk/Pulumi/Core/InputMap.cs
@@ -60,6 +60,15 @@ namespace Pulumi
         }
 
         Input<ImmutableDictionary<string, Input<V>>> _inputValue;
+        /// <summary>
+        /// InputMap externally has to behave as an <c>Input{ImmutableDictionary{string, T}}</c>, but we actually
+        /// want to keep nested Input/Output values separate, so that we can serialise the overall map shape even if
+        /// one of the inner elements is an unknown value.
+        ///
+        /// To do that we keep a separate value of the form <c>Input{ImmutableDictionary{string, Input{T}}}</c>
+        /// which each time we set syncs the flattened value to the base <c>Input{ImmutableDictionary{string,
+        /// T}}</c>. 
+        /// </summary>
         Input<ImmutableDictionary<string, Input<V>>> Value
         {
             get => _inputValue;

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -513,6 +513,16 @@
             </code>
             </summary>
         </member>
+        <member name="P:Pulumi.InputList`1.Value">
+             <summary>
+             InputList externally has to behave as an <c>Input{ImmutableArray{T}}</c>, but we actually want to
+             keep nested Input/Output values separate, so that we can serialise the overall list shape even if one of the
+             inner elements is an unknown value.
+            
+             To do that we keep a separate value of the form <c>Input{ImmutableArray{Input{T}}}</c>/> which each
+             time we set syncs the flattened value to the base <c>Input{ImmutableArray{T}}</c>. 
+             </summary>
+        </member>
         <member name="M:Pulumi.InputList`1.Add(Pulumi.InputList{`0})">
             <summary>
             Note: this is non-standard convenience for use with collection initializers.
@@ -556,6 +566,17 @@
                 });
             </code>
             </summary>
+        </member>
+        <member name="P:Pulumi.InputMap`1.Value">
+             <summary>
+             InputMap externally has to behave as an <c>Input{ImmutableDictionary{string, T}}</c>, but we actually
+             want to keep nested Input/Output values separate, so that we can serialise the overall map shape even if
+             one of the inner elements is an unknown value.
+            
+             To do that we keep a separate value of the form <c>Input{ImmutableDictionary{string, Input{T}}}</c>
+             which each time we set syncs the flattened value to the base <c>Input{ImmutableDictionary{string,
+             T}}</c>. 
+             </summary>
         </member>
         <member name="M:Pulumi.InputMap`1.Add(Pulumi.InputMap{`0})">
             <summary>

--- a/sdk/Pulumi/Serialization/Serializer.cs
+++ b/sdk/Pulumi/Serialization/Serializer.cs
@@ -103,6 +103,15 @@ namespace Pulumi.Serialization
 $"Tasks are not allowed inside ResourceArgs. Please wrap your Task in an Output:\n\t{ctx}");
             }
 
+            // if prop is an InputList<T>
+            var propType = prop.GetType();
+            if (propType.IsGenericType && propType.GetGenericTypeDefinition() == typeof(InputList<>))
+            {
+                // pull off the Value property from the InputList<T>
+                var inputList = propType.GetProperty("Value", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(prop);
+                return await SerializeAsync(ctx, inputList, keepResources, keepOutputValues).ConfigureAwait(false);
+            }
+
             if (prop is IInput input)
             {
                 if (_excessiveDebugOutput)
@@ -289,7 +298,6 @@ $"Tasks are not allowed inside ResourceArgs. Please wrap your Task in an Output:
                 return null;
             }
 
-            var propType = prop.GetType();
             if (propType.IsValueType && propType.GetCustomAttribute<EnumTypeAttribute>() != null)
             {
                 var mi = propType.GetMethod("op_Explicit", BindingFlags.Public | BindingFlags.Static, null, new[] { propType }, null);

--- a/sdk/Pulumi/Serialization/Serializer.cs
+++ b/sdk/Pulumi/Serialization/Serializer.cs
@@ -103,11 +103,18 @@ namespace Pulumi.Serialization
 $"Tasks are not allowed inside ResourceArgs. Please wrap your Task in an Output:\n\t{ctx}");
             }
 
-            // if prop is an InputList<T>
             var propType = prop.GetType();
+            // if prop is an InputList<T>
             if (propType.IsGenericType && propType.GetGenericTypeDefinition() == typeof(InputList<>))
             {
                 // pull off the Value property from the InputList<T>
+                var inputList = propType.GetProperty("Value", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(prop);
+                return await SerializeAsync(ctx, inputList, keepResources, keepOutputValues).ConfigureAwait(false);
+            }
+            // if prop is an InputMap<T>
+            if (propType.IsGenericType && propType.GetGenericTypeDefinition() == typeof(InputMap<>))
+            {
+                // pull off the Value property from the InputMap<T>
                 var inputList = propType.GetProperty("Value", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(prop);
                 return await SerializeAsync(ctx, inputList, keepResources, keepOutputValues).ConfigureAwait(false);
             }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-dotnet/issues/22

InputList and InputMap are types used to make it easier to work with lists/maps where both the overall structure or individual elements can be `Input`s.

The current implementation just flattens everything to a top-level input. That is `InputList<T>` is just `Input<ImmutableArray<T>>`. So if you start with a known empty list then add an unknown input element to it you end up with an unknown list structure. This is not ideal for previews (see #22) and doesn't align with the other SDKs where if you add an unknown element to a list the overall list shape is still known and sent to the engine for preview correctly.

This PR fixes the above by keeping track of non-flattened data inside InputMap/List. i.e. the internal shape of `InputList<T>` is now `Input<ImmutableArray<Input<T>>>`. This allows us to take a known list and add an unknown element to it and leave the overall shape of the list still known.

We do this without changing the public surface of InputList/Map, so they still inherit from `Input<ImmutableArray<T>>`. We add another field for the nested structure and ensure that we just always update both fields (the one in InputList/Map and the one in the base Input class) together. In the property serializer we then use reflection to pull out the fully nested value (e.g. `Input<ImmutableArray<Input<T>>>`) and then recursively serialize that, rather than hitting the standard `IInput` case and getting the flattened value (e.g. `Input<ImmutableArray<T>>`).