### PR TITLE
Fix invalid module path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ DEV_VERSION := $(shell if command -v changie > /dev/null; then changie next patc
 
 install::
 	cd pulumi-language-dotnet && ${GO} install \
-		-ldflags "-X github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/version.Version=$(DEV_VERSION)" ./...
+		-ldflags "-X github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3/version.Version=$(DEV_VERSION)" ./...
 
 build::
 	cd pulumi-language-dotnet && ${GO} build \
-		-ldflags "-X github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/version.Version=$(DEV_VERSION)" .
+		-ldflags "-X github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3/version.Version=$(DEV_VERSION)" .
 
 changelog::
 	changie new

--- a/build/Program.fs
+++ b/build/Program.fs
@@ -147,7 +147,7 @@ let buildLanguagePlugin() =
     cleanLanguagePlugin()
     let devVersion = getDevVersion()
     printfn $"Building pulumi-language-dotnet Plugin {devVersion}"
-    let ldflags = $"-ldflags \"-X github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/version.Version={devVersion}\""
+    let ldflags = $"-ldflags \"-X github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3/version.Version={devVersion}\""
     if Shell.Exec("go", $"build {ldflags}", pulumiLanguageDotnet) <> 0
     then failwith "Building pulumi-language-dotnet failed"
     let output = Path.Combine(pulumiLanguageDotnet, "pulumi-language-dotnet")

--- a/pulumi-language-dotnet/go.mod
+++ b/pulumi-language-dotnet/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet
+module github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3
 
 go 1.24
 

--- a/pulumi-language-dotnet/main.go
+++ b/pulumi-language-dotnet/main.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
-	"github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/version"
+	"github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3/version"
 	dotnetcodegen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"


### PR DESCRIPTION
We currently tag this module with v3.x so its path should include `/v3.

https://go.dev/ref/mod#major-version-suffixes

> Starting with major version 2, module paths must have a major version suffix like /v2 that matches the major version. For example, if a module has the path example.com/mod at v1.0.0, it must have the path example.com/mod/v2 at version v2.0.0.

