### PR TITLE
Add the `--preview-only` option for `destroy` in the .NET API

### DIFF
--- a/.changes/unreleased/Improvements-554.yaml
+++ b/.changes/unreleased/Improvements-554.yaml
@@ -1,0 +1,6 @@
+component: sdk/auto
+kind: Improvements
+body: Add the `--preview-only` flag to the `destroy` command in the Automation API
+time: 2025-03-26T15:10:14.335982Z
+custom:
+    PR: "554"

--- a/sdk/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -739,12 +739,12 @@ namespace Pulumi.Automation.Tests
         [Fact]
         public async Task PreviewDestroy()
         {
-            var program = PulumiFn.Create(() => {});
+            var program = PulumiFn.Create(() => { });
             Assert.IsType<PulumiFnInline>(program);
 
             var stackName = $"{RandomStackName()}";
             var projectName = "inline_node";
-            using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program) {});
+            using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program) { });
 
             try
             {
@@ -756,8 +756,9 @@ namespace Pulumi.Automation.Tests
 
                 // pulumi destroy
                 var destroyResult = await stack.DestroyAsync(new DestroyOptions
-                    { PreviewOnly = true
-                    });
+                {
+                    PreviewOnly = true
+                });
                 Assert.Equal(UpdateKind.Update, destroyResult.Summary.Kind);
                 Assert.Equal(UpdateState.Succeeded, destroyResult.Summary.Result);
             }

--- a/sdk/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -755,7 +755,9 @@ namespace Pulumi.Automation.Tests
                 Assert.Equal(UpdateState.Succeeded, upResult.Summary.Result);
 
                 // pulumi destroy
-                var destroyResult = await stack.DestroyAsync(DestroyOptions{ PreviewOnly = true });
+                var destroyResult = await stack.DestroyAsync(new DestroyOptions
+                    { PreviewOnly = true
+                    });
                 Assert.Equal(UpdateKind.Update, destroyResult.Summary.Kind);
                 Assert.Equal(UpdateState.Succeeded, destroyResult.Summary.Result);
             }

--- a/sdk/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -743,7 +743,7 @@ namespace Pulumi.Automation.Tests
             Assert.IsType<PulumiFnInline>(program);
 
             var stackName = $"{RandomStackName()}";
-            var projectName = "inline_node";
+            var projectName = "inline_dotnet";
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program) { });
 
             try

--- a/sdk/Pulumi.Automation/DestroyOptions.cs
+++ b/sdk/Pulumi.Automation/DestroyOptions.cs
@@ -15,6 +15,11 @@ namespace Pulumi.Automation
         public bool? ShowSecrets { get; set; }
 
         /// <summary>
+        /// Only show a preview of the destroy, but don't perform the destroy itself.
+        /// </summary>
+        public bool? PreviewOnly { get; set; }
+
+        /// <summary>
         /// Continue to perform the destroy operation despite the occurrence of errors.
         /// </summary>
         public bool? ContinueOnError { get; set; }

--- a/sdk/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/Pulumi.Automation/Pulumi.Automation.xml
@@ -65,6 +65,11 @@
             Show config secrets when they appear.
             </summary>
         </member>
+        <member name="P:Pulumi.Automation.DestroyOptions.PreviewOnly">
+            <summary>
+            Only show a preview of the destroy, but don't perform the destroy itself.
+            </summary>
+        </member>
         <member name="P:Pulumi.Automation.DestroyOptions.ContinueOnError">
             <summary>
             Continue to perform the destroy operation despite the occurrence of errors.

--- a/sdk/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/Pulumi.Automation/WorkspaceStack.cs
@@ -630,9 +630,9 @@ namespace Pulumi.Automation
             var args = new List<string> { "destroy" };
 
             if (options != null && options.PreviewOnly is true) {
-              args.Add("--preview-only")
+              args.Add("--preview-only");
             } else {
-              args.Add("--yes", "--skip-preview")
+              args.Add("--yes", "--skip-preview");
             }
 
             args.AddRange(GetRemoteArgs());

--- a/sdk/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/Pulumi.Automation/WorkspaceStack.cs
@@ -629,11 +629,14 @@ namespace Pulumi.Automation
         {
             var args = new List<string> { "destroy" };
 
-            if (options != null && options.PreviewOnly is true) {
-              args.Add("--preview-only");
-            } else {
-              args.Add("--yes");
-              args.Add("--skip-preview");
+            if (options != null && options.PreviewOnly is true)
+            {
+                args.Add("--preview-only");
+            }
+            else
+            {
+                args.Add("--yes");
+                args.Add("--skip-preview");
             }
 
             args.AddRange(GetRemoteArgs());

--- a/sdk/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/Pulumi.Automation/WorkspaceStack.cs
@@ -627,12 +627,13 @@ namespace Pulumi.Automation
             DestroyOptions? options = null,
             CancellationToken cancellationToken = default)
         {
-            var args = new List<string>
-            {
-                "destroy",
-                "--yes",
-                "--skip-preview",
-            };
+            var args = new List<string> { "destroy" };
+
+            if (options != null && options.PreviewOnly is true) {
+              args.Add("--preview-only")
+            } else {
+              args.Add("--yes", "--skip-preview")
+            }
 
             args.AddRange(GetRemoteArgs());
 

--- a/sdk/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/Pulumi.Automation/WorkspaceStack.cs
@@ -632,7 +632,8 @@ namespace Pulumi.Automation
             if (options != null && options.PreviewOnly is true) {
               args.Add("--preview-only");
             } else {
-              args.Add("--yes", "--skip-preview");
+              args.Add("--yes");
+              args.Add("--skip-preview");
             }
 
             args.AddRange(GetRemoteArgs());


### PR DESCRIPTION
Part of https://github.com/pulumi/pulumi/issues/18725. This PR adds the ability to run destroy --preview-only via the .NET automation API.