### PR TITLE
remove the mention of sync-proto-files from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,6 @@ make build
 # Testing the language plugin
 dotnet run test-language-plugin
 
-# Sync proto files from pulumi/pulumi
-dotnet run sync-proto-files
-
 # List all integration tests
 dotnet run list-integration-tests
 


### PR DESCRIPTION
This has been removed in 9b585c8fe0f42f86f07075449e5227260c14af10, remove it from the README as well to avoid confusion.