### PR TITLE
Fix Provider and Providers in transforms

### DIFF
--- a/.changes/unreleased/bug-fixes-460.yaml
+++ b/.changes/unreleased/bug-fixes-460.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Fix the Provider and Providers option when used in resource transforms
+time: 2025-02-12T18:17:49.30145Z
+custom:
+    PR: "460"

--- a/sdk/Pulumi/Deployment/Deployment_Prepare.cs
+++ b/sdk/Pulumi/Deployment/Deployment_Prepare.cs
@@ -297,7 +297,7 @@ namespace Pulumi
                     response.Options.IgnoreChanges.AddRange(result.Value.Options.IgnoreChanges);
                     response.Options.PluginDownloadUrl = result.Value.Options.PluginDownloadURL ?? "";
                     response.Options.Protect = result.Value.Options.Protect ?? false;
-                    response.Options.Provider = result.Value.Options.Provider == null ? "" : await result.Value.Options.Provider.Urn.GetValueAsync("").ConfigureAwait(false);
+                    response.Options.Provider = result.Value.Options.Provider == null ? "" : await result.Value.Options.Provider.Ref.ConfigureAwait(false);
                     response.Options.ReplaceOnChanges.AddRange(result.Value.Options.ReplaceOnChanges);
                     response.Options.RetainOnDelete = result.Value.Options.RetainOnDelete ?? false;
                     response.Options.Version = result.Value.Options.Version;
@@ -311,8 +311,7 @@ namespace Pulumi
                     {
                         foreach (var provider in componentOptions.Providers)
                         {
-                            var urn = await provider.Urn.GetValueAsync("").ConfigureAwait(false);
-                            response.Options.Providers.Add(provider.Package, urn);
+                            response.Options.Providers.Add(provider.Package, await provider.Ref.ConfigureAwait(false));
                         }
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-dotnet/issues/455

When marshalling options back to the engine after resource transforms we were incorrectly sending `provider` and `providers` back as just the URNs. They should in fact be "refs" of the form `<urn>::<id>`.