### PR TITLE
Change PropertyValue.TryUnwrap to Unwrap

### DIFF
--- a/.changes/unreleased/Improvements-562.yaml
+++ b/.changes/unreleased/Improvements-562.yaml
@@ -1,0 +1,6 @@
+component: sdk/provider
+kind: Improvements
+body: Replaced `PropertyValue.TryUnwrap` with `Unwrap`
+time: 2025-03-31T14:22:07.096797+01:00
+custom:
+    PR: "562"

--- a/sdk/Pulumi/Provider/PropertyValue.cs
+++ b/sdk/Pulumi/Provider/PropertyValue.cs
@@ -196,26 +196,23 @@ namespace Pulumi.Experimental.Provider
         }
 
         // Unwraps any outer secret or output values.
-        public bool TryUnwrap([NotNullWhen(true)] out PropertyValue? value)
+        public PropertyValue Unwrap()
         {
             if (SecretValue != null)
             {
-                value = null;
-                return SecretValue.TryUnwrap(out value);
+                return SecretValue.Unwrap();
             }
             else if (OutputValue.HasValue)
             {
                 var inner = OutputValue.Value.Value;
-                // Might be null
+                // Might be null which means this is unknown, translate that Computed
                 if (inner == null)
                 {
-                    value = null;
-                    return false;
+                    return Computed;
                 }
-                return inner.TryUnwrap(out value);
+                return inner.Unwrap();
             }
-            value = this;
-            return true;
+            return this;
         }
 
         public bool IsNull


### PR DESCRIPTION
Noticed this while working on the python SDK. Rather than having this function return a partial result we can _always_ return a `PropertyValue` by just translating `OutputReferences` that have a null value to `Computed` values (which is what the null inner value really means).