### PR TITLE
Consistent inheritance behavior for InputAttribute and OutputAttribute

### DIFF
--- a/.changes/unreleased/bug-fixes-506.yaml
+++ b/.changes/unreleased/bug-fixes-506.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Fix inconsistent behavior of inheritance for InputAttribute and OutputAttribute
+time: 2025-02-24T09:40:25.1221824+01:00
+custom:
+    PR: "506"

--- a/integration_tests/provider_construct/dotnet/Component.cs
+++ b/integration_tests/provider_construct/dotnet/Component.cs
@@ -1,6 +1,18 @@
 using Pulumi;
 
-class Component : Pulumi.ComponentResource
+
+abstract class ComponentBase : ComponentResource
+{
+    protected ComponentBase(string type, string name, ResourceArgs? args, ComponentResourceOptions? options = null, bool remote = false)
+        : base(type, name, args, options, remote)
+    {
+    }
+
+    [Output("inheritOutputAttribute")]
+    public abstract Output<string> InheritOutputAttribute { get; protected set; }
+}
+
+class Component : ComponentBase
 {
     public Component(string name, ComponentArgs args, ComponentResourceOptions? opts = null)
         : base("test:index:Test", name, args, opts, remote: true)
@@ -8,32 +20,57 @@ class Component : Pulumi.ComponentResource
     }
 
     [Output("passwordResult")]
-    public Output<string> PasswordResult { get; private set; } = default!;
+    public Output<string> PasswordResult { get; protected set; } = default!;
 
     [Output("complexResult")]
-    public Output<ComplexType> ComplexResult { get; set; } = default!;
+    public Output<ComplexType> ComplexResult { get; protected set; } = default!;
+
+    // the Output attribute is inherited from the base class
+    public override Output<string> InheritOutputAttribute { get; protected set; }
 }
 
-class ComponentArgs : ResourceArgs
+public abstract class ComponentArgsBase : ResourceArgs {
+    [Input("inheritInputAttribute")]
+    public abstract Input<string> InheritInputAttribute  { get; set; }
+}
+
+public sealed class ComponentArgs : ComponentArgsBase
 {
     [Input("passwordLength")]
     public Input<int> PasswordLength { get; set; } = null!;
 
     [Input("complex")]
     public Input<ComplexTypeArgs> Complex { get; set; } = null!;
+
+    // the Input attribute is inherited from the base class
+    public override Input<string> InheritInputAttribute  { get; set; } = null!;
 }
 
-public sealed class ComplexTypeArgs : global::Pulumi.ResourceArgs
+public abstract class ComplexTypeArgsBase : ResourceArgs {
+    [Input("inheritOutputAttribute")]
+    public abstract string InheritInputAttribute  { get; set; }
+}
+
+public sealed class ComplexTypeArgs : ComplexTypeArgsBase
 {
     [Input("name", required: true)]
     public string Name { get; set; } = null!;
 
     [Input("intValue", required: true)]
     public int IntValue { get; set; }
+
+    // the Input attribute is inherited from the base class
+    public override string InheritInputAttribute  { get; set; } = null!;
+}
+
+public abstract class ComplexTypeBase
+{
+    [Output("inheritOutputAttribute")]
+    public abstract string InheritOutputAttribute { get; set; }
 }
 
 [OutputType]
-public sealed class ComplexType
+public sealed class ComplexType : ComplexTypeBase
 {
     [Output("name")]
     public string Name { get; set; }
@@ -41,10 +78,14 @@ public sealed class ComplexType
     [Output("intValue")]
     public int IntValue { get; set; }
 
+    // the Output attribute is inherited from the base class
+    public override string InheritOutputAttribute { get; set; }
+
     [OutputConstructor]
-    public ComplexType(string name, int intValue)
+    public ComplexType(string name, int intValue, string inheritOutputAttribute)
     {
         Name = name;
         IntValue = intValue;
+        InheritOutputAttribute = inheritOutputAttribute;
     }
 }

