### PR TITLE
Infer namespaces in dotnet

### DIFF
--- a/.changes/unreleased/Improvements-555.yaml
+++ b/.changes/unreleased/Improvements-555.yaml
@@ -1,0 +1,6 @@
+component: sdk/provider
+kind: Improvements
+body: Infer package name and namespace in ComponentProviderHost
+time: 2025-03-26T23:35:49.26489+01:00
+custom:
+    PR: "555"

--- a/sdk/Pulumi.Tests/Provider/ComponentAnalyzerTests.cs
+++ b/sdk/Pulumi.Tests/Provider/ComponentAnalyzerTests.cs
@@ -928,7 +928,7 @@ public class ComponentAnalyzerTests
         Assert.Equal(name, schema.Name);
     }
 
-    private readonly Metadata _metadata = new Metadata("my-component", "0.0.1", "Test package");
+    private readonly Metadata _metadata = new Metadata("my-component", "my-package", "0.0.1", "Test package");
 
     private static PackageSpec CreateBasePackageSpec(
         Dictionary<string, ResourceSpec>? resources = null,
@@ -937,6 +937,7 @@ public class ComponentAnalyzerTests
         var pkg = new PackageSpec
         {
             Name = "my-component",
+            Namespace = "my-package",
             Version = "0.0.1",
             DisplayName = "Test package"
         };

--- a/sdk/Pulumi.Tests/Provider/ComponentProviderHostTests.cs
+++ b/sdk/Pulumi.Tests/Provider/ComponentProviderHostTests.cs
@@ -1,0 +1,41 @@
+using Xunit;
+using Pulumi.Experimental.Provider;
+
+namespace Pulumi.Tests.Provider
+{
+    public class ComponentProviderHostTests
+    {
+
+        [Fact]
+        public void ParseAssemblyName_NullInput_ReturnsNullValues()
+        {
+            var (namespaceName, packageName) = ComponentProviderHost.ParseAssemblyName(null);
+            Assert.Null(namespaceName);
+            Assert.Null(packageName);
+        }
+
+        [Fact]
+        public void ParseAssemblyName_SinglePart_ReturnsNullNamespaceAndKebabCasePackage()
+        {
+            var (namespaceName, packageName) = ComponentProviderHost.ParseAssemblyName("MyPackage");
+            Assert.Null(namespaceName);
+            Assert.Equal("my-package", packageName);
+        }
+
+        [Fact]
+        public void ParseAssemblyName_MultiPart_ReturnsKebabCaseNamespaceAndPackage()
+        {
+            var (namespaceName, packageName) = ComponentProviderHost.ParseAssemblyName("MyNamespace.MyPackage");
+            Assert.Equal("my-namespace", namespaceName);
+            Assert.Equal("my-package", packageName);
+        }
+
+        [Fact]
+        public void ParseAssemblyName_ComplexName_HandlesMultipleParts()
+        {
+            var (namespaceName, packageName) = ComponentProviderHost.ParseAssemblyName("MyCompany.MyProduct.MyPackage");
+            Assert.Equal("my-company", namespaceName);
+            Assert.Equal("my-package", packageName);
+        }
+    }
+}

--- a/sdk/Pulumi.Tests/Provider/ComponentProviderTests.cs
+++ b/sdk/Pulumi.Tests/Provider/ComponentProviderTests.cs
@@ -16,7 +16,7 @@ namespace Pulumi.Tests.Provider
         public ComponentProviderTests()
         {
             var assembly = typeof(TestComponent).Assembly;
-            _provider = new ComponentProvider(assembly, "test-package", new[] { typeof(TestComponent) });
+            _provider = new ComponentProvider(assembly, "test-package", null, new[] { typeof(TestComponent) });
         }
 
         [Fact]

--- a/sdk/Pulumi.Tests/Provider/ComponentProviderTests.cs
+++ b/sdk/Pulumi.Tests/Provider/ComponentProviderTests.cs
@@ -16,7 +16,8 @@ namespace Pulumi.Tests.Provider
         public ComponentProviderTests()
         {
             var assembly = typeof(TestComponent).Assembly;
-            _provider = new ComponentProvider(assembly, "test-package", null, new[] { typeof(TestComponent) });
+            var metadata = new Metadata(Name: "test-package");
+            _provider = new ComponentProvider(assembly, metadata, new[] { typeof(TestComponent) });
         }
 
         [Fact]

--- a/sdk/Pulumi/Provider/ComponentAnalyzer.cs
+++ b/sdk/Pulumi/Provider/ComponentAnalyzer.cs
@@ -53,6 +53,13 @@ namespace Pulumi.Experimental.Provider
                     nameof(metadata));
             }
 
