### PR TITLE
Keep the main projects on net6.0

### DIFF
--- a/sdk/Pulumi.Automation/Pulumi.Automation.csproj
+++ b/sdk/Pulumi.Automation/Pulumi.Automation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>
     <Company>Pulumi Corp.</Company>

--- a/sdk/Pulumi.FSharp/Pulumi.FSharp.fsproj
+++ b/sdk/Pulumi.FSharp/Pulumi.FSharp.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>
     <Company>Pulumi Corp.</Company>

--- a/sdk/Pulumi/Pulumi.csproj
+++ b/sdk/Pulumi/Pulumi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>
     <Company>Pulumi Corp.</Company>


### PR DESCRIPTION
_Follow-up to_: https://github.com/pulumi/pulumi-dotnet/pull/500 and https://github.com/pulumi/pulumi/pull/18619

While net6 isn't actually in support anymore, a hard migration to net8 is causing lots of downstream issues. So leave these projects targeting net6 for now, they'll still build fine with net8.
