### PR TITLE
Update `pulumi` submodule to v3.153.0 tag

### DIFF
--- a/pulumi-language-dotnet/language_test.go
+++ b/pulumi-language-dotnet/language_test.go
@@ -232,8 +232,10 @@ func TestLanguage(t *testing.T) {
 		"l2-invoke-options-depends-on":          "dotnet build failed",
 		"l2-invoke-secrets": "" +
 			"Pulumi.Deployment+InvokeException: 'simple-invoke:index:secretInvoke' failed: value is not a string",
-		"l2-map-keys":        "dotnet build failed",
-		"l2-resource-secret": "test hanging",
+		"l2-map-keys":                "dotnet build failed",
+		"l2-resource-secret":         "test hanging",
+		"l1-builtin-project-root":    "#466",
+		"l2-component-property-deps": "https://github.com/pulumi/pulumi/issues/18741: add programgen support for call",
 	}
 
 	for _, tt := range tests.Tests {

--- a/pulumi-language-dotnet/testdata/sdks/any-type-function-15.0.0/Pulumi.AnyTypeFunction.csproj
+++ b/pulumi-language-dotnet/testdata/sdks/any-type-function-15.0.0/Pulumi.AnyTypeFunction.csproj
@@ -11,7 +11,7 @@
     <PackageIcon>logo.png</PackageIcon>
     <Version>15.0.0</Version>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/pulumi-language-dotnet/testdata/sdks/component-13.3.7/Pulumi.Component.csproj
+++ b/pulumi-language-dotnet/testdata/sdks/component-13.3.7/Pulumi.Component.csproj
@@ -11,7 +11,7 @@
     <PackageIcon>logo.png</PackageIcon>
     <Version>13.3.7</Version>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
Update `pulumi` submodule to the v3.153.0 tag. This brings in two new conformance tests.

- `l1-builtin-project-root` support is being added in #466 
- `l2-component-property-deps` is blocked on .NET programgen support for `Call` (and #488)

Somewhat suspicious that a couple generated SDKs changed (I ran the conformance tests with `PULUMI_ACCEPT=true`). Are we not snapshot comparing those?