+            if (metadata.Namespace != null && !Regex.IsMatch(metadata.Namespace, "^[a-z][-a-z0-9]*$"))
+            {
+                throw new ArgumentException(
+                    "Namespace must start with a letter and contain only lowercase letters, numbers and hyphens",
+                    nameof(metadata));
+            }
+
             if (componentTypes.Length == 0)
             {
                 throw new ArgumentException("At least one component type must be provided");
@@ -128,6 +135,7 @@ namespace Pulumi.Experimental.Provider
             {
                 Name = metadata.Name,
                 Version = metadata.Version ?? "",
+                Namespace = metadata.Namespace ?? "",
                 DisplayName = metadata.DisplayName ?? metadata.Name,
                 Language = languages.ToImmutableSortedDictionary(),
                 Resources = resources.ToImmutableSortedDictionary(),
@@ -414,12 +422,14 @@ namespace Pulumi.Experimental.Provider
     public class Metadata
     {
         public string Name { get; }
+        public string? Namespace { get; }
         public string? Version { get; }
         public string? DisplayName { get; }
 
-        public Metadata(string name, string? version = null, string? displayName = null)
+        public Metadata(string name, string? ns = null, string? version = null, string? displayName = null)
         {
             Name = name;
+            Namespace = ns;
             Version = version;
             DisplayName = displayName;
         }

--- a/sdk/Pulumi/Provider/ComponentAnalyzer.cs
+++ b/sdk/Pulumi/Provider/ComponentAnalyzer.cs
@@ -419,19 +419,5 @@ namespace Pulumi.Experimental.Provider
         }
     }
 
-    public class Metadata
-    {
-        public string Name { get; }
-        public string? Namespace { get; }
-        public string? Version { get; }
-        public string? DisplayName { get; }
-
-        public Metadata(string name, string? ns = null, string? version = null, string? displayName = null)
-        {
-            Name = name;
-            Namespace = ns;
-            Version = version;
-            DisplayName = displayName;
-        }
-    }
+    public record Metadata(string Name, string? Namespace = null, string? Version = null, string? DisplayName = null);
 }

