### PR TITLE
Handle logging arguments in provider's getEngineAddress

### DIFF
--- a/.changes/unreleased/bug-fixes-536.yaml
+++ b/.changes/unreleased/bug-fixes-536.yaml
@@ -1,0 +1,6 @@
+component: sdk/provider
+kind: bug-fixes
+body: Handle logging arguments in provider's getEngineAddress
+time: 2025-03-10T11:10:52.170215+01:00
+custom:
+    PR: "536"

--- a/sdk/Pulumi.Tests/Provider/ProviderTests.cs
+++ b/sdk/Pulumi.Tests/Provider/ProviderTests.cs
@@ -93,9 +93,9 @@ namespace Pulumi.Tests.Provider
         {
             // Helper method to access the private static method for testing
             var method = typeof(Pulumi.Experimental.Provider.Provider).GetMethod(
-                "GetEngineAddress", 
+                "GetEngineAddress",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-            
+
             try
             {
                 return (string?)method?.Invoke(null, new object[] { args });
@@ -119,7 +119,7 @@ namespace Pulumi.Tests.Provider
         [Fact]
         public void GetEngineAddress_WithLoggingArgs_ReturnsAddress()
         {
-            var args = new[] { 
+            var args = new[] {
                 "--logtostderr",
                 "-v=3",
                 "127.0.0.1:51776",

--- a/sdk/Pulumi.Tests/Provider/ProviderTests.cs
+++ b/sdk/Pulumi.Tests/Provider/ProviderTests.cs
@@ -152,7 +152,7 @@ namespace Pulumi.Tests.Provider
         [Fact]
         public void GetEngineAddress_WithOnlyLoggingArgs_ReturnsNull()
         {
-            var args = new[] { "--logtostderr", "-v=3", "--logflow" };
+            var args = new[] { "--logtostderr", "-v10", "--logflow" };
             var address = GetEngineAddress(args);
             Assert.Null(address);
         }

--- a/sdk/Pulumi.Tests/Provider/ProviderTests.cs
+++ b/sdk/Pulumi.Tests/Provider/ProviderTests.cs
@@ -95,7 +95,17 @@ namespace Pulumi.Tests.Provider
             var method = typeof(Pulumi.Experimental.Provider.Provider).GetMethod(
                 "GetEngineAddress", 
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-            return (string?)method?.Invoke(null, new object[] { args });
+            
+            try
+            {
+                return (string?)method?.Invoke(null, new object[] { args });
+            }
+            catch (System.Reflection.TargetInvocationException ex)
+            {
+                if (ex.InnerException != null)
+                    throw ex.InnerException;
+                throw;
+            }
         }
 
         [Fact]
@@ -132,19 +142,19 @@ namespace Pulumi.Tests.Provider
         }
 
         [Fact]
-        public void GetEngineAddress_WithNoArgs_ThrowsException()
+        public void GetEngineAddress_WithNoArgs_ReturnsNull()
         {
             var args = Array.Empty<string>();
-            var ex = Assert.Throws<ArgumentException>(() => GetEngineAddress(args));
-            Assert.Equal("No engine address provided in arguments", ex.Message);
+            var address = GetEngineAddress(args);
+            Assert.Null(address);
         }
 
         [Fact]
-        public void GetEngineAddress_WithOnlyLoggingArgs_ThrowsException()
+        public void GetEngineAddress_WithOnlyLoggingArgs_ReturnsNull()
         {
             var args = new[] { "--logtostderr", "-v=3", "--logflow" };
-            var ex = Assert.Throws<ArgumentException>(() => GetEngineAddress(args));
-            Assert.Equal("No engine address provided in arguments", ex.Message);
+            var address = GetEngineAddress(args);
+            Assert.Null(address);
         }
 
         [Fact]
@@ -156,7 +166,7 @@ namespace Pulumi.Tests.Provider
             };
             var ex = Assert.Throws<ArgumentException>(() => GetEngineAddress(args));
             Assert.Equal(
-                "Expected exactly one engine address argument, but got 2 non-logging arguments",
+                "Expected at most one engine address argument, but got 2 non-logging arguments",
                 ex.Message);
         }
     }

--- a/sdk/Pulumi.Tests/Provider/ProviderTests.cs
+++ b/sdk/Pulumi.Tests/Provider/ProviderTests.cs
@@ -86,4 +86,78 @@ namespace Pulumi.Tests.Provider
             Assert.Contains("GetSchema", exc.Message);
         }
     }