--- a/integration_tests/provider_construct/dotnet/Program.cs
+++ b/integration_tests/provider_construct/dotnet/Program.cs
@@ -13,17 +13,21 @@ class Program
         {
             DebuggerUtils.WaitForDebugger();
 
-            var complexArgs10 = new ComplexTypeArgs{ Name = "component10", IntValue = 100 };
+            var complexArgs10 = new ComplexTypeArgs{ Name = "component10", IntValue = 100, InheritInputAttribute = "SomeInput"};
+            const string inheritInputAttribute10 = "ComponentInput";
             var component10 = new Component("component10", new ComponentArgs()
             {
                 PasswordLength = 10,
-                Complex = complexArgs10
+                Complex = complexArgs10,
+                InheritInputAttribute = inheritInputAttribute10
             });
-            var complexArgs20 = new ComplexTypeArgs{ Name = "component20", IntValue = 200 };
+            var complexArgs20 = new ComplexTypeArgs{ Name = "component20", IntValue = 200, InheritInputAttribute = "AnotherInput" };
+            const string inheritInputAttribute20 = "AnotherComponentInput";
             var component20 = new Component("component20", new ComponentArgs()
             {
                 PasswordLength = 20,
-                Complex = complexArgs20
+                Complex = complexArgs20,
+                InheritInputAttribute = inheritInputAttribute20
             });
 
             var result10 = await OutputUtilities.GetValueAsync(component10.PasswordResult);
@@ -35,6 +39,11 @@ class Program
             var complexResult20 = await OutputUtilities.GetValueAsync(component20.ComplexResult);
             ValidateComplexResult(complexResult10, complexArgs10);
             ValidateComplexResult(complexResult20, complexArgs20);
+
+            var inheritedOutputResult10 = await OutputUtilities.GetValueAsync(component10.InheritOutputAttribute);
+            var inheritedOutputResult20 = await OutputUtilities.GetValueAsync(component20.InheritOutputAttribute);
+            inheritedOutputResult10.Should().Be(inheritInputAttribute10);
+            inheritedOutputResult20.Should().Be(inheritInputAttribute20);
         });
 
         return returnCode;
@@ -44,5 +53,6 @@ class Program
     {
         result.Name.Should().Be(expected.Name);
         result.IntValue.Should().Be(expected.IntValue);
+        result.InheritOutputAttribute.Should().Be(expected.InheritInputAttribute);
     }
 }

