### PR TITLE
Add a `make changelog` command for consistency with `pulumi/pulumi`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ build::
 	cd pulumi-language-dotnet && ${GO} build \
 		-ldflags "-X github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/version.Version=$(DEV_VERSION)" .
 
+changelog::
+	changie new
+
 test_integration:: build
 	cd integration_tests && gotestsum -- --parallel 1 --timeout 60m ./...
 


### PR DESCRIPTION
It wasn't immediately obvious to me how to produce a changelog, but `make changelog` was the first thing I tried. This PR adds a `make changelog` command to mimic `pulumi/pulumi`.