--- a/sdk/Pulumi/Provider/ComponentProvider.cs
+++ b/sdk/Pulumi/Provider/ComponentProvider.cs
@@ -18,6 +18,7 @@ namespace Pulumi.Experimental.Provider
     {
         private readonly Assembly componentAssembly;
         private readonly string packageName;
+        private readonly string ns;
         private readonly Type[]? componentTypes;
 #pragma warning disable CS0618 // Type or member is obsolete
         private readonly PropertyValueSerializer serializer;
@@ -28,11 +29,13 @@ namespace Pulumi.Experimental.Provider
         /// </summary>
         /// <param name="componentAssembly">The assembly containing component types</param>
         /// <param name="packageName">Optional package name (defaults to assembly name)</param>
+        /// <param name="ns">Optional namespace (defaults to assembly namespace)</param>
         /// <param name="componentTypes">Optional array of known component types</param>
-        public ComponentProvider(Assembly componentAssembly, string? packageName = null, Type[]? componentTypes = null)
+        public ComponentProvider(Assembly componentAssembly, string? packageName = null, string? ns = null, Type[]? componentTypes = null)
         {
             this.componentAssembly = componentAssembly;
             this.packageName = packageName ?? this.componentAssembly.GetName().Name!.ToLower();
+            this.ns = this.componentAssembly.GetTypes().First().Namespace!.ToLower();
             this.componentTypes = componentTypes;
 #pragma warning disable CS0618 // Type or member is obsolete
             this.serializer = new PropertyValueSerializer();
@@ -47,7 +50,7 @@ namespace Pulumi.Experimental.Provider
         /// <returns>The schema for the components in the assembly</returns>
         public override Task<GetSchemaResponse> GetSchema(GetSchemaRequest request, CancellationToken ct)
         {
-            var metadata = new Metadata(packageName);
+            var metadata = new Metadata(packageName, ns);
             var schema = componentTypes != null
                 ? ComponentAnalyzer.GenerateSchema(metadata, componentTypes)
                 : ComponentAnalyzer.GenerateSchema(metadata, componentAssembly);

--- a/sdk/Pulumi/Provider/ComponentProviderHost.cs
+++ b/sdk/Pulumi/Provider/ComponentProviderHost.cs
@@ -1,13 +1,8 @@
 using System;
-using System.Collections.Immutable;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-using Pulumi.Utilities;
+using Humanizer;
 
 namespace Pulumi.Experimental.Provider
 {
@@ -26,7 +21,29 @@ namespace Pulumi.Experimental.Provider
         public static Task Serve(string[] args, Assembly? componentAssembly = null, string? packageName = null)
         {
             var assembly = componentAssembly ?? Assembly.GetCallingAssembly();
-            return Provider.Serve(args, null, host => new ComponentProvider(assembly, packageName), CancellationToken.None);
+            (var parsedNamespace, var parsedPackage) = ParseAssemblyName(assembly.GetName().Name);
+            packageName = packageName ?? parsedPackage ?? throw new ArgumentNullException(nameof(packageName));
+            var metadata = new Metadata(Name: packageName, Namespace: parsedNamespace);
+            return Provider.Serve(args, null, host => new ComponentProvider(assembly, metadata), CancellationToken.None);
+        }
+
+        internal static (string? namespaceName, string? packageName) ParseAssemblyName(string? assemblyName)
+        {
+            if (assemblyName == null)
+            {
+                return (null, null);
+            }
+
+            var parts = assemblyName.Split('.');
+            if (parts.Length < 2)
+            {
+                return (null, assemblyName.Kebaberize());
+            }
+
+            var package = parts[^1]; // Take last part
+            var ns = parts[0]; // Take first part
+
+            return (ns.Kebaberize(), package.Kebaberize());
         }
     }
 }

--- a/sdk/Pulumi/Provider/Schema.cs
+++ b/sdk/Pulumi/Provider/Schema.cs
@@ -11,6 +11,9 @@ namespace Pulumi.Experimental.Provider
         [JsonPropertyName("name")]
         public string Name { get; init; } = "";
 
+        [JsonPropertyName("namespace")]
+        public string Namespace { get; init; } = "";
+
         [JsonPropertyName("displayName")]
         public string DisplayName { get; init; } = "";
 

--- a/sdk/Pulumi/Pulumi.csproj
+++ b/sdk/Pulumi/Pulumi.csproj
@@ -37,6 +37,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="2.9.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -201,12 +201,13 @@
             A provider that can be used to construct components from a given assembly with automatic schema inference.
             </summary>
         </member>
-        <member name="M:Pulumi.Experimental.Provider.ComponentProvider.#ctor(System.Reflection.Assembly,System.String,System.Type[])">
+        <member name="M:Pulumi.Experimental.Provider.ComponentProvider.#ctor(System.Reflection.Assembly,System.String,System.String,System.Type[])">
             <summary>
             Creates a new component provider.
             </summary>
             <param name="componentAssembly">The assembly containing component types</param>
             <param name="packageName">Optional package name (defaults to assembly name)</param>
+            <param name="ns">Optional namespace (defaults to assembly namespace)</param>
             <param name="componentTypes">Optional array of known component types</param>
         </member>
         <member name="M:Pulumi.Experimental.Provider.ComponentProvider.GetSchema(Pulumi.Experimental.Provider.GetSchemaRequest,System.Threading.CancellationToken)">

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -201,13 +201,12 @@
             A provider that can be used to construct components from a given assembly with automatic schema inference.
             </summary>
         </member>
-        <member name="M:Pulumi.Experimental.Provider.ComponentProvider.#ctor(System.Reflection.Assembly,System.String,System.String,System.Type[])">
+        <member name="M:Pulumi.Experimental.Provider.ComponentProvider.#ctor(System.Reflection.Assembly,Pulumi.Experimental.Provider.Metadata,System.Type[])">
             <summary>
             Creates a new component provider.
             </summary>
             <param name="componentAssembly">The assembly containing component types</param>
-            <param name="packageName">Optional package name (defaults to assembly name)</param>
-            <param name="ns">Optional namespace (defaults to assembly namespace)</param>
+            <param name="metadata">The metadata for the package</param>
             <param name="componentTypes">Optional array of known component types</param>
         </member>
         <member name="M:Pulumi.Experimental.Provider.ComponentProvider.GetSchema(Pulumi.Experimental.Provider.GetSchemaRequest,System.Threading.CancellationToken)">


### PR DESCRIPTION
Key changes around the ComponentProviderHost:

- Introduces a new property `Namespace` to package metadata
- For assembly name `Foo.Bar.Buzz` or `Foo.Buzz` calculated package name as `buzz` and namespace as `foo`, for assembly name `Buzz` leaves namespace empty
- Namespace and package names are kebab-cased with Humanizer
- Changes the ComponentProvider constructor to accept the entire `metadata` record, which is built in the host
- ComponentProviderHost is the still "simple mode" entry point with sensible defaults, users can eject to ComponentProvider pretty easily