### PR TITLE
Expose `--remote-executor-image` in the Automation API

### DIFF
--- a/.changes/unreleased/Improvements-587.yaml
+++ b/.changes/unreleased/Improvements-587.yaml
@@ -1,6 +1,6 @@
 component: sdk/auto
 kind: Improvements
-body: Expose `--remote-executor-*` flags in the Automation API.
+body: Expose `--remote-executor-*` flags in the Automation API
 time: 2025-05-06T15:07:46.076901+02:00
 custom:
     PR: "587"

--- a/.changes/unreleased/Improvements-587.yaml
+++ b/.changes/unreleased/Improvements-587.yaml
@@ -1,0 +1,6 @@
+component: sdk/auto
+kind: Improvements
+body: Expose `--remote-executor-*` flags in the Automation API.
+time: 2025-05-06T15:07:46.076901+02:00
+custom:
+    PR: "587"

--- a/sdk/Pulumi.Automation/DockerImageCredentials.cs
+++ b/sdk/Pulumi.Automation/DockerImageCredentials.cs
@@ -1,0 +1,20 @@
+// Copyright 2016-2022, Pulumi Corporation
+
+namespace Pulumi.Automation
+{
+    /// <summary>
+    /// Credentials for the remote execution Docker image.
+    /// </summary>
+    public class DockerImageCredentials
+    {
+        /// <summary>
+        /// The username for the image.
+        /// </summary>
+        public string Username { get; set; }
+
+        /// <summary>
+        /// The password for the image.
+        /// </summary>
+        public string Password { get; set; }
+    }
+}

--- a/sdk/Pulumi.Automation/DockerImageCredentials.cs
+++ b/sdk/Pulumi.Automation/DockerImageCredentials.cs
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation
+// Copyright 2016-2025, Pulumi Corporation
 
 namespace Pulumi.Automation
 {

--- a/sdk/Pulumi.Automation/DockerImageCredentials.cs
+++ b/sdk/Pulumi.Automation/DockerImageCredentials.cs
@@ -16,5 +16,11 @@ namespace Pulumi.Automation
         /// The password for the image.
         /// </summary>
         public string Password { get; set; }
+
+        public DockerImageCredentials(string username, string password)
+        {
+            this.Username = username;
+            this.Password = password;
+        }
     }
 }

--- a/sdk/Pulumi.Automation/ExecutorImage.cs
+++ b/sdk/Pulumi.Automation/ExecutorImage.cs
@@ -1,0 +1,20 @@
+// Copyright 2016-2022, Pulumi Corporation
+
+namespace Pulumi.Automation
+{
+    /// <summary>
+    /// Information about the remote execution image.
+    /// </summary>
+    public class ExecutorImage
+    {
+        /// <summary>
+        /// The Docker image to use.
+        /// </summary>
+        public string Image { get; set; }
+
+        /// <summary>
+        /// Credentials for the remote execution Docker image.
+        /// </summary>
+        public DockerImageCredentials? DockerImageCredentials { get; set; }
+    }
+}

--- a/sdk/Pulumi.Automation/ExecutorImage.cs
+++ b/sdk/Pulumi.Automation/ExecutorImage.cs
@@ -7,6 +7,11 @@ namespace Pulumi.Automation
     /// </summary>
     public class ExecutorImage
     {
+        public ExecutorImage(string image)
+        {
+            this.Image = image;
+        }
+
         /// <summary>
         /// The Docker image to use.
         /// </summary>
@@ -15,6 +20,6 @@ namespace Pulumi.Automation
         /// <summary>
         /// Credentials for the remote execution Docker image.
         /// </summary>
-        public DockerImageCredentials? DockerImageCredentials { get; set; }
+        public DockerImageCredentials? Credentials { get; set; }
     }
 }

--- a/sdk/Pulumi.Automation/ExecutorImage.cs
+++ b/sdk/Pulumi.Automation/ExecutorImage.cs
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation
+// Copyright 2016-2025, Pulumi Corporation
 
 namespace Pulumi.Automation
 {

--- a/sdk/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/Pulumi.Automation/LocalWorkspace.cs
@@ -39,6 +39,7 @@ namespace Pulumi.Automation
         private readonly IDictionary<string, EnvironmentVariableValue>? _remoteEnvironmentVariables;
         private readonly IList<string>? _remotePreRunCommands;
         private readonly bool _remoteSkipInstallDependencies;
+        private readonly ExecutorImage? _remoteExecutorImage;
 
         internal Task ReadyTask { get; }
 
@@ -334,6 +335,7 @@ namespace Pulumi.Automation
                 this.Remote = options.Remote;
                 this._remoteGitProgramArgs = options.RemoteGitProgramArgs;
                 this._remoteSkipInstallDependencies = options.RemoteSkipInstallDependencies;
+                this._remoteExecutorImage = options.RemoteExecutorImage;
 
                 if (options.EnvironmentVariables != null)
                     this.EnvironmentVariables = new Dictionary<string, string?>(options.EnvironmentVariables);
@@ -1002,6 +1004,21 @@ namespace Pulumi.Automation
             if (_remoteSkipInstallDependencies)
             {
                 args.Add("--remote-skip-install-dependencies");
+            }
+
+            if (_remoteExecutorImage)
+            {
+                args.Add("--remote-executor-image");
+                args.Add(_remoteExecutorImage.image);
+
+                if (_remoteExecutorImage.credentials)
+                {
+                    args.Add("--remote-executor-image-username")
+                    args.Add(_remoteExecutorImage.credentials.username)
+
+                    args.Add("--remote-executor-image-password")
+                    args.Add(_remoteExecutorImage.credentials.password)
+                }
             }
 
             return args;

--- a/sdk/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/Pulumi.Automation/LocalWorkspace.cs
@@ -1006,18 +1006,18 @@ namespace Pulumi.Automation
                 args.Add("--remote-skip-install-dependencies");
             }
 
