### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -4,6 +4,7 @@ permissions:
   # To create the follow-up PR.
   contents: write
   pull-requests: write
+  id-token: write
 
 on:
   release:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,17 +1,22 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: Build and test
 
 on:
-  merge_group:
-  pull_request:
+  merge_group: null
+  pull_request: null
   push:
     branches:
       - main
 
 env:
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN_PRODUCTION }}
   AWS_REGION: us-west-2
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PULUMI_TEST_OWNER: "moolumi"
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: PULUMI_ACCESS_TOKEN=PULUMI_ACCESS_TOKEN_PRODUCTION
 
 jobs:
   setup_matrix:
@@ -19,6 +24,9 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - id: set-matrix
         run: |
           os="${{ contains(github.event.pull_request.labels.*.name, 'ci/test') && 'ubuntu-latest macos-latest windows-latest' || 'ubuntu-latest' }}"
@@ -27,6 +35,9 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -45,17 +56,14 @@ jobs:
     name: Lint Go
     runs-on: ubuntu-22.04
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@v4
       - name: Set up Go 1.24.x
         uses: actions/setup-go@v5
         with:
           go-version: 1.24.x
-
-      # We leverage the golangci-lint action to install
-      # and maintain the cache,
-      # but we want to run the command ourselves.
-      # The action doesn't have an install-only mode,
-      # so we'll ask it to print its help output instead.
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
@@ -71,6 +79,9 @@ jobs:
     name: Lint Changelog
     runs-on: ubuntu-22.04
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@v4
       - name: Check if folder is empty
         id: folder_check
@@ -96,6 +107,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -140,7 +154,7 @@ jobs:
           files: "*"
           fail_ci_if_error: false
           verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
   integration-tests:
     strategy:
       fail-fast: false
@@ -149,6 +163,9 @@ jobs:
         dotnet-version: [8.0.x, 9.0.x]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Set TARGET_FRAMEWORK
         shell: bash
         run: |
@@ -228,6 +245,9 @@ jobs:
         dotnet-version: [8.0.x]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Set TARGET_FRAMEWORK
         shell: bash
         run: |
@@ -280,6 +300,9 @@ jobs:
     outputs:
       version: "${{ steps.version.outputs.version }}"
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Get the latest version
@@ -318,6 +341,9 @@ jobs:
     runs-on: ubuntu-latest
     if: always() # always report a status
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Build failed
         if: ${{ needs.build.result != 'success' }}
         run: exit 1

--- a/.github/workflows/release-dotnet-provider.yml
+++ b/.github/workflows/release-dotnet-provider.yml
@@ -1,15 +1,23 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 on:
   push:
-    branches: [ main ]
-    paths: [ CHANGELOG.md ]
+    branches: [main]
+    paths: [CHANGELOG.md]
 
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 
 jobs:
   release-pulumi-language-dotnet:
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@v4
       - name: Fetch Tags
         run: |

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -4,6 +4,7 @@ permissions:
   # To create a PR
   contents: write
   pull-requests: write
+  id-token: write
 
 on:
   workflow_call:
@@ -28,16 +29,22 @@ on:
 env:
   PULUMI_VERSION: ${{ inputs.version }}
   GITHUB_REF: ${{ inputs.ref }}
-  NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN_PRODUCTION }}
   AWS_REGION: us-west-2
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: NUGET_PUBLISH_KEY,PULUMI_ACCESS_TOKEN=PULUMI_ACCESS_TOKEN_PRODUCTION
 
 jobs:
   publish-dotnet-sdk:
     name: Publish dotnet SDK
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
