### PR TITLE
Handle null runtime values in InputMap/List cast

### DIFF
--- a/.changes/unreleased/bug-fixes-459.yaml
+++ b/.changes/unreleased/bug-fixes-459.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Handle null in InputMap/List implicit conversions
+time: 2025-02-12T16:47:02.408546Z
+custom:
+    PR: "459"

--- a/sdk/Pulumi.Tests/Core/InputTests.cs
+++ b/sdk/Pulumi.Tests/Core/InputTests.cs
@@ -168,7 +168,7 @@ namespace Pulumi.Tests.Core
                 // This should now throw an exception
                 await Assert.ThrowsAsync<ArgumentException>(() => map.ToOutput().DataTask).ConfigureAwait(false);
             });
-            
+
         // Regression test for https://github.com/pulumi/pulumi-dotnet/issues/456
         [Fact]
         public Task InputMapNull()

--- a/sdk/Pulumi.Tests/Core/InputTests.cs
+++ b/sdk/Pulumi.Tests/Core/InputTests.cs
@@ -143,6 +143,46 @@ namespace Pulumi.Tests.Core
                 Assert.Equal(456, data.Value);
             });
 
+        // Regression test for https://github.com/pulumi/pulumi-dotnet/issues/456
+        [Fact]
+        public Task InputMapNull()
+            => RunInPreview(async () =>
+            {
+                ImmutableDictionary<string, string>? nullDict = null;
+                var map = (InputMap<string>)nullDict!;
+
+                var data = await map.ToOutput().DataTask.ConfigureAwait(false);
+                Assert.True(data.IsKnown);
+                Assert.Null(data.Value);
+
+                var nullDictOutput = Output.Create(nullDict);
+                map = (InputMap<string>)nullDictOutput!;
+
+                data = await map.ToOutput().DataTask.ConfigureAwait(false);
+                Assert.True(data.IsKnown);
+                Assert.Null(data.Value);
+            });
+
+        // Regression test for https://github.com/pulumi/pulumi-dotnet/issues/456
+        [Fact]
+        public Task InputListNull()
+            => RunInPreview(async () =>
+            {
+                ImmutableArray<string> nullList = default;
+                var list = (InputList<string>)nullList;
+
+                var data = await list.ToOutput().DataTask.ConfigureAwait(false);
+                Assert.True(data.IsKnown);
+                Assert.True(data.Value.IsDefault);
+
+                var nullListOutput = Output.Create(nullList);
+                list = (InputList<string>)nullListOutput!;
+
+                data = await list.ToOutput().DataTask.ConfigureAwait(false);
+                Assert.True(data.IsKnown);
+                Assert.True(data.Value.IsDefault);
+            });
+
         private class SampleArgs
         {
             public readonly InputList<Union<string, int>> List = new InputList<Union<string, int>>();

--- a/sdk/Pulumi/Core/InputMap.cs
+++ b/sdk/Pulumi/Core/InputMap.cs
@@ -46,6 +46,12 @@ namespace Pulumi
         {
             return inputs.Apply(inputs =>
             {
+                // Backcompat: See the comment in the implicit conversion from Output<ImmutableDictionary<string, V>>.
+                if (inputs == null)
+                {
+                    return null!;
+                }
+
                 var list = inputs.Select(kv => kv.Value.Apply(value => KeyValuePair.Create(kv.Key, value)));
                 return Output.All(list).Apply(kvs =>
                 {
@@ -157,6 +163,14 @@ namespace Pulumi
         public static implicit operator InputMap<V>(Output<ImmutableDictionary<string, V>> values)
             => new InputMap<V>(values.Apply(values =>
             {
+                // Backwards compatibility: if the immutable dictionary is null just flow through the nullness. This is
+                // against the nullability annotations but it used to "work" before
+                // https://github.com/pulumi/pulumi-dotnet/pull/449.
+                if (values == null)
+                {
+                    return null!;
+                }
+
                 var builder = ImmutableDictionary.CreateBuilder<string, Input<V>>();
                 foreach (var value in values)
                 {

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -520,7 +520,7 @@
              inner elements is an unknown value.
             
              To do that we keep a separate value of the form <c>Input{ImmutableArray{Input{T}}}</c>/> which each
-             time we set syncs the flattened value to the base <c>Input{ImmutableArray{T}}</c>. 
+             time we set syncs the flattened value to the base <c>Input{ImmutableArray{T}}</c>.
              </summary>
         </member>
         <member name="M:Pulumi.InputList`1.Add(Pulumi.InputList{`0})">


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-dotnet/issues/456

This is a bit of a sad fix but `InputMap` used to tolerate the implicit cast from dictionary being called with null by just passing that null down. If you tried to call Add or enumerate it would NRE, but if it just got assigned to another resource property the serialiser could handle it.

https://github.com/pulumi/pulumi-dotnet/pull/449 broke this because it always tried to enumerate the incoming immutable dictionary to build the new internal nested immutable dictionary. This fixes it to behave as before were null flows through as null.