### PR TITLE
Capture async context for engine callback methods

### DIFF
--- a/.changes/unreleased/Bug Fixes-561.yaml
+++ b/.changes/unreleased/Bug Fixes-561.yaml
@@ -1,0 +1,7 @@
+component: sdk
+kind: Bug Fixes
+body: Async context is now captured from the main program and restored in transform
+  functions
+time: 2025-03-28T21:44:55.124212431Z
+custom:
+  PR: "561"

--- a/integration_tests/transformations_remote/Program.cs
+++ b/integration_tests/transformations_remote/Program.cs
@@ -162,6 +162,9 @@ class TransformsStack : Stack
     // Scenario #3 - apply a transformation to the Stack to transform all (future) resources in the stack
     private static async Task<ResourceTransformResult?> Scenario3(ResourceTransformArgs args, CancellationToken ct)
     {
+        // Log each transform that happens to check that we have full access to the Deployment here
+        Pulumi.Log.Debug($"Transforming {args.Type} with stack transform");
+
         if (args.Type == "testprovider:index:Random")
         {
             var resultArgs = args.Args;

--- a/sdk/Pulumi/Deployment/Callbacks.cs
+++ b/sdk/Pulumi/Deployment/Callbacks.cs
@@ -71,12 +71,16 @@ namespace Pulumi
             {
                 // When we invoke callbacks we want to invoke them in the async context that originally constructed the Callback system.
                 Task<IMessage>? task = null;
-                if (_executionContext is not null) {
-                    ExecutionContext.Run(_executionContext, (_) => {
+                if (_executionContext is not null)
+                {
+                    ExecutionContext.Run(_executionContext, (_) =>
+                    {
                         task = callback(request.Request, context.CancellationToken);
                     }, null);
                     Debug.Assert(task != null, "task != null");
-                } else {
+                }
+                else
+                {
                     task = callback(request.Request, context.CancellationToken);
                 }
                 var result = await task.ConfigureAwait(false);

--- a/sdk/Pulumi/Deployment/Deployment.cs
+++ b/sdk/Pulumi/Deployment/Deployment.cs
@@ -183,8 +183,10 @@ namespace Pulumi
                 return _callbacks;
             }
 
-            // Atomically allocate a callbacks instance to use
-            var callbacks = new CallbacksHost();
+            // Atomically allocate a callbacks instance to use, capture the current async context and pass it
+            // to the callbacks host. Importantly this captures the current Deployment.Instance, so basic
+            // things like engine logging work in transforms.
+            var callbacks = new CallbacksHost(System.Threading.ExecutionContext.Capture());
             var current = Interlocked.CompareExchange(ref _callbacks, callbacks, null);
             if (current == null)
             {

--- a/sdk/Pulumi/Deployment/Deployment.cs
+++ b/sdk/Pulumi/Deployment/Deployment.cs
@@ -186,7 +186,7 @@ namespace Pulumi
             // Atomically allocate a callbacks instance to use, capture the current async context and pass it
             // to the callbacks host. Importantly this captures the current Deployment.Instance, so basic
             // things like engine logging work in transforms.
-            var callbacks = new CallbacksHost(System.Threading.ExecutionContext.Capture());
+            var callbacks = new CallbacksHost(ExecutionContext.Capture());
             var current = Interlocked.CompareExchange(ref _callbacks, callbacks, null);
             if (current == null)
             {


### PR DESCRIPTION
The `Callback` system is what allows the engine to callback to the language runtime to invoke generic code. Currently just used for the transforms system, but soon to be extended for other uses as well.

We were incorrectly not propagating the async context from where the callback system was created (somewhere inside the users program as part of resource registration call) to the threads that the callbacks run on (in the kestral server threadpool).

This meant that inside a transform function you couldn't access any of the async context that you had access to just outside the transform function. Importantly this includes the deployment instance that allows access to the engine.

We probably wouldn't recommend registering more resources from the transform function (although, you _could_) but users definitely should have access to the engine logging system from inside the transform function.

This PR adds the requisite ExecutionContext capture and run calls to copy and restore the async context from the main program to the threads running the callback functions.