### PR TITLE
Add support for object type as Any in component schema

### DIFF
--- a/sdk/Pulumi.Tests/Provider/ComponentAnalyzerTests.cs
+++ b/sdk/Pulumi.Tests/Provider/ComponentAnalyzerTests.cs
@@ -581,6 +581,54 @@ public class ComponentAnalyzerTests
         var expected = CreateBasePackageSpec(resources);
         AssertSchemaEqual(expected, schema);
     }
+    
+    class AnyTypesArgs : ResourceArgs
+    {
+        [Input("inputAny", required: true)]
+        public Input<object> InputAny { get; set; } = null!;
+        
+        [Input("optionalInputAny")]
+        public Input<object>? OptionalInputAny { get; set; }
+    }
+
+    class AnyTypesComponent : ComponentResource
+    {
+        [Output("outputAny")]
+        public Output<object> OutputAny { get; private set; } = null!;
+        
+        [Output("optionalOutputAny")]
+        public Output<object?> OptionalOutputAny { get; private set; } = null!;
+
+        public AnyTypesComponent(string name, AnyTypesArgs args, ComponentResourceOptions? options = null)
+            : base("my-component:index:AnyTypesComponent", name, args, options)
+        {
+        }
+    }
+
+    [Fact]
+    public void TestAnalyzeAny()
+    {
+        var schema = ComponentAnalyzer.GenerateSchema(_metadata, typeof(AnyTypesComponent));
+
+        var resources = new Dictionary<string, ResourceSpec>();
+        resources.Add("my-component:index:AnyTypesComponent",
+            new ResourceSpec(
+                new Dictionary<string, PropertySpec>
+                {
+                    ["inputAny"] = PropertySpec.CreateReference("pulumi.json#/Any"),
+                    ["optionalInputAny"] = PropertySpec.CreateReference("pulumi.json#/Any")
+                },
+                new HashSet<string> { "inputAny" },
+                new Dictionary<string, PropertySpec>
+                {
+                    ["outputAny"] = PropertySpec.CreateReference("pulumi.json#/Any"),
+                    ["optionalOutputAny"] = PropertySpec.CreateReference("pulumi.json#/Any")
+                },
+                new HashSet<string> { "outputAny" }));
+
+        var expected = CreateBasePackageSpec(resources);
+        AssertSchemaEqual(expected, schema);
+    }
 
     class MyResource : CustomResource
     {

--- a/sdk/Pulumi.Tests/Provider/ComponentAnalyzerTests.cs
+++ b/sdk/Pulumi.Tests/Provider/ComponentAnalyzerTests.cs
@@ -581,12 +581,12 @@ public class ComponentAnalyzerTests
         var expected = CreateBasePackageSpec(resources);
         AssertSchemaEqual(expected, schema);
     }
-    
+
     class AnyTypesArgs : ResourceArgs
     {
         [Input("inputAny", required: true)]
         public Input<object> InputAny { get; set; } = null!;
-        
+
         [Input("optionalInputAny")]
         public Input<object>? OptionalInputAny { get; set; }
     }
@@ -595,7 +595,7 @@ public class ComponentAnalyzerTests
     {
         [Output("outputAny")]
         public Output<object> OutputAny { get; private set; } = null!;
-        
+
         [Output("optionalOutputAny")]
         public Output<object?> OptionalOutputAny { get; private set; } = null!;
 

--- a/sdk/Pulumi/Provider/ComponentAnalyzer.cs
+++ b/sdk/Pulumi/Provider/ComponentAnalyzer.cs
@@ -405,6 +405,8 @@ namespace Pulumi.Experimental.Provider
                 return "pulumi.json#/Archive";
             if (type == typeof(Asset))
                 return "pulumi.json#/Asset";
+            if (type == typeof(object))
+                return "pulumi.json#/Any";
             return null;
         }
     }


### PR DESCRIPTION
## Summary
- Add support for mapping `object` type properties to `Any` in component schemas
- Add test cases for both required and optional `object` type properties
- This allows component providers to accept arbitrary data structures through `object` type properties

## Test plan
- Added unit tests verifying both required and optional object properties are correctly mapped to the 'Any' type in schemas
- All unit tests passing
