### PR TITLE
Default the component provider version to 0.0.0

### DIFF
--- a/.changes/unreleased/Improvements-556.yaml
+++ b/.changes/unreleased/Improvements-556.yaml
@@ -1,0 +1,6 @@
+component: sdk/provider
+kind: Improvements
+body: Default the version of ComponentProviderHost to 0.0.0
+time: 2025-03-27T10:31:22.779157+01:00
+custom:
+    PR: "556"

--- a/sdk/Pulumi/Provider/ComponentProviderHost.cs
+++ b/sdk/Pulumi/Provider/ComponentProviderHost.cs
@@ -23,8 +23,10 @@ namespace Pulumi.Experimental.Provider
             var assembly = componentAssembly ?? Assembly.GetCallingAssembly();
             (var parsedNamespace, var parsedPackage) = ParseAssemblyName(assembly.GetName().Name);
             packageName = packageName ?? parsedPackage ?? throw new ArgumentNullException(nameof(packageName));
-            var metadata = new Metadata(Name: packageName, Namespace: parsedNamespace);
-            return Provider.Serve(args, null, host => new ComponentProvider(assembly, metadata), CancellationToken.None);
+            // Default the version to "0.0.0" for now, otherwise SDK codegen gets confused without a version.
+            var version = "0.0.0";
+            var metadata = new Metadata(Name: packageName, Namespace: parsedNamespace, Version: version);
+            return Provider.Serve(args, version, host => new ComponentProvider(assembly, metadata), CancellationToken.None);
         }
 
         internal static (string? namespaceName, string? packageName) ParseAssemblyName(string? assemblyName)


### PR DESCRIPTION
Default the component provider schema version to "0.0.0" if not provided for now, otherwise SDK codegen gets confused without a version.