### PR TITLE
Fix adding duplicate key-value pairs to InputMap

### DIFF
--- a/.changes/unreleased/bug-fixes-462.yaml
+++ b/.changes/unreleased/bug-fixes-462.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Fix adding the same value to InputMap multiple times
+time: 2025-02-13T09:04:11.345766Z
+custom:
+    PR: "462"

--- a/sdk/Pulumi.Tests/Core/InputTests.cs
+++ b/sdk/Pulumi.Tests/Core/InputTests.cs
@@ -1,5 +1,6 @@
 // Copyright 2016-2019, Pulumi Corporation
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
@@ -141,6 +142,31 @@ namespace Pulumi.Tests.Core
                 sample = new SampleArgs { Union = Union<string, int>.FromT1(456) };
                 data = await sample.Union.ToOutput().DataTask.ConfigureAwait(false);
                 Assert.Equal(456, data.Value);
+            });
+
+        [Fact]
+        public Task InputMapAdd()
+            => RunInPreview(async () =>
+            {
+                var map = new InputMap<string>();
+
+                // Add a key and value
+                map.Add("K1", "V1");
+                // Add the a new key and the same value twice
+                map.Add("K2", "V2");
+                map.Add("K2", "V2");
+
+                // We should be able to get this map still
+                var data = await map.ToOutput().DataTask.ConfigureAwait(false);
+                Assert.Equal(2, data.Value.Count);
+                Assert.Equal(new Dictionary<string, string> { ["K1"] = "V1", ["K2"] = "V2" }, data.Value);
+
+                // Add a new key and two different values
+                map.Add("K3", "V3");
+                map.Add("K3", "V3_wrong");
+
+                // This should now throw an exception
+                await Assert.ThrowsAsync<ArgumentException>(() => map.ToOutput().DataTask).ConfigureAwait(false);
             });
 
         private class SampleArgs

--- a/sdk/Pulumi.Tests/Serialization/MarshalOutputTests.cs
+++ b/sdk/Pulumi.Tests/Serialization/MarshalOutputTests.cs
@@ -147,6 +147,12 @@ namespace Pulumi.Tests.Serialization
             },
             new object[]
             {
+                // Added the same key value to an input map twice merged the secretness (and other output information)
+                new InputMap<string> { { "foo", Output.CreateSecret("hello")}, { "foo", "hello"  } },
+                ImmutableDictionary<string, object>.Empty.Add("foo", CreateSecretValue("hello"))
+            },
+            new object[]
+            {
                 new BarArgs { Foo = new FooArgs { Foo = "hello" } },
                 ImmutableDictionary<string, object>.Empty.Add("foo",
                     ImmutableDictionary<string, object>.Empty.Add("foo", "hello"))

--- a/sdk/Pulumi/Core/InputMap.cs
+++ b/sdk/Pulumi/Core/InputMap.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+using Microsoft.VisualBasic;
 
 namespace Pulumi
 {
@@ -91,7 +92,30 @@ namespace Pulumi
 
         public void Add(string key, Input<V> value)
         {
-            Value = Value.Apply(self => self.Add(key, value));
+            Value = Value.Apply(self =>
+            {
+                // ImmutableDictionary allows the same value to be added twice for the same. Sameness is decided via EqualityComparer<V>,
+                // which used to work well for InputMap but now that we have Input<T> as values, we need to compare the value inside the
+                // Input<T> and not the Input<T> itself. See https://github.com/pulumi/pulumi-dotnet/issues/458.
+
+                if (!self.TryGetValue(key, out var existingValue))
+                {
+                    // If the key is not present, add it
+                    return self.Add(key, value);
+                }
+
+                // Else we can only know if the key is ok to add if we compare the values inside the Input<T>. This is a
+                // bit odd, because firstly the exception is only seen if awaiting _this_ value, not the value for the
+                // dictionary itself. That shouldn't be an issue because the only thing that can resolve the
+                // dictionaries inner levels separately is the property serializer and it always reads all the values.
+                // The other oddity is this merges the secretness and dependency information of the two values, so if
+                // you add "K" with a secret "hello", and then call add for "K" again with a non-secret "hello" it's going to
+                // merge both and keep the secret tag. Doing better then this requires a custom Apply function here.
+                return self.SetItem(key,
+                    Output.Tuple(existingValue, value).Apply(x =>
+                        EqualityComparer<V>.Default.Equals(x.Item1, x.Item2) ?
+                            x.Item1 : throw new ArgumentException($"Key '{key}' already exists in the map with a different value.")));
+            });
         }
 
         /// <summary>

--- a/sdk/Pulumi/Core/InputMap.cs
+++ b/sdk/Pulumi/Core/InputMap.cs
@@ -68,7 +68,7 @@ namespace Pulumi
         ///
         /// To do that we keep a separate value of the form <c>Input{ImmutableDictionary{string, Input{T}}}</c>
         /// which each time we set syncs the flattened value to the base <c>Input{ImmutableDictionary{string,
-        /// T}}</c>. 
+        /// T}}</c>.
         /// </summary>
         Input<ImmutableDictionary<string, Input<V>>> Value
         {
@@ -94,9 +94,10 @@ namespace Pulumi
         {
             Value = Value.Apply(self =>
             {
-                // ImmutableDictionary allows the same value to be added twice for the same. Sameness is decided via EqualityComparer<V>,
-                // which used to work well for InputMap but now that we have Input<T> as values, we need to compare the value inside the
-                // Input<T> and not the Input<T> itself. See https://github.com/pulumi/pulumi-dotnet/issues/458.
+                // ImmutableDictionary allows the same key value pair to be added twice. Sameness is decided
+                // via EqualityComparer<V>, which used to work well for InputMap but now that we have Input<T>
+                // as values, we need to compare the value inside the Input<T> and not the Input<T> itself.
+                // See https://github.com/pulumi/pulumi-dotnet/issues/458.
 
                 if (!self.TryGetValue(key, out var existingValue))
                 {
@@ -104,13 +105,16 @@ namespace Pulumi
                     return self.Add(key, value);
                 }
 
-                // Else we can only know if the key is ok to add if we compare the values inside the Input<T>. This is a
-                // bit odd, because firstly the exception is only seen if awaiting _this_ value, not the value for the
-                // dictionary itself. That shouldn't be an issue because the only thing that can resolve the
-                // dictionaries inner levels separately is the property serializer and it always reads all the values.
-                // The other oddity is this merges the secretness and dependency information of the two values, so if
-                // you add "K" with a secret "hello", and then call add for "K" again with a non-secret "hello" it's going to
-                // merge both and keep the secret tag. Doing better then this requires a custom Apply function here.
+                // Else we can only know if the key is ok to add if we compare the values inside the Input<T>.
+                // This is a bit odd for two reasons.
+                // 1) Firstly the exception is only seen if awaiting _this_ value, not the value for the
+                //    dictionary itself. That shouldn't be an issue because the only thing that can resolve
+                //    the dictionaries inner levels separately is the property serializer and it always reads
+                //    all the values.
+                // 2) Secondly this merges the secretness and dependency information of the two values, so if
+                //    you add "K" with a secret "hello", and then call add for "K" again with a non-secret
+                //    "hello" it's going to merge both and keep the secret tag. Doing better then this
+                //    requires a custom Apply function here.
                 return self.SetItem(key,
                     Output.Tuple(existingValue, value).Apply(x =>
                         EqualityComparer<V>.Default.Equals(x.Item1, x.Item2) ?

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -575,7 +575,7 @@
             
              To do that we keep a separate value of the form <c>Input{ImmutableDictionary{string, Input{T}}}</c>
              which each time we set syncs the flattened value to the base <c>Input{ImmutableDictionary{string,
-             T}}</c>. 
+             T}}</c>.
              </summary>
         </member>
         <member name="M:Pulumi.InputMap`1.Add(Pulumi.InputMap{`0})">


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-dotnet/issues/458

Before https://github.com/pulumi/pulumi-dotnet/pull/449 it used to be possible to `Add` the same key value pair to `InputMap` multiple times. This because of a feature of the underlying ConcurrentDictionary which will use `EqualityComparer` to see if the key and value being added are the same as what's in the dictionary already and if so just returns the existing dictionary. 

#449 broke this because now all the values of the dictionary are `Input`s which don't have a sensible notion of equality. This adds some extra handling in our Add method to try and maintain this feature.

It _does_ have two oddities:
1. The exception is recorded on the value, not the map overall. This shouldn't be observable because users can only resolve InputMap as a single `Input<Dict<K, V>>` and not directly access the nested input values. But it's worth calling out to keep in mind for the future.
2. The value always merges the secretes and dependencies of all `Input`s added to the one key. Those properties don't get overwritten, so if you add `("k", secret("hello"))` then add `("k", "hello")` you might expect that value to no longer be secret because it's been overwritten, but in fact the secretness is merged and so it's still secret. Fixing this would require a custom apply implementation to await both values, then _iff_ they're both known keep just the output data from the later one, but you'd still end up with merged data if either was unknown. All in all it didn't feel worth the complexity to do different here.