-            if (_remoteExecutorImage)
+            if (_remoteExecutorImage != null)
             {
                 args.Add("--remote-executor-image");
-                args.Add(_remoteExecutorImage.image);
+                args.Add(_remoteExecutorImage.Image);
 
-                if (_remoteExecutorImage.credentials)
+                if (_remoteExecutorImage.Credentials != null)
                 {
                     args.Add("--remote-executor-image-username");
-                    args.Add(_remoteExecutorImage.credentials.username);
+                    args.Add(_remoteExecutorImage.Credentials.Username);
 
                     args.Add("--remote-executor-image-password");
-                    args.Add(_remoteExecutorImage.credentials.password);
+                    args.Add(_remoteExecutorImage.Credentials.Password);
                 }
             }
 

--- a/sdk/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/Pulumi.Automation/LocalWorkspace.cs
@@ -1013,11 +1013,11 @@ namespace Pulumi.Automation
 
                 if (_remoteExecutorImage.credentials)
                 {
-                    args.Add("--remote-executor-image-username")
-                    args.Add(_remoteExecutorImage.credentials.username)
+                    args.Add("--remote-executor-image-username");
+                    args.Add(_remoteExecutorImage.credentials.username);
 
-                    args.Add("--remote-executor-image-password")
-                    args.Add(_remoteExecutorImage.credentials.password)
+                    args.Add("--remote-executor-image-password");
+                    args.Add(_remoteExecutorImage.credentials.password);
                 }
             }
 

--- a/sdk/Pulumi.Automation/LocalWorkspaceOptions.cs
+++ b/sdk/Pulumi.Automation/LocalWorkspaceOptions.cs
@@ -92,6 +92,11 @@ namespace Pulumi.Automation
         internal IList<string>? RemotePreRunCommands { get; set; }
 
         /// <summary>
+        /// Optional information about a remote execution image.
+        /// </summary>
+        internal ExecutorImage? RemoteExecutorImage { get; set; }
+
+        /// <summary>
         /// Whether to skip the default dependency installation step.
         /// </summary>
         internal bool RemoteSkipInstallDependencies { get; set; }

--- a/sdk/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/Pulumi.Automation/Pulumi.Automation.xml
@@ -85,6 +85,21 @@
             Runs the program in the workspace to perform the destroy.
             </summary>
         </member>
+        <member name="T:Pulumi.Automation.DockerImageCredentials">
+            <summary>
+            Credentials for the remote execution Docker image.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.DockerImageCredentials.Username">
+            <summary>
+            The username for the image.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.DockerImageCredentials.Password">
+            <summary>
+            The password for the image.
+            </summary>
+        </member>
         <member name="T:Pulumi.Automation.Events.CancelEvent">
             <summary>
             <see cref="T:Pulumi.Automation.Events.CancelEvent"/> is emitted when the user initiates a cancellation of the update in progress, or
@@ -374,6 +389,21 @@
              settings file found on disk.
             
              </summary>
+        </member>
+        <member name="T:Pulumi.Automation.ExecutorImage">
+            <summary>
+            Information about the remote execution image.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.ExecutorImage.Image">
+            <summary>
+            The Docker image to use.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.ExecutorImage.Credentials">
+            <summary>
+            Credentials for the remote execution Docker image.
+            </summary>
         </member>
         <member name="T:Pulumi.Automation.HistoryOptions">
             <summary>
@@ -889,6 +919,11 @@
             An optional list of arbitrary commands to run before a remote Pulumi operation is invoked.
             </summary>
         </member>
+        <member name="P:Pulumi.Automation.LocalWorkspaceOptions.RemoteExecutorImage">
+            <summary>
+            Optional information about a remote execution image.
+            </summary>
+        </member>
         <member name="P:Pulumi.Automation.LocalWorkspaceOptions.RemoteSkipInstallDependencies">
             <summary>
             Whether to skip the default dependency installation step.
@@ -1322,6 +1357,11 @@
         <member name="P:Pulumi.Automation.RemoteWorkspaceOptions.SkipInstallDependencies">
             <summary>
             Whether to skip the default dependency installation step.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoteWorkspaceOptions.ExecutorImage">
+            <summary>
+            Information about a remote execution image.
             </summary>
         </member>
         <member name="P:Pulumi.Automation.RemoteWorkspaceStack.Name">

--- a/sdk/Pulumi.Automation/RemoteWorkspaceOptions.cs
+++ b/sdk/Pulumi.Automation/RemoteWorkspaceOptions.cs
@@ -34,5 +34,10 @@ namespace Pulumi.Automation
         /// Whether to skip the default dependency installation step.
         /// </summary>
         public bool SkipInstallDependencies { get; set; }
+
+        /// <summary>
+        /// Information about a remote execution image.
+        /// </summary>
+        public ExecutorImage? ExecutorImage { get; set; }
     }
 }


### PR DESCRIPTION
Forgot about this one, as it wasn't listed on the ticket. This PR makes the `--remote-executor-image` flags accessible in the `dotnet` Automation API.

* https://github.com/pulumi/pulumi/pull/19286
* https://github.com/pulumi/pulumi/pull/15697
* https://github.com/pulumi/pulumi/pull/19304

Fixes https://github.com/pulumi/pulumi/issues/15693.