+
+    public class ProviderEngineAddressTests
+    {
+        private static string? GetEngineAddress(string[] args)
+        {
+            // Helper method to access the private static method for testing
+            var method = typeof(Pulumi.Experimental.Provider.Provider).GetMethod(
+                "GetEngineAddress", 
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            return (string?)method?.Invoke(null, new object[] { args });
+        }
+
+        [Fact]
+        public void GetEngineAddress_WithValidAddress_ReturnsAddress()
+        {
+            var args = new[] { "127.0.0.1:51776" };
+            var address = GetEngineAddress(args);
+            Assert.Equal("127.0.0.1:51776", address);
+        }
+
+        [Fact]
+        public void GetEngineAddress_WithLoggingArgs_ReturnsAddress()
+        {
+            var args = new[] { 
+                "--logtostderr",
+                "-v=3",
+                "127.0.0.1:51776",
+                "--logflow"
+            };
+            var address = GetEngineAddress(args);
+            Assert.Equal("127.0.0.1:51776", address);
+        }
+
+        [Fact]
+        public void GetEngineAddress_WithTracingArg_ReturnsAddress()
+        {
+            var args = new[] {
+                "--tracing",
+                "1",
+                "127.0.0.1:51776"
+            };
+            var address = GetEngineAddress(args);
+            Assert.Equal("127.0.0.1:51776", address);
+        }
+
+        [Fact]
+        public void GetEngineAddress_WithNoArgs_ThrowsException()
+        {
+            var args = Array.Empty<string>();
+            var ex = Assert.Throws<ArgumentException>(() => GetEngineAddress(args));
+            Assert.Equal("No engine address provided in arguments", ex.Message);
+        }
+
+        [Fact]
+        public void GetEngineAddress_WithOnlyLoggingArgs_ThrowsException()
+        {
+            var args = new[] { "--logtostderr", "-v=3", "--logflow" };
+            var ex = Assert.Throws<ArgumentException>(() => GetEngineAddress(args));
+            Assert.Equal("No engine address provided in arguments", ex.Message);
+        }
+
+        [Fact]
+        public void GetEngineAddress_WithMultipleAddresses_ThrowsException()
+        {
+            var args = new[] {
+                "127.0.0.1:51776",
+                "127.0.0.1:51777"
+            };
+            var ex = Assert.Throws<ArgumentException>(() => GetEngineAddress(args));
+            Assert.Equal(
+                "Expected exactly one engine address argument, but got 2 non-logging arguments",
+                ex.Message);
+        }
+    }
 }

--- a/sdk/Pulumi/Provider/Provider.cs
+++ b/sdk/Pulumi/Provider/Provider.cs
@@ -542,6 +542,8 @@ namespace Pulumi.Experimental.Provider
             // maxRpcMessageSize raises the gRPC Max message size from `4194304` (4mb) to `419430400` (400mb)
             var maxRpcMessageSize = 400 * 1024 * 1024;
 
+            var engineAddress = GetEngineAddress(args);
+
             return Host.CreateDefaultBuilder()
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
@@ -560,10 +562,7 @@ namespace Pulumi.Experimental.Provider
                             config.Sources.Clear();
 
                             var memConfig = new Dictionary<string, string?>();
-                            if (args.Length > 0)
-                            {
-                                memConfig.Add("Host", args[0]);
-                            }
+                            memConfig.Add("Host", engineAddress);
                             if (version != null)
                             {
                                 memConfig.Add("Version", version);
@@ -599,6 +598,41 @@ namespace Pulumi.Experimental.Provider
                     configuration?.Invoke(webBuilder);
                 })
                 .Build();