--- a/sdk/Pulumi/Provider/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Provider/PropertyValueSerializer.cs
@@ -935,14 +935,14 @@ namespace Pulumi.Experimental.Provider
             var properties = componentType.GetProperties();
             foreach (var property in properties)
             {
-                var customAttribute = property.GetCustomAttribute<OutputAttribute>();
+                var outputAttribute = property.GetCustomAttribute<OutputAttribute>();
 
-                if (customAttribute != null)
+                if (outputAttribute != null)
                 {
                     var propertyName = property.Name;
-                    if (!string.IsNullOrWhiteSpace(customAttribute.Name))
+                    if (!string.IsNullOrWhiteSpace(outputAttribute.Name))
                     {
-                        propertyName = customAttribute.Name;
+                        propertyName = outputAttribute.Name;
                     }
 
                     var value = property.GetValue(component);

--- a/sdk/Pulumi/Provider/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Provider/PropertyValueSerializer.cs
@@ -176,11 +176,11 @@ namespace Pulumi.Experimental.Provider
                 propertyName = inputAttribute.Name;
             }
 
-            var output = property.GetCustomAttribute<OutputAttribute>();
+            var outputAttribute = property.GetCustomAttribute<OutputAttribute>();
 
-            if (output != null && !string.IsNullOrWhiteSpace(output.Name))
+            if (outputAttribute != null && !string.IsNullOrWhiteSpace(outputAttribute.Name))
             {
-                propertyName = output.Name;
+                propertyName = outputAttribute.Name;
             }
 
             return propertyName;
@@ -935,14 +935,14 @@ namespace Pulumi.Experimental.Provider
             var properties = componentType.GetProperties();
             foreach (var property in properties)
             {
-                var outputAttr = property.GetCustomAttribute<OutputAttribute>();
+                var customAttribute = property.GetCustomAttribute<OutputAttribute>();
 
-                if (outputAttr != null)
+                if (customAttribute != null)
                 {
                     var propertyName = property.Name;
-                    if (!string.IsNullOrWhiteSpace(outputAttr.Name))
+                    if (!string.IsNullOrWhiteSpace(customAttribute.Name))
                     {
-                        propertyName = outputAttr.Name;
+                        propertyName = customAttribute.Name;
                     }
 
                     var value = property.GetValue(component);

--- a/sdk/Pulumi/Provider/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Provider/PropertyValueSerializer.cs
@@ -164,27 +164,21 @@ namespace Pulumi.Experimental.Provider
         private string PropertyName(PropertyInfo property, Type declaringType)
         {
             var propertyName = property.Name;
-            var inputAttribute =
-                property
-                    .GetCustomAttributes(typeof(InputAttribute))
-                    .FirstOrDefault();
+            var inputAttribute = property.GetCustomAttribute<InputAttribute>();
 
             if (inputAttribute == null && TryGetBackingField(propertyName, out var inputField))
             {
-                inputAttribute = inputField.GetCustomAttributes(typeof(InputAttribute)).FirstOrDefault();
+                inputAttribute = inputField.GetCustomAttribute<InputAttribute>();
             }
 
-            if (inputAttribute is InputAttribute input && !string.IsNullOrWhiteSpace(input.Name))
+            if (inputAttribute != null && !string.IsNullOrWhiteSpace(inputAttribute.Name))
             {
-                propertyName = input.Name;
+                propertyName = inputAttribute.Name;
             }
 
-            var outputAttribute =
-                property
-                    .GetCustomAttributes(typeof(OutputAttribute))
-                    .FirstOrDefault();
+            var output = property.GetCustomAttribute<OutputAttribute>();
 
-            if (outputAttribute is OutputAttribute output && !string.IsNullOrWhiteSpace(output.Name))
+            if (output != null && !string.IsNullOrWhiteSpace(output.Name))
             {
                 propertyName = output.Name;
             }
@@ -941,16 +935,14 @@ namespace Pulumi.Experimental.Provider
             var properties = componentType.GetProperties();
             foreach (var property in properties)
             {
-                var outputAttr = property
-                    .GetCustomAttributes(typeof(OutputAttribute), false)
-                    .FirstOrDefault();
+                var outputAttr = property.GetCustomAttribute<OutputAttribute>();
 
-                if (outputAttr is OutputAttribute attr)
+                if (outputAttr != null)
                 {
                     var propertyName = property.Name;
-                    if (!string.IsNullOrWhiteSpace(attr.Name))
+                    if (!string.IsNullOrWhiteSpace(outputAttr.Name))
                     {
-                        propertyName = attr.Name;
+                        propertyName = outputAttr.Name;
                     }
 
                     var value = property.GetValue(component);

--- a/sdk/Pulumi/Resources/ComponentResource.cs
+++ b/sdk/Pulumi/Resources/ComponentResource.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Pulumi
@@ -97,18 +98,16 @@ namespace Pulumi
                     continue;
                 }
 
-                var outputAttribute =
-                    prop.GetCustomAttributes(typeof(OutputAttribute), false)
-                        .FirstOrDefault();
+                var outputAttribute = prop.GetCustomAttribute<OutputAttribute>();
 
-                if (outputAttribute is OutputAttribute attr)
+                if (outputAttribute != null)
                 {
                     var registerdOutputKey = prop.Name;
-                    if (!string.IsNullOrWhiteSpace(attr.Name))
+                    if (!string.IsNullOrWhiteSpace(outputAttribute.Name))
                     {
                         // when using [Output("<name>")] we will export the value of this property
                         // with its key equal to the provided <name>
-                        registerdOutputKey = attr.Name;
+                        registerdOutputKey = outputAttribute.Name;
                     }
 
                     // otherwise if we only have [Output] we will simply use the name of the property itself


### PR DESCRIPTION
The InputAttribute and OutputAttribute have an AttributeUseage  with inherit: true.

When using abstract classes and properties, the current implementation does not handle inheritance of the attributes consistently. In some cases, the attributes are checked with inherit: false, in other cases with inherit:true.

I have made the behavior consistent and as expected from the AttributeUseage of InputAttribute and OutputAttribute.