### PR TITLE
Changelog for 3.79 release

### DIFF
--- a/.changes/unreleased/Bug Fixes-570.yaml
+++ b/.changes/unreleased/Bug Fixes-570.yaml
@@ -1,6 +1,0 @@
-component: sdk
-kind: Bug Fixes
-body: Fix deserialising InputMap<T> with unknown values
-time: 2025-04-08T15:27:15.996764278+01:00
-custom:
-  PR: "570"

--- a/.changes/unreleased/Improvements-573.yaml
+++ b/.changes/unreleased/Improvements-573.yaml
@@ -1,6 +1,0 @@
-component: sdk/auto
-kind: Improvements
-body: Adds the `ConfigFile` option to all operation options in the Automation API (UpOptions, PreviewOptions, RefreshOptions, DestroyOptions) to support specifyin
-time: 2025-04-15T13:27:42.162596701-05:00
-custom:
-    PR: "573"

--- a/.changes/v3.79.0.md
+++ b/.changes/v3.79.0.md
@@ -1,0 +1,10 @@
+## v3.79.0 - 2025-04-24
+
+### Bug Fixes
+
+- [sdk] Fix deserialising InputMap<T> with unknown values [#570](https://github.com/pulumi/pulumi-dotnet/pull/570)
+
+### Improvements
+
+- [sdk/auto] Adds the `ConfigFile` option to all operation options in the Automation API (UpOptions, PreviewOptions, RefreshOptions, DestroyOptions) to support specifyin [#573](https://github.com/pulumi/pulumi-dotnet/pull/573)
+

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,6 +67,19 @@ jobs:
         # in the pull request.
         run: make lint GOLANGCI_LINT_ARGS=--out-format=colored-line-number
 
+  lint-changelog:
+    name: Lint Changelog
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint changelog
+        run: |
+          # Check the changelog is batchable
+          if [ ! -z $(ls .changes/unreleased) ]; then
+              # There are changes so check changie will batch them
+              changie batch auto --dry-run
+          fi
+
   build:
     needs: setup_matrix
     strategy:


### PR DESCRIPTION
Also adding a lint step to check changelog entries added are valid. The `.changes/unreleased/Bug Fixes-570.yaml` file had "Bug Fixes" instead of "bug-fixes" for it's kind that I had to fix before `changie batch auto` would run.