### PR TITLE
[sdk] Support parameterization for remote component resources

### DIFF
--- a/.changes/unreleased/Improvements-502.yaml
+++ b/.changes/unreleased/Improvements-502.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Support parameterization for remote component resources
+time: 2025-02-22T08:54:11.922966+01:00
+custom:
+    PR: "502"

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -1907,6 +1907,21 @@
             <param name="options">A bag of options that control this resource's behavior.</param>
             <param name="remote">True if this is a remote component resource.</param>
         </member>
+        <member name="M:Pulumi.ComponentResource.#ctor(System.String,System.String,Pulumi.ResourceArgs,Pulumi.ComponentResourceOptions,System.Boolean,Pulumi.RegisterPackageRequest)">
+            <summary>
+            Creates and registers a new component resource.  <paramref name="type"/> is the fully
+            qualified type token and <paramref name="name"/> is the "name" part to use in creating a
+            stable and globally unique URN for the object. <c>options.parent</c> is the optional parent
+            for this component, and [options.dependsOn] is an optional list of other resources that
+            this resource depends on, controlling the order in which we perform resource operations.
+            </summary>
+            <param name="type">The type of the resource.</param>
+            <param name="name">The unique name of the resource.</param>
+            <param name="args">The arguments to use to populate the new resource.</param>
+            <param name="options">A bag of options that control this resource's behavior.</param>
+            <param name="remote">True if this is a remote component resource.</param>
+            <param name="registerPackageRequest">Package parameterization options.</param>
+        </member>
         <member name="M:Pulumi.ComponentResource.RegisterOutputs">
             <summary>
             RegisterOutputs registers synthetic outputs that a component has initialized, usually by

--- a/sdk/Pulumi/Resources/ComponentResource.cs
+++ b/sdk/Pulumi/Resources/ComponentResource.cs
@@ -28,7 +28,7 @@ namespace Pulumi
         /// <param name="name">The unique name of the resource.</param>
         /// <param name="options">A bag of options that control this resource's behavior.</param>
         public ComponentResource(string type, string name, ComponentResourceOptions? options = null)
-            : this(type, name, ResourceArgs.Empty, options)
+            : this(type, name, ResourceArgs.Empty, options, remote: false, registerPackageRequest: null)
         {
         }
 
@@ -44,10 +44,35 @@ namespace Pulumi
         /// <param name="args">The arguments to use to populate the new resource.</param>
         /// <param name="options">A bag of options that control this resource's behavior.</param>
         /// <param name="remote">True if this is a remote component resource.</param>
-#pragma warning disable RS0022 // Constructor make noninheritable base class inheritable
         public ComponentResource(
             string type, string name, ResourceArgs? args, ComponentResourceOptions? options = null, bool remote = false)
-            : base(type, name, custom: false, args ?? ResourceArgs.Empty, options ?? new ComponentResourceOptions(), remote)
+            : this(type, name, args ?? ResourceArgs.Empty, options ?? new ComponentResourceOptions(), remote, registerPackageRequest: null)
+        {
+
+        }
+
+        /// <summary>
+        /// Creates and registers a new component resource.  <paramref name="type"/> is the fully
+        /// qualified type token and <paramref name="name"/> is the "name" part to use in creating a
+        /// stable and globally unique URN for the object. <c>options.parent</c> is the optional parent
+        /// for this component, and [options.dependsOn] is an optional list of other resources that
+        /// this resource depends on, controlling the order in which we perform resource operations.
+        /// </summary>
+        /// <param name="type">The type of the resource.</param>
+        /// <param name="name">The unique name of the resource.</param>
+        /// <param name="args">The arguments to use to populate the new resource.</param>
+        /// <param name="options">A bag of options that control this resource's behavior.</param>
+        /// <param name="remote">True if this is a remote component resource.</param>
+        /// <param name="registerPackageRequest">Package parameterization options.</param>
+#pragma warning disable RS0022 // Constructor make noninheritable base class inheritable
+        public ComponentResource(
+            string type,
+            string name,
+            ResourceArgs? args,
+            ComponentResourceOptions? options,
+            bool remote,
+            RegisterPackageRequest? registerPackageRequest = null)
+            : base(type, name, custom: false, args ?? ResourceArgs.Empty, options ?? new ComponentResourceOptions(), remote, dependency: false, registerPackageRequest)
 #pragma warning restore RS0022 // Constructor make noninheritable base class inheritable
         {
             this.remote = remote;


### PR DESCRIPTION
### Description

When generating parameterized .NET SDKs, resources that marked `isComponent: true` in the schema do not support parameterization leading to runtime errors that mentioned missing plugins
```
error: Could not automatically download and install resource plugin 'pulumi-resource-<parameterized-package>' at version v0.0.x
```
This PR adds SDK support for parameterized _remote_ component resources. Still required SDK-gen support from pulumi/pulumi to emit the actual `RegisterPackageRequest` in the newly added constructor overload 

Fixes #503 