### PR TITLE
Component provider host for auto-inferred components

### DIFF
--- a/.changes/unreleased/Improvements-507.yaml
+++ b/.changes/unreleased/Improvements-507.yaml
@@ -1,0 +1,6 @@
+component: sdk/provider
+kind: Improvements
+body: Component provider host for auto-inferred components
+time: 2025-02-24T16:07:06.547901+01:00
+custom:
+    PR: "507"

--- a/.changes/unreleased/Improvements-507.yaml
+++ b/.changes/unreleased/Improvements-507.yaml
@@ -1,6 +1,6 @@
 component: sdk/provider
 kind: Improvements
-body: Component provider host for auto-inferred components
+body: Implement component provider host for auto-inferred components
 time: 2025-02-24T16:07:06.547901+01:00
 custom:
     PR: "507"

--- a/integration_tests/integration_dotnet_test.go
+++ b/integration_tests/integration_dotnet_test.go
@@ -612,6 +612,15 @@ func TestProviderCallInvalidArgument(t *testing.T) {
 }
 
 //nolint:paralleltest // ProgramTest calls testing.T.Parallel
+func TestProviderComponentHost(t *testing.T) {
+	const testDir = "provider_component_host"
+	testDotnetProgram(t, &integration.ProgramTestOptions{
+		Dir:   filepath.Join(testDir, "example"),
+		Quick: true,
+	})
+}
+
+//nolint:paralleltest // ProgramTest calls testing.T.Parallel
 func TestProviderConstruct(t *testing.T) {
 	const testDir = "provider_construct"
 	testDotnetProgram(t, &integration.ProgramTestOptions{

--- a/integration_tests/provider_component_host/Component.cs
+++ b/integration_tests/provider_component_host/Component.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Pulumi;
+
+public sealed class ComponentArgs : ResourceArgs
+{
+    [Input("passwordLength", required: true)]
+    public Input<int> PasswordLength { get; set; } = null!;
+
+    [Input("complex")]
+    public Input<ComplexTypeArgs> Complex { get; set; } = null!;
+}
+
+public sealed class ComplexTypeArgs : ResourceArgs
+{
+    [Input("name", required: true)]
+    public string Name { get; set; } = null!;
+
+    [Input("intValue", required: true)]
+    public int IntValue { get; set; }
+}
+
+[OutputType]
+public sealed class ComplexType
+{
+    [Output("name")]
+    public string Name { get; set; }
+
+    [Output("intValue")]
+    public int IntValue { get; set; }
+
+    [OutputConstructor]
+    public ComplexType(string name, int intValue)
+    {
+        Name = name;
+        IntValue = intValue;
+    }
+}
+
+class Component : ComponentResource
+{
+    private static readonly char[] Chars =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".ToCharArray();
+
+    [Output("passwordResult")]
+    public Output<string> PasswordResult { get; set; }
+
+    [Output("complexResult")]
+    public Output<ComplexType> ComplexResult { get; set; }
+
+    public Component(string name, ComponentArgs args, ComponentResourceOptions? opts = null)
+        : base("test:index:Test", name, args, opts)
+    {
+        PasswordResult = args.PasswordLength.Apply(GenerateRandomString);
+        if (args.Complex != null)
+        {
+            ComplexResult = args.Complex.Apply(complex => Output.Create(AsTask(new ComplexType(complex.Name, complex.IntValue))));
+        }
+    }
+
+    private static Output<string> GenerateRandomString(int length)
+    {
+        var result = new StringBuilder(length);
+        var random = new Random();
+
+        for (var i = 0; i < length; i++)
+        {
+            result.Append(Chars[random.Next(Chars.Length)]);
+        }
+
+        return Output.CreateSecret(result.ToString());
+    }
+
+    private async Task<T> AsTask<T>(T value)
+    {
+        await Task.Delay(10);
+        return value;
+    }
+}

--- a/integration_tests/provider_component_host/Program.cs
+++ b/integration_tests/provider_component_host/Program.cs
@@ -1,0 +1,8 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Pulumi.Experimental.Provider;
+
+class Program
+{
+    public static Task Main(string []args) => ComponentProviderHost.Serve(args);
+}

--- a/integration_tests/provider_component_host/PulumiPlugin.yaml
+++ b/integration_tests/provider_component_host/PulumiPlugin.yaml
@@ -1,0 +1,1 @@
+runtime: dotnet

--- a/integration_tests/provider_component_host/TestProvider.csproj
+++ b/integration_tests/provider_component_host/TestProvider.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <AssemblyName>dotnet-components</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\sdk\Pulumi\Pulumi.csproj"/>
+  </ItemGroup>
+</Project>

--- a/integration_tests/provider_component_host/example/Pulumi.yaml
+++ b/integration_tests/provider_component_host/example/Pulumi.yaml
@@ -1,0 +1,13 @@
+name: dotnet-component-yaml
+runtime: yaml
+plugins:
+  providers:
+    - name: dotnet-components
+      path: ..
+resources:
+  hello:
+    type: dotnet-components:index:Component
+    properties:
+      passwordLength: 12
+outputs:
+  value: ${hello.passwordResult}

--- a/sdk/Pulumi.Tests/Provider/ComponentProviderTests.cs
+++ b/sdk/Pulumi.Tests/Provider/ComponentProviderTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Pulumi.Experimental.Provider;
+
+namespace Pulumi.Tests.Provider
+{
+    public class ComponentProviderTests
+    {
+        private ComponentProvider _provider;
+
+        public ComponentProviderTests()
+        {
+            var assembly = typeof(TestComponent).Assembly;
+            _provider = new ComponentProvider(assembly, "test-package", new[] { typeof(TestComponent) });
+        }
+
+        [Fact]
+        public async Task GetSchema_ShouldReturnValidSchema()
+        {
+            var request = new GetSchemaRequest(1, null, null);
+            var response = await _provider.GetSchema(request, CancellationToken.None);
+
+            Assert.NotNull(response);
+            Assert.NotNull(response.Schema);
+            Assert.Contains("TestComponent", response.Schema);
+            Assert.Contains("testProperty", response.Schema);
+        }
+
+        [Fact]
+        public async Task Construct_ValidComponent_ShouldThrowExpectedDeploymentException()
+        {
+            var name = "test-component";
+            var inputs = new Dictionary<string, PropertyValue>
+            {
+                ["testProperty"] = new PropertyValue("test-value")
+            }.ToImmutableDictionary();
+            var options = new ComponentResourceOptions();
+            var request = new ConstructRequest(
+                "test-package:index:TestComponent",
+                name,
+                inputs,
+                options
+            );
+
+            // We haven't initiated the deployment, so component construction will fail. Expect that specific exception,
+            // since it will indicate that the rest of the provider is working. The checks are somewhat brittle and may fail
+            // if we change the exception message or stack, but hopefully that will not happen too often.
+            var exception = await Assert.ThrowsAsync<TargetInvocationException>(
+                async () => await _provider.Construct(request, CancellationToken.None)
+            );
+
+            Assert.IsType<InvalidOperationException>(exception.InnerException);
+            Assert.Contains("Deployment", exception.InnerException!.Message);
+        }
+
+        [Fact]
+        public async Task Construct_InvalidPackageName_ShouldThrowException()
+        {
+            var request = new ConstructRequest(
+                "wrong:index:TestComponent",
+                "test",
+                ImmutableDictionary<string, PropertyValue>.Empty,
+                new ComponentResourceOptions()
+            );
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(
+                async () => await _provider.Construct(request, CancellationToken.None)
+            );
+
+            Assert.Contains("Invalid resource type", exception.Message);
+        }
+
+        [Fact]
+        public async Task Construct_NonExistentComponent_ShouldThrowException()
+        {
+            var request = new ConstructRequest(
+                "test-package:index:NonExistentComponent",
+                "test",
+                ImmutableDictionary<string, PropertyValue>.Empty,
+                new ComponentResourceOptions()
+            );
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(
+                async () => await _provider.Construct(request, CancellationToken.None)
+            );
+
+            Assert.Contains("Component type not found", exception.Message);
+        }
+    }
+
+    class TestComponentArgs : ResourceArgs
+    {
+        [Input("testProperty", required: true)]
+        public Input<string> TestProperty { get; set; } = null!;
+    }
+
+    class TestComponent : ComponentResource
+    {
+        public TestComponent(string name, TestComponentArgs args, ComponentResourceOptions? options = null)
+            : base("test-package:index:TestComponent", name, args, options)
+        {
+        }
+    }
+}

--- a/sdk/Pulumi/Provider/ComponentAnalyzer.cs
+++ b/sdk/Pulumi/Provider/ComponentAnalyzer.cs
@@ -29,9 +29,8 @@ namespace Pulumi.Experimental.Provider
         /// <returns>A PackageSpec containing the complete schema for all components and their types</returns>
         public static PackageSpec GenerateSchema(Metadata metadata, Assembly assembly)
         {
-            var types = assembly.GetTypes()
-                .Where(t => typeof(ComponentResource).IsAssignableFrom(t) && !t.IsAbstract);
-            return GenerateSchema(metadata, types.ToArray());
+            var types = FindComponentTypes(assembly).ToArray();
+            return GenerateSchema(metadata, types);
         }
 
         /// <summary>
@@ -72,6 +71,29 @@ namespace Pulumi.Experimental.Provider
             }
 
             return analyzer.GenerateSchema(metadata, components, analyzer.typeDefinitions);
+        }
+
+        /// <summary>
+        /// Finds a component type by name in the given assembly or type array.
+        /// </summary>
+        public static Type? FindComponentType(string name, Assembly assembly, Type[]? componentTypes = null)
+        {
+            // First try to find the type in explicitly provided component types
+            var componentType = componentTypes?.FirstOrDefault(t => t.Name == name);
+
+            // Fall back to assembly lookup if not found or if no types were provided
+            if (componentType == null)
+            {
+                componentType = FindComponentTypes(assembly).FirstOrDefault(t => t.Name == name);
+            }
+
+            return componentType;
+        }
+
+        private static IEnumerable<Type> FindComponentTypes(Assembly assembly)
+        {
+            return assembly.GetTypes()
+                .Where(t => typeof(ComponentResource).IsAssignableFrom(t) && !t.IsAbstract);
         }
 
         private PackageSpec GenerateSchema(

--- a/sdk/Pulumi/Provider/ComponentProvider.cs
+++ b/sdk/Pulumi/Provider/ComponentProvider.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Immutable;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Pulumi.Utilities;
+
+namespace Pulumi.Experimental.Provider
+{
+    /// <summary>
+    /// A provider that can be used to construct components from a given assembly with automatic schema inference.
+    /// </summary>
+    public class ComponentProvider : Provider
+    {
+        private readonly Assembly componentAssembly;
+        private readonly string packageName;
+        private readonly Type[]? componentTypes;
+#pragma warning disable CS0618 // Type or member is obsolete
+        private readonly PropertyValueSerializer serializer;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        /// <summary>
+        /// Creates a new component provider.
+        /// </summary>
+        /// <param name="componentAssembly">The assembly containing component types</param>
+        /// <param name="packageName">Optional package name (defaults to assembly name)</param>
+        /// <param name="componentTypes">Optional array of known component types</param>
+        public ComponentProvider(Assembly componentAssembly, string? packageName = null, Type[]? componentTypes = null)
+        {
+            this.componentAssembly = componentAssembly;
+            this.packageName = packageName ?? this.componentAssembly.GetName().Name!.ToLower();
+            this.componentTypes = componentTypes;
+#pragma warning disable CS0618 // Type or member is obsolete
+            this.serializer = new PropertyValueSerializer();
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        /// <summary>
+        /// Gets the schema for the components in the assembly.
+        /// </summary>
+        /// <param name="request">The request containing the package name</param>
+        /// <param name="ct">The cancellation token</param>
+        /// <returns>The schema for the components in the assembly</returns>
+        public override Task<GetSchemaResponse> GetSchema(GetSchemaRequest request, CancellationToken ct)
+        {
+            var metadata = new Metadata(packageName);
+            var schema = componentTypes != null
+                ? ComponentAnalyzer.GenerateSchema(metadata, componentTypes)
+                : ComponentAnalyzer.GenerateSchema(metadata, componentAssembly);
+
+            // Serialize to JSON
+            var jsonSchema = JsonSerializer.Serialize(schema, new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            });
+
+            return Task.FromResult(new GetSchemaResponse
+            {
+                Schema = jsonSchema
+            });
+        }
+
+        /// <summary>
+        /// Constructs a component resource.
+        /// </summary>
+        /// <param name="request">The request containing the component type and inputs</param>
+        /// <param name="ct">The cancellation token</param>
+        /// <returns>The constructed component resource</returns>
+        /// <exception cref="ArgumentException">If the resource type is invalid</exception>
+        /// <exception cref="InvalidOperationException">If the component type is not found or cannot be constructed</exception>
+        public override async Task<ConstructResponse> Construct(ConstructRequest request, CancellationToken ct)
+        {
+            // Parse type token
+            var parts = request.Type.Split(':');
+            if (parts.Length != 3 || parts[0] != packageName)
+                throw new ArgumentException($"Invalid resource type: {request.Type}");
+
+            var componentName = parts[2];
+            var componentType = ComponentAnalyzer.FindComponentType(componentName, componentAssembly, componentTypes)
+                ?? throw new ArgumentException($"Component type not found: {componentName}");
+
+            // Create args instance by deserializing inputs
+            var argsType = GetArgsType(componentType);
+            var args = serializer.Deserialize(new PropertyValue(request.Inputs), argsType);
+
+            // Create component instance
+            var component = (ComponentResource)Activator.CreateInstance(componentType, request.Name, args, request.Options)!;
+
+            var urn = await OutputUtilities.GetValueAsync(component.Urn);
+            if (string.IsNullOrEmpty(urn))
+            {
+                throw new InvalidOperationException($"URN of resource {request.Name} is not known.");
+            }
+
+            var stateValue = await serializer.StateFromComponentResource(component);
+
+            return new ConstructResponse(new Experimental.Provider.Urn(urn), stateValue, ImmutableDictionary<string, ISet<Urn>>.Empty);
+        }
+
+        private static Type GetArgsType(Type componentType)
+        {
+            var constructor = componentType.GetConstructors().First();
+            var argsParameter = constructor.GetParameters()
+                .FirstOrDefault(p => p.Name == "args")
+                ?? throw new ArgumentException($"Component {componentType.Name} must have an 'args' parameter in constructor");
+
+            return argsParameter.ParameterType;
+        }
+    }
+}

--- a/sdk/Pulumi/Provider/ComponentProviderHost.cs
+++ b/sdk/Pulumi/Provider/ComponentProviderHost.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Immutable;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Pulumi.Utilities;
+
+namespace Pulumi.Experimental.Provider
+{
+    /// <summary>
+    /// A host to serve the component provider automatically. See <see cref="Serve(string[], Assembly?, string?)"/> for more details.
+    /// </summary>
+    public static class ComponentProviderHost
+    {
+        /// <summary>
+        /// Serves the component provider. It discovers all component types in the given assembly and serves them
+        /// automatically as a component provider, including GetSchema and Construct methods.
+        /// </summary>
+        /// <param name="args">The command-line arguments</param>
+        /// <param name="componentAssembly">The assembly containing component types</param>
+        /// <param name="packageName">Optional package name (defaults to assembly name)</param>
+        public static Task Serve(string[] args, Assembly? componentAssembly = null, string? packageName = null)
+        {
+            var assembly = componentAssembly ?? Assembly.GetCallingAssembly();
+            return Provider.Serve(args, null, host => new ComponentProvider(assembly, packageName), CancellationToken.None);
+        }
+    }
+}

--- a/sdk/Pulumi/Provider/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Provider/PropertyValueSerializer.cs
@@ -382,14 +382,19 @@ namespace Pulumi.Experimental.Provider
 
         public Task<T> Deserialize<T>(PropertyValue value)
         {
-            var rootPath = new[] { "$" };
-            var deserialized = DeserializeValue(value, typeof(T), rootPath);
+            var deserialized = Deserialize(value, typeof(T));
             if (deserialized is T deserializedValue)
             {
                 return Task.FromResult(deserializedValue);
             }
 
             throw new InvalidOperationException($"Could not deserialize value of type {typeof(T).Name}");
+        }
+
+        public object? Deserialize(PropertyValue value, Type targetType)
+        {
+            var rootPath = new[] { "$" };
+            return DeserializeValue(value, targetType, rootPath);
         }
 
         private object? DeserializeValue(PropertyValue value, Type targetType, string[] path)

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -191,6 +191,56 @@
             <param name="componentTypes">The component resource types to analyze</param>
             <returns>A PackageSpec containing the complete schema for all components and their types</returns>
         </member>
+        <member name="M:Pulumi.Experimental.Provider.ComponentAnalyzer.FindComponentType(System.String,System.Reflection.Assembly,System.Type[])">
+            <summary>
+            Finds a component type by name in the given assembly or type array.
+            </summary>
+        </member>
+        <member name="T:Pulumi.Experimental.Provider.ComponentProvider">
+            <summary>
+            A provider that can be used to construct components from a given assembly with automatic schema inference.
+            </summary>
+        </member>
+        <member name="M:Pulumi.Experimental.Provider.ComponentProvider.#ctor(System.Reflection.Assembly,System.String,System.Type[])">
+            <summary>
+            Creates a new component provider.
+            </summary>
+            <param name="componentAssembly">The assembly containing component types</param>
+            <param name="packageName">Optional package name (defaults to assembly name)</param>
+            <param name="componentTypes">Optional array of known component types</param>
+        </member>
+        <member name="M:Pulumi.Experimental.Provider.ComponentProvider.GetSchema(Pulumi.Experimental.Provider.GetSchemaRequest,System.Threading.CancellationToken)">
+            <summary>
+            Gets the schema for the components in the assembly.
+            </summary>
+            <param name="request">The request containing the package name</param>
+            <param name="ct">The cancellation token</param>
+            <returns>The schema for the components in the assembly</returns>
+        </member>
+        <member name="M:Pulumi.Experimental.Provider.ComponentProvider.Construct(Pulumi.Experimental.Provider.ConstructRequest,System.Threading.CancellationToken)">
+            <summary>
+            Constructs a component resource.
+            </summary>
+            <param name="request">The request containing the component type and inputs</param>
+            <param name="ct">The cancellation token</param>
+            <returns>The constructed component resource</returns>
+            <exception cref="T:System.ArgumentException">If the resource type is invalid</exception>
+            <exception cref="T:System.InvalidOperationException">If the component type is not found or cannot be constructed</exception>
+        </member>
+        <member name="T:Pulumi.Experimental.Provider.ComponentProviderHost">
+            <summary>
+            A host to serve the component provider automatically. See <see cref="M:Pulumi.Experimental.Provider.ComponentProviderHost.Serve(System.String[],System.Reflection.Assembly,System.String)"/> for more details.
+            </summary>
+        </member>
+        <member name="M:Pulumi.Experimental.Provider.ComponentProviderHost.Serve(System.String[],System.Reflection.Assembly,System.String)">
+            <summary>
+            Serves the component provider. It discovers all component types in the given assembly and serves them
+            automatically as a component provider, including GetSchema and Construct methods.
+            </summary>
+            <param name="args">The command-line arguments</param>
+            <param name="componentAssembly">The assembly containing component types</param>
+            <param name="packageName">Optional package name (defaults to assembly name)</param>
+        </member>
         <member name="T:Pulumi.Experimental.Provider.LogSeverity">
             <summary>
             LogSeverity is the severity level of a log message.  Errors are fatal; all others are informational.


### PR DESCRIPTION
Similar to other language SDKs, this PR implements a high-level component provider host that discovers schemas and constructors of all components in a given assembly or list of types at runtime.

Instantiating a component provider is now as simple as authoring a component and then calling

```csharp
class Program
{
    public static Task Main(string []args) => ComponentProviderHost.Serve(args);
}
```

(see the provider_component_host example)

Resolve https://github.com/pulumi/pulumi-dotnet/issues/469