### PR TITLE
Specify StringComparison for correctness

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,4 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
+dotnet_diagnostic.CA1310.severity = error

--- a/sdk/Pulumi/Provider/ComponentAnalyzer.cs
+++ b/sdk/Pulumi/Provider/ComponentAnalyzer.cs
@@ -370,7 +370,7 @@ namespace Pulumi.Experimental.Provider
                 }
             }
 
-            if (!type.IsInterface && !type.IsPrimitive && type != typeof(string) && !(type.Namespace?.StartsWith("System") ?? false))
+            if (!type.IsInterface && !type.IsPrimitive && type != typeof(string) && !(type.Namespace?.StartsWith("System", StringComparison.Ordinal) ?? false))
             {
                 var typeName = GetTypeName(type);
                 var typeRef = $"#/types/{metadata.Name}:index:{typeName}";
@@ -391,7 +391,7 @@ namespace Pulumi.Experimental.Provider
         private string GetTypeName(Type type)
         {
             var name = type.Name;
-            return name.EndsWith("Args") ? name[..^4] : name;
+            return name.EndsWith("Args", StringComparison.Ordinal) ? name[..^4] : name;
         }
 
         private string? GetBuiltinTypeName(Type type)

--- a/sdk/Pulumi/Provider/Provider.cs
+++ b/sdk/Pulumi/Provider/Provider.cs
@@ -613,7 +613,7 @@ namespace Pulumi.Experimental.Provider
 
                 // Skip logging-related arguments
                 if (arg == "--logtostderr") continue;
-                if (arg.StartsWith("-v")) continue;
+                if (arg.StartsWith("-v", StringComparison.Ordinal)) continue;
                 if (arg == "--logflow") continue;
                 if (arg == "--tracing")
                 {


### PR DESCRIPTION
This change specifies a StringComparison in calls to `StartsWith` and `EndsWith`, and enables the [analyzer rule](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1310) to enforce it going forward.

Note: We should enable a more aggressive set of analysis rules beyond the default set (likely via `<AnalysisMode>Recommended</AnalysisMode>` in the .csproj files), but that requires more fixes, so just enabling this specific rule for now.