+        }
+
+        private static string? GetEngineAddress(string[] args)
+        {
+            var cleanArgs = new List<string>();
+            
+            for (int i = 0; i < args.Length; i++)
+            {
+                var arg = args[i];
+                
+                // Skip logging-related arguments
+                if (arg == "--logtostderr") continue;
+                if (arg.StartsWith("-v=")) continue;
+                if (arg == "--logflow") continue;
+                if (arg == "--tracing")
+                {
+                    i++; // Skip the tracing value
+                    continue;
+                }
+                
+                cleanArgs.Add(arg);
+            }
+
+            if (cleanArgs.Count == 0)
+            {
+                throw new ArgumentException("No engine address provided in arguments");
+            }
+            
+            if (cleanArgs.Count > 1)
+            {
+                throw new ArgumentException(
+                    $"Expected exactly one engine address argument, but got {cleanArgs.Count} non-logging arguments");
+            }
+
+            return cleanArgs[0];
         }
     }
 

--- a/sdk/Pulumi/Provider/Provider.cs
+++ b/sdk/Pulumi/Provider/Provider.cs
@@ -562,7 +562,10 @@ namespace Pulumi.Experimental.Provider
                             config.Sources.Clear();
 
                             var memConfig = new Dictionary<string, string?>();
-                            memConfig.Add("Host", engineAddress);
+                            if (engineAddress != null)
+                            {
+                                memConfig.Add("Host", engineAddress);
+                            }
                             if (version != null)
                             {
                                 memConfig.Add("Version", version);
@@ -623,13 +626,13 @@ namespace Pulumi.Experimental.Provider
 
             if (cleanArgs.Count == 0)
             {
-                throw new ArgumentException("No engine address provided in arguments");
+                return null;
             }
             
             if (cleanArgs.Count > 1)
             {
                 throw new ArgumentException(
-                    $"Expected exactly one engine address argument, but got {cleanArgs.Count} non-logging arguments");
+                    $"Expected at most one engine address argument, but got {cleanArgs.Count} non-logging arguments");
             }
 
             return cleanArgs[0];

--- a/sdk/Pulumi/Provider/Provider.cs
+++ b/sdk/Pulumi/Provider/Provider.cs
@@ -613,7 +613,7 @@ namespace Pulumi.Experimental.Provider
 
                 // Skip logging-related arguments
                 if (arg == "--logtostderr") continue;
-                if (arg.StartsWith("-v=")) continue;
+                if (arg.StartsWith("-v")) continue;
                 if (arg == "--logflow") continue;
                 if (arg == "--tracing")
                 {

--- a/sdk/Pulumi/Provider/Provider.cs
+++ b/sdk/Pulumi/Provider/Provider.cs
@@ -606,11 +606,11 @@ namespace Pulumi.Experimental.Provider
         private static string? GetEngineAddress(string[] args)
         {
             var cleanArgs = new List<string>();
-            
+
             for (int i = 0; i < args.Length; i++)
             {
                 var arg = args[i];
-                
+
                 // Skip logging-related arguments
                 if (arg == "--logtostderr") continue;
                 if (arg.StartsWith("-v=")) continue;
@@ -620,7 +620,7 @@ namespace Pulumi.Experimental.Provider
                     i++; // Skip the tracing value
                     continue;
                 }
-                
+
                 cleanArgs.Add(arg);
             }
 
@@ -628,7 +628,7 @@ namespace Pulumi.Experimental.Provider
             {
                 return null;
             }
-            
+
             if (cleanArgs.Count > 1)
             {
                 throw new ArgumentException(


### PR DESCRIPTION
Passing a --logflow argument to the CLI will make it pass all its arguments to providers. This PR ports this [Node.js implementation](https://github.com/pulumi/pulumi/blob/05970ff66567eeed7723d7b6ee2c37d3b464f580/sdk/nodejs/provider/internals.ts#L30-L53) and [Java implementation](https://github.com/pulumi/pulumi-java/pull/1708) that discards known logging parameters from engine address calculation.

~This change now requires an address while previously it was optional. I believe this is a correct change, again in line with other SDKs, but let me know if there are legit cases when address is not passed.~