### PR TITLE
Don't always return a parameterised schema

### DIFF
--- a/integration_tests/testprovider/TestProvider.cs
+++ b/integration_tests/testprovider/TestProvider.cs
@@ -50,6 +50,9 @@ public class TestProvider : Provider
 {
     ""name"": ""NAME"",
     ""version"": ""1.0.0"",
+    ""meta"": {
+        ""supportPack"": true
+    },
     ""resources"": {
         ""NAME:index:Echo"": {
             ""description"": ""A test resource that echoes its input."",
@@ -81,7 +84,10 @@ public class TestProvider : Provider
     }
 ";
 
-
+        if (parameter == "testprovider")
+        {
+            parameterization = "";
+        }
 
         // Very hacky schema build just to test out that parameterization calls are made
         parameterization = parameterization.Replace("UTFBYTES", Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(parameter)));


### PR DESCRIPTION
When we changed the test provider to test parameterised schemas we accidentally made it always parameterised. This changes it so that it won't always have a "parameterisation" block, and adds the necessary "supportPack" flag to keep existing tests working with local sdks.