### PR TITLE
Add ability to disable ToString on Output<T>

### DIFF
--- a/.changes/unreleased/Improvements-461.yaml
+++ b/.changes/unreleased/Improvements-461.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Add ability to disable ToString on Output<T>
+time: 2025-02-12T23:00:10.931454944Z
+custom:
+    PR: "461"

--- a/sdk/Pulumi.Tests/Core/OutputTests.cs
+++ b/sdk/Pulumi.Tests/Core/OutputTests.cs
@@ -1,5 +1,6 @@
 // Copyright 2016-2019, Pulumi Corporation
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -950,6 +951,19 @@ namespace Pulumi.Tests.Core
                     Assert.True(data.IsKnown);
                     Assert.Equal(0, data.Value);
                 });
+
+            [Theory]
+            [InlineData("true")]
+            [InlineData("1")]
+            public void OutputToStringThrowsWhenSet(string? variableValue)
+            {
+                Environment.SetEnvironmentVariable("PULUMI_ERROR_OUTPUT_STRING", variableValue);
+                var o1 = CreateOutput(0, isKnown: true);
+                Assert.Throws<InvalidOperationException>(() => o1.ToString());
+
+                Environment.SetEnvironmentVariable("PULUMI_ERROR_OUTPUT_STRING", null);
+                Assert.EndsWith("This function may throw in a future version of Pulumi.", o1.ToString());
+            }
         }
     }
 }

--- a/sdk/Pulumi/Core/Output.cs
+++ b/sdk/Pulumi/Core/Output.cs
@@ -693,7 +693,8 @@ namespace Pulumi
 
         public override string ToString()
         {
-            var message = string.Join(Environment.NewLine, new string[] {
+            var messageLines = new List<string>
+            {
                 "Calling [ToString] on an [Output<T>] is not supported.",
                 "",
                 "To get the value of an Output<T> as an Output<string> consider:",
@@ -701,10 +702,17 @@ namespace Pulumi
                 "2. Output.Format($\"prefix{hostname}suffix\");",
                 "",
                 "See https://www.pulumi.com/docs/concepts/inputs-outputs for more details.",
-                "This function may throw in a future version of Pulumi.",
-            });
+            };
 
-            return message;
+            var errorOutputString = Environment.GetEnvironmentVariable("PULUMI_ERROR_OUTPUT_STRING");
+
+            if (errorOutputString == "1" || string.Equals(errorOutputString, "true", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(string.Join(Environment.NewLine, messageLines));
+            }
+
+            messageLines.Add("This function may throw in a future version of Pulumi.");
+            return string.Join(Environment.NewLine, messageLines);
         }
     }
 


### PR DESCRIPTION
This PR provides an ability that is already present in the Python and JS languages to to disable converting `Output<T>` to a string. 

Currently in the dotnet language this will return a helpful message in the string contents to advise not to do this but does not fail the pulumi program.

This functionality is opted-in by setting the environment variable `PULUMI_ERROR_OUTPUT_STRING` to `true` or `1` to throw an exception.