### PR TITLE
Make Input.ToOutput non-nullable

### DIFF
--- a/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
+++ b/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
@@ -68,6 +68,7 @@ public class PropertyValueTests
             Pair("password", new PropertyValue(new PropertyValue("PW"))));
 
         var basicArgs = await serializer.Deserialize<SecretArgs>(data);
+        Assert.NotNull(basicArgs.Password);
         var passwordOutput = await basicArgs.Password.ToOutput().DataTask;
         Assert.True(passwordOutput.IsSecret);
         Assert.True(passwordOutput.IsKnown);

--- a/sdk/Pulumi/Core/Input.cs
+++ b/sdk/Pulumi/Core/Input.cs
@@ -42,8 +42,9 @@ namespace Pulumi
         public static implicit operator Output<T>(Input<T> input)
             => input._outputValue;
 
-        IOutput IInput.ToOutput()
-            => this.ToOutput();
+        IOutput IInput.ToOutput() => (Output<T>)this;
+
+        public Output<T> ToOutput() => this;
     }
 
     public static class InputExtensions
@@ -51,29 +52,26 @@ namespace Pulumi
         /// <summary>
         /// <see cref="Output{T}.Apply{U}(Func{T, Output{U}?})"/> for more details.
         /// </summary>
-        public static Output<U> Apply<T, U>(this Input<T>? input, Func<T, U> func)
+        public static Output<U> Apply<T, U>(this Input<T> input, Func<T, U> func)
             => input.ToOutput().Apply(func);
 
         /// <summary>
         /// <see cref="Output{T}.Apply{U}(Func{T, Output{U}?})"/> for more details.
         /// </summary>
-        public static Output<U> Apply<T, U>(this Input<T>? input, Func<T, Task<U>> func)
+        public static Output<U> Apply<T, U>(this Input<T> input, Func<T, Task<U>> func)
             => input.ToOutput().Apply(func);
 
         /// <summary>
         /// <see cref="Output{T}.Apply{U}(Func{T, Output{U}?})"/> for more details.
         /// </summary>
-        public static Output<U> Apply<T, U>(this Input<T>? input, Func<T, Input<U>?> func)
+        public static Output<U> Apply<T, U>(this Input<T> input, Func<T, Input<U>?> func)
             => input.ToOutput().Apply(func);
 
         /// <summary>
         /// <see cref="Output{T}.Apply{U}(Func{T, Output{U}?})"/> for more details.
         /// </summary>
-        public static Output<U> Apply<T, U>(this Input<T>? input, Func<T, Output<U>?> func)
+        public static Output<U> Apply<T, U>(this Input<T> input, Func<T, Output<U>?> func)
             => input.ToOutput().Apply(func);
-
-        public static Output<T> ToOutput<T>(this Input<T>? input)
-            => input ?? Output.Create(default(T)!);
     }
 
     public static class InputListExtensions


### PR DESCRIPTION
The extension method to turn an input to an output had a very misleading nullability annotation:
```
        public static Output<T> ToOutput<T>(this Input<T>? input)
            => input ?? Output.Create(default(T)!);
```

This then propagated to other methods like the `Apply` extension methods, and JSON converters.

I've moved this extension method to an instance method on `Input<T>` and removed the nullability from it (well there's no way to make an instance method nullable).

This is a breaking change but I've had multiple users complain to me about this method. I think there's further work that could be done on improving the nullability annotations around outputs.