### PR TITLE
feat(automation): add config-file option to operation options

### DIFF
--- a/.changes/unreleased/Improvements-573.yaml
+++ b/.changes/unreleased/Improvements-573.yaml
@@ -1,0 +1,6 @@
+component: sdk/auto
+kind: Improvements
+body: Adds the `ConfigFile` option to all operation options in the Automation API (UpOptions, PreviewOptions, RefreshOptions, DestroyOptions) to support specifyin
+time: 2025-04-15T13:27:42.162596701-05:00
+custom:
+    PR: "573"

--- a/sdk/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/Pulumi.Automation/Pulumi.Automation.xml
@@ -1503,6 +1503,11 @@
             Format standard output as JSON not text.
             </summary>
         </member>
+        <member name="P:Pulumi.Automation.UpdateOptions.ConfigFile">
+            <summary>
+            Path to a YAML file containing stack configuration values.
+            </summary>
+        </member>
         <member name="T:Pulumi.Automation.UpOptions">
             <summary>
             Options controlling the behavior of an <see cref="M:Pulumi.Automation.WorkspaceStack.UpAsync(Pulumi.Automation.UpOptions,System.Threading.CancellationToken)"/> operation.

--- a/sdk/Pulumi.Automation/UpdateOptions.cs
+++ b/sdk/Pulumi.Automation/UpdateOptions.cs
@@ -71,5 +71,10 @@ namespace Pulumi.Automation
         /// Format standard output as JSON not text.
         /// </summary>
         public bool? Json { get; set; }
+
+        /// <summary>
+        /// Path to a YAML file containing stack configuration values.
+        /// </summary>
+        public string? ConfigFile { get; set; }
     }
 }

--- a/sdk/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/Pulumi.Automation/WorkspaceStack.cs
@@ -1079,6 +1079,12 @@ namespace Pulumi.Automation
             {
                 args.Add("--json");
             }
+
+            if (!string.IsNullOrWhiteSpace(options.ConfigFile))
+            {
+                args.Add("--config-file");
+                args.Add(options.ConfigFile);
+            }
         }
 
         private bool Remote


### PR DESCRIPTION
  Add ConfigFile property to UpdateOptions class, which is inherited by all
  operation options (UpOptions, PreviewOptions, RefreshOptions, DestroyOptions).
  This enables specifying a YAML file containing stack configuration values
  when performing operations through the .NET Automation API.
This will fix part of https://github.com/pulumi/pulumi/issues/17773