### PR TITLE
Add --show-reads Support to .NET PreviewOptions and UpOptions

### DIFF
--- a/sdk/Pulumi.Automation/PreviewOptions.cs
+++ b/sdk/Pulumi.Automation/PreviewOptions.cs
@@ -35,5 +35,10 @@ namespace Pulumi.Automation
         /// Refresh the state of the stack's resources before this preview.
         /// </summary>
         public bool? Refresh { get; set; }
+
+        /// <summary>
+        /// Show read logs in the preview.
+        /// </summary>
+        public bool? ShowReads { get; set; }
     }
 }

--- a/sdk/Pulumi.Automation/UpOptions.cs
+++ b/sdk/Pulumi.Automation/UpOptions.cs
@@ -45,5 +45,10 @@ namespace Pulumi.Automation
         /// Refresh the state of the stack's resources before this update.
         /// </summary>
         public bool? Refresh { get; set; }
+
+        /// <summary>
+        /// Show read logs in the preview.
+        /// </summary>
+        public bool? ShowReads { get; set; }
     }
 }

--- a/sdk/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/Pulumi.Automation/WorkspaceStack.cs
@@ -332,6 +332,12 @@ namespace Pulumi.Automation
                 if (options.ExpectNoChanges is true)
                     args.Add("--expect-no-changes");
 
+                if (options.ShowReads.HasValue)
+                {
+                    args.Add("--show-reads");
+                    args.Add(options.ShowReads.Value ? "true" : "false");
+                }
+
                 if (options.Diff is true)
                     args.Add("--diff");
 
@@ -446,6 +452,12 @@ namespace Pulumi.Automation
 
                 if (options.ExpectNoChanges is true)
                     args.Add("--expect-no-changes");
+
+                if (options.ShowReads.HasValue)
+                {
+                    args.Add("--show-reads");
+                    args.Add(options.ShowReads.Value ? "true" : "false");
+                }
 
                 if (options.Diff is true)
                     args.Add("--diff");


### PR DESCRIPTION
## Overview

This PR adds support for the `--show-reads` flag in Pulumi CLI to the .NET SDK by introducing a new `bool? ShowReads` property in both `PreviewOptions` and `UpOptions`.

## Changes

- Added `ShowReads` property to `PreviewOptions` and `UpOptions`.
- Passed `ShowReads` as a nullable boolean to the `pulumi preview` and `pulumi up` CLI commands.

## Related Issue

Closes #541