### PR TITLE
Fix deserialisation of InputMaps with nested output values

### DIFF
--- a/.changes/unreleased/Bug Fixes-570.yaml
+++ b/.changes/unreleased/Bug Fixes-570.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Bug Fixes
+body: Fix deserialising InputMap<T> with unknown values
+time: 2025-04-08T15:27:15.996764278+01:00
+custom:
+  PR: "570"

--- a/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
+++ b/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
@@ -843,4 +843,33 @@ public class PropertyValueTests
         var stringValueOutput = await nestedValueOutput.Value.StringOutput.DataTask;
         Assert.Equal("hello", stringValueOutput.Value);
     }
+
+    public class TagsType : ResourceArgs
+    {
+        [Input("tags", required: false)] private InputMap<string>? _tags;
+
+        public InputMap<string> Tags
+        {
+            get => _tags ??= [];
+            set => _tags = value;
+        }
+    }
+
+    [Fact]
+    public async Task DeserializingUnknownOutputInputMapWorks()
+    {
+        var serializer = CreateSerializer();
+
+        var resource = new DependencyResource("urn:pulumi::stack::proj::type::name");
+        var unknownWithDeps = OutputUtilities.WithDependency(OutputUtilities.CreateUnknown(""), resource);
+        var serialized = await serializer.Serialize(unknownWithDeps);
+
+        var value = Object(Pair("tags", Object(Pair("staticString", new PropertyValue("string")),
+            Pair("staticString2", serialized))));
+
+        var result = await serializer.Deserialize<TagsType>(value);
+
+        var tags = await result.Tags.ToOutput().DataTask;
+        Assert.False(tags.IsKnown, "tags should be unknown");
+    }
 }

--- a/sdk/Pulumi/Provider/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Provider/PropertyValueSerializer.cs
@@ -476,7 +476,7 @@ namespace Pulumi.Experimental.Provider
                 var inputDictionaryType = typeof(Input<>).MakeGenericType(dictionaryType);
                 var inputDictionary = DeserializeValue(value, inputDictionaryType, path);
 
-                var ctor = targetType.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, new Type[]{inputDictionaryType});
+                var ctor = targetType.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, new Type[] { inputDictionaryType });
                 if (ctor == null)
                 {
                     throw new InvalidOperationException(


### PR DESCRIPTION
Error was raised to me on community slack.

This fixes deserializing into an `InputMap<T>` when one of the values is an unknown or computed value. Before this fix it would error that, for example, `string` was expected not `Output<T>`.