### PR TITLE
Add `--exclude` and `--exclude-dependents` to the Automation API

### DIFF
--- a/.changes/unreleased/Improvements-582.yaml
+++ b/.changes/unreleased/Improvements-582.yaml
@@ -1,0 +1,6 @@
+component: sdk/auto
+kind: Improvements
+body: Add `--exclude` and `--exclude-dependents` to the Automation API
+time: 2025-04-29T15:01:57.144867+02:00
+custom:
+    PR: "582"

--- a/sdk/Pulumi.Automation/DestroyOptions.cs
+++ b/sdk/Pulumi.Automation/DestroyOptions.cs
@@ -7,6 +7,8 @@ namespace Pulumi.Automation
     /// </summary>
     public sealed class DestroyOptions : UpdateOptions
     {
+        public bool? ExcludeDependents { get; set; }
+
         public bool? TargetDependents { get; set; }
 
         /// <summary>

--- a/sdk/Pulumi.Automation/PreviewOptions.cs
+++ b/sdk/Pulumi.Automation/PreviewOptions.cs
@@ -16,6 +16,8 @@ namespace Pulumi.Automation
 
         public List<string>? Replace { get; set; }
 
+        public bool? ExcludeDependents { get; set; }
+
         public bool? TargetDependents { get; set; }
 
         public PulumiFn? Program { get; set; }

--- a/sdk/Pulumi.Automation/UpOptions.cs
+++ b/sdk/Pulumi.Automation/UpOptions.cs
@@ -16,6 +16,8 @@ namespace Pulumi.Automation
 
         public List<string>? Replace { get; set; }
 
+        public bool? ExcludeDependents { get; set; }
+
         public bool? TargetDependents { get; set; }
 
         public PulumiFn? Program { get; set; }

--- a/sdk/Pulumi.Automation/UpdateOptions.cs
+++ b/sdk/Pulumi.Automation/UpdateOptions.cs
@@ -18,6 +18,8 @@ namespace Pulumi.Automation
 
         public List<string>? Target { get; set; }
 
+        public List<string>? Exclude { get; set; }
+
         public List<string>? PolicyPacks { get; set; }
 
         public List<string>? PolicyPackConfigs { get; set; }

--- a/sdk/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/Pulumi.Automation/WorkspaceStack.cs
@@ -359,6 +359,9 @@ namespace Pulumi.Automation
                     }
                 }
 
+                if (options.ExcludeDependents is true)
+                    args.Add("--exclude-dependents");
+
                 if (options.TargetDependents is true)
                     args.Add("--target-dependents");
 
@@ -479,6 +482,9 @@ namespace Pulumi.Automation
                         args.Add(item);
                     }
                 }
+
+                if (options.ExcludeDependents is true)
+                    args.Add("--exclude-dependents");
 
                 if (options.TargetDependents is true)
                     args.Add("--target-dependents");
@@ -658,6 +664,9 @@ namespace Pulumi.Automation
 
             if (options != null)
             {
+                if (options.ExcludeDependents is true)
+                    args.Add("--exclude-dependents");
+
                 if (options.TargetDependents is true)
                     args.Add("--target-dependents");
 
@@ -1037,6 +1046,15 @@ namespace Pulumi.Automation
             {
                 args.Add("--message");
                 args.Add(options.Message);
+            }
+
+            if (options.Exclude?.Any() == true)
+            {
+                foreach (var item in options.Exclude)
+                {
+                    args.Add("--exclude");
+                    args.Add(item);
+                }
             }
 
             if (options.Target?.Any() == true)


### PR DESCRIPTION
The final PR in this saga. This PR adds the `--exclude` and `--exclude-dependents` to the Automation API.

* https://github.com/pulumi/pulumi-java/pull/1781
* https://github.com/pulumi/pulumi/pull/19333
* https://github.com/pulumi/pulumi/pull/19310
* https://github.com/pulumi/pulumi/pull/19270