### PR TITLE
Minor simplification in Output<T>.ToString

### DIFF
--- a/sdk/Pulumi/Core/Output.cs
+++ b/sdk/Pulumi/Core/Output.cs
@@ -693,26 +693,24 @@ namespace Pulumi
 
         public override string ToString()
         {
-            var messageLines = new List<string>
-            {
+            var message = string.Join(Environment.NewLine,
                 "Calling [ToString] on an [Output<T>] is not supported.",
                 "",
                 "To get the value of an Output<T> as an Output<string> consider:",
                 "1. o.Apply(v => $\"prefix{v}suffix\")",
                 "2. Output.Format($\"prefix{hostname}suffix\");",
                 "",
-                "See https://www.pulumi.com/docs/concepts/inputs-outputs for more details.",
-            };
+                "See https://www.pulumi.com/docs/concepts/inputs-outputs for more details."
+            );
 
             var errorOutputString = Environment.GetEnvironmentVariable("PULUMI_ERROR_OUTPUT_STRING");
 
             if (errorOutputString == "1" || string.Equals(errorOutputString, "true", StringComparison.OrdinalIgnoreCase))
             {
-                throw new InvalidOperationException(string.Join(Environment.NewLine, messageLines));
+                throw new InvalidOperationException(message);
             }
 
-            messageLines.Add("This function may throw in a future version of Pulumi.");
-            return string.Join(Environment.NewLine, messageLines);
+            return string.Join(Environment.NewLine, message, "This function may throw in a future version of Pulumi.");
         }
     }
 


### PR DESCRIPTION
It doesn't really matter, but I noticed while porting to Java in https://github.com/pulumi/pulumi-java/pull/1665 that the implementation could be simplified slightly (no need for the `List<string>`), so I've gone ahead and updated the code here to match the Java implementation.