### PR TITLE
Update PropertyValue to match the new Go and Python SDKs

### DIFF
--- a/.changes/unreleased/Improvements-591.yaml
+++ b/.changes/unreleased/Improvements-591.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Update PropertyValue to track secretness and dependencies directly on PropertyValue
+time: 2025-05-08T20:57:40.898523836+01:00
+custom:
+  PR: "591"

--- a/integration_tests/utils/ComponentResourceProviderBase.cs
+++ b/integration_tests/utils/ComponentResourceProviderBase.cs
@@ -31,7 +31,7 @@ public class ComponentResourceProviderBase : Provider
 
         var serializedResult = await serializer.Serialize(result);
 
-        if (!serializedResult.TryGetObject(out var resultObject))
+        if (!serializedResult.TryGetMap(out var resultObject))
         {
             throw new InvalidOperationException("Expected result to be an object");
         }

--- a/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
+++ b/sdk/Pulumi.Tests/Provider/PropertyValueTests.cs
@@ -67,7 +67,7 @@ public class PropertyValueTests
     {
         var serializer = CreateSerializer();
         var data = Object(
-            Pair("password", new PropertyValue(new PropertyValue("PW"))));
+            Pair("password", new PropertyValue("PW").WithSecret(true)));
 
         var basicArgs = await serializer.Deserialize<SecretArgs>(data);
         var passwordOutput = await basicArgs.Password.ToOutput().DataTask;
@@ -425,7 +425,7 @@ public class PropertyValueTests
     public async Task DeserializingSecretUnknownInputsWorks()
     {
         var serializer = CreateSerializer();
-        var deserialized = await serializer.Deserialize<Input<string>>(new PropertyValue(PropertyValue.Computed));
+        var deserialized = await serializer.Deserialize<Input<string>>(PropertyValue.Computed.WithSecret(true));
         var output = deserialized.ToOutput();
         var data = await output.DataTask;
         Assert.Null(data.Value);
@@ -437,7 +437,7 @@ public class PropertyValueTests
     public async Task DeserializingSecretInputsWorks()
     {
         var serializer = CreateSerializer();
-        var secretValue = new PropertyValue(new PropertyValue("Hello"));
+        var secretValue = new PropertyValue("Hello").WithSecret(true);
         var deserialized = await serializer.Deserialize<Input<string>>(secretValue);
         var output = deserialized.ToOutput();
         var data = await output.DataTask;
@@ -451,9 +451,7 @@ public class PropertyValueTests
     {
         var serializer = CreateSerializer();
         var resources = ImmutableHashSet.Create(new Urn("pulumi:pulumi:Stack"));
-        var output = new PropertyValue(new OutputReference(
-            value: new PropertyValue("Hello"),
-            dependencies: resources));
+        var output = new PropertyValue("Hello").WithDependencies(resources);
 
         var deserialized = await serializer.Deserialize<Input<string>>(output);
         var deserializedOutput = deserialized.ToOutput();
@@ -477,9 +475,8 @@ public class PropertyValueTests
     public async Task DeserializingUnknownOutputWorks()
     {
         var serializer = CreateSerializer();
-        var output = new PropertyValue(new OutputReference(
-            value: PropertyValue.Computed,
-            dependencies: ImmutableHashSet<Urn>.Empty));
+        var resources = ImmutableHashSet.Create(new Urn("pulumi:pulumi:Stack"));
+        var output = PropertyValue.Computed.WithDependencies(resources);
 
         var deserialized = await serializer.Deserialize<Input<string>>(output);
         var deserializedOutput = deserialized.ToOutput();
@@ -493,11 +490,8 @@ public class PropertyValueTests
     public async Task DeserializingWrappedOutputSecretWorks()
     {
         var serializer = CreateSerializer();
-        // secretOutput = Secret(Output("Hello"))
-        var secretOutput = new PropertyValue(
-            new PropertyValue(new OutputReference(
-                value: new PropertyValue("Hello"),
-                dependencies: ImmutableHashSet<Urn>.Empty)));
+        var resources = ImmutableHashSet.Create(new Urn("pulumi:pulumi:Stack"));
+        var secretOutput = new PropertyValue("Hello").WithSecret(true).WithDependencies(resources);
 
         var deserialized = await serializer.Deserialize<Input<string>>(secretOutput);
         var deserializedOutput = deserialized.ToOutput();
@@ -511,10 +505,8 @@ public class PropertyValueTests
     public async Task DeserializingWrappedUnknownOutputSecretWorks()
     {
         var serializer = CreateSerializer();
-        var secretOutput = new PropertyValue(
-            new PropertyValue(new OutputReference(
-                value: PropertyValue.Computed,
-                dependencies: ImmutableHashSet<Urn>.Empty)));
+        var resources = ImmutableHashSet.Create(new Urn("pulumi:pulumi:Stack"));
+        var secretOutput = PropertyValue.Computed.WithSecret(true).WithDependencies(resources);
 
         var deserialized = await serializer.Deserialize<Input<string>>(secretOutput);
         var deserializedOutput = deserialized.ToOutput();
@@ -529,10 +521,8 @@ public class PropertyValueTests
     {
         var serializer = CreateSerializer();
         // secretOutput = Output(Secret("Hello"))
-        var secretOutput = new PropertyValue(
-            new OutputReference(
-                value: new PropertyValue(new PropertyValue("Hello")),
-                dependencies: ImmutableHashSet<Urn>.Empty));
+        var resources = ImmutableHashSet.Create(new Urn("pulumi:pulumi:Stack"));
+        var secretOutput = new PropertyValue("Hello").WithSecret(true).WithDependencies(resources);
 
         var deserialized = await serializer.Deserialize<Input<string>>(secretOutput);
         var deserializedOutput = deserialized.ToOutput();
@@ -547,10 +537,8 @@ public class PropertyValueTests
     public async Task DeserializingWrappedUnknownSecretInOutputWorks()
     {
         var serializer = CreateSerializer();
-        var secretOutput = new PropertyValue(
-            new OutputReference(
-                value: new PropertyValue(PropertyValue.Computed),
-                dependencies: ImmutableHashSet<Urn>.Empty));
+        var resources = ImmutableHashSet.Create(new Urn("pulumi:pulumi:Stack"));
+        var secretOutput = PropertyValue.Computed.WithSecret(true).WithDependencies(resources);
 
         var deserialized = await serializer.Deserialize<Input<string>>(secretOutput);
         var deserializedOutput = deserialized.ToOutput();
@@ -589,15 +577,14 @@ public class PropertyValueTests
 
         var secretUnknown = Output.CreateSecret(OutputUtilities.CreateUnknown(""));
         serialized = await serializer.Serialize(secretUnknown);
-        expected = new PropertyValue(PropertyValue.Computed);
+        expected = PropertyValue.Computed.WithSecret(true);
         Assert.Equal(expected, serialized);
 
         var resource = new DependencyResource("urn:pulumi::stack::proj::type::name");
         var unknownWithDeps = OutputUtilities.WithDependency(OutputUtilities.CreateUnknown(""), resource);
         serialized = await serializer.Serialize(unknownWithDeps);
-        expected = new PropertyValue(new OutputReference(
-            null,
-            ImmutableHashSet.Create(new Urn("urn:pulumi::stack::proj::type::name"))));
+        expected = PropertyValue.Computed.WithDependencies(
+            [new Urn("urn:pulumi::stack::proj::type::name")]);
         Assert.Equal(expected, serialized);
     }
 

--- a/sdk/Pulumi/Provider/PropertyValue.cs
+++ b/sdk/Pulumi/Provider/PropertyValue.cs
@@ -20,7 +20,7 @@ namespace Pulumi.Experimental.Provider
 #pragma warning disable CA1720 // Identifier contains type name
         String,
         Array,
-        Object,
+        Map,
 #pragma warning restore CA1720 // Identifier contains type name
         Asset,
         Archive,
@@ -93,9 +93,9 @@ namespace Pulumi.Experimental.Provider
                 {
                     return PropertyValueType.Array;
                 }
-                else if (ObjectValue != null)
+                else if (MapValue != null)
                 {
-                    return PropertyValueType.Object;
+                    return PropertyValueType.Map;
                 }
                 else if (AssetValue != null)
                 {
@@ -130,7 +130,7 @@ namespace Pulumi.Experimental.Provider
                     NumberValue == null &&
                     StringValue == null &&
                     ArrayValue == null &&
-                    ObjectValue == null &&
+                    MapValue == null &&
                     AssetValue == null &&
                     ArchiveValue == null &&
                     ResourceValue == null &&
@@ -144,7 +144,7 @@ namespace Pulumi.Experimental.Provider
         private readonly double? NumberValue;
         private readonly string? StringValue;
         private readonly ImmutableArray<PropertyValue>? ArrayValue;
-        private readonly ImmutableDictionary<string, PropertyValue>? ObjectValue;
+        private readonly ImmutableDictionary<string, PropertyValue>? MapValue;
         private readonly Asset? AssetValue;
         private readonly Archive? ArchiveValue;
         private readonly ResourceReference? ResourceValue;
@@ -199,10 +199,10 @@ namespace Pulumi.Experimental.Provider
                 }
                 return true;
             }
-            else if (ObjectValue != null && other.ObjectValue != null)
+            else if (MapValue != null && other.MapValue != null)
             {
-                var self = ObjectValue;
-                var them = other.ObjectValue;
+                var self = MapValue;
+                var them = other.MapValue;
                 if (self.Count != them.Count)
                 {
                     return false;
@@ -261,7 +261,7 @@ namespace Pulumi.Experimental.Provider
             if (NumberValue != null) return HashCode.Combine(hash, NumberValue.GetHashCode());
             if (StringValue != null) return HashCode.Combine(hash, StringValue.GetHashCode());
             if (ArrayValue != null) return HashCode.Combine(hash, ArrayValue.GetHashCode());
-            if (ObjectValue != null) return HashCode.Combine(hash, ObjectValue.GetHashCode());
+            if (MapValue != null) return HashCode.Combine(hash, MapValue.GetHashCode());
             if (AssetValue != null) return HashCode.Combine(hash, AssetValue.GetHashCode());
             if (ArchiveValue != null) return HashCode.Combine(hash, ArchiveValue.GetHashCode());
             if (ResourceValue != null) return HashCode.Combine(hash, ResourceValue.GetHashCode());
@@ -275,7 +275,7 @@ namespace Pulumi.Experimental.Provider
             Func<double, T> numberCase,
             Func<string, T> stringCase,
             Func<ImmutableArray<PropertyValue>, T> arrayCase,
-            Func<ImmutableDictionary<string, PropertyValue>, T> objectCase,
+            Func<ImmutableDictionary<string, PropertyValue>, T> mapCase,
             Func<Asset, T> assetCase,
             Func<Archive, T> archiveCase,
             Func<ResourceReference, T> resourceCase,
@@ -285,7 +285,7 @@ namespace Pulumi.Experimental.Provider
             if (NumberValue != null) return numberCase(NumberValue.Value);
             if (StringValue != null) return stringCase(StringValue);
             if (ArrayValue != null) return arrayCase(ArrayValue.Value);
-            if (ObjectValue != null) return objectCase(ObjectValue);
+            if (MapValue != null) return mapCase(MapValue);
             if (AssetValue != null) return assetCase(AssetValue);
             if (ArchiveValue != null) return archiveCase(ArchiveValue);
             if (ResourceValue != null) return resourceCase(ResourceValue.Value);
@@ -337,11 +337,11 @@ namespace Pulumi.Experimental.Provider
             return false;
         }
 
-        public bool TryGetObject([NotNullWhen(true)] out ImmutableDictionary<string, PropertyValue>? value)
+        public bool TryGetMap([NotNullWhen(true)] out ImmutableDictionary<string, PropertyValue>? value)
         {
-            if (ObjectValue != null)
+            if (MapValue != null)
             {
-                value = ObjectValue;
+                value = MapValue;
                 return true;
             }
             value = default;
@@ -444,7 +444,7 @@ namespace Pulumi.Experimental.Provider
         }
         public PropertyValue(ImmutableDictionary<string, PropertyValue> value)
         {
-            ObjectValue = value;
+            MapValue = value;
             IsSecret = false;
             Dependencies = ImmutableHashSet<Urn>.Empty;
         }
@@ -486,7 +486,7 @@ namespace Pulumi.Experimental.Provider
             NumberValue = value.NumberValue;
             StringValue = value.StringValue;
             ArrayValue = value.ArrayValue;
-            ObjectValue = value.ObjectValue;
+            MapValue = value.MapValue;
             AssetValue = value.AssetValue;
             ArchiveValue = value.ArchiveValue;
             ResourceValue = value.ResourceValue;

--- a/sdk/Pulumi/Provider/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Provider/PropertyValueSerializer.cs
@@ -303,7 +303,7 @@ namespace Pulumi.Experimental.Provider
             {
                 var data = await output.GetDataAsync().ConfigureAwait(false);
 
-                PropertyValue? element = null;
+                PropertyValue element = PropertyValue.Computed;
                 if (data.IsKnown)
                 {
                     element = await Serialize(data.Value);
@@ -330,17 +330,10 @@ namespace Pulumi.Experimental.Provider
                 }
                 else
                 {
-                    outputValue = new PropertyValue(new OutputReference(
-                        value: element,
-                        dependencies: dependantResources.ToImmutable()));
+                    outputValue = element.WithDependencies(dependantResources.ToImmutable());
                 }
 
-                if (data.IsSecret)
-                {
-                    return new PropertyValue(outputValue);
-                }
-
-                return outputValue;
+                return outputValue.WithSecret(data.IsSecret);
             }
 
             if (value is IInput input)
@@ -559,17 +552,6 @@ namespace Pulumi.Experimental.Provider
                     return newInputCtor.Invoke(new[] { outputValue });
                 }
 
-                if (value.IsComputed)
-                {
-                    return CreateInput(CreateOutput(createOutputData.Invoke(new object?[]
-                    {
-                        ImmutableHashSet<Resource>.Empty, // resources
-                        null, // value
-                        false, // isKnown
-                        false // isSecret
-                    })));
-                }
-
                 var inputToOutputCast =
                     targetType
                         .GetMethods(BindingFlags.Public | BindingFlags.Static)
@@ -580,9 +562,31 @@ namespace Pulumi.Experimental.Provider
 
                         });
 
-                if (value.TryGetSecret(out var secretValue))
+                if (!value.Dependencies.IsEmpty)
                 {
-                    var inner = DeserializeValue(secretValue, targetType, path);
+                    var dependencies = ImmutableHashSet.CreateBuilder<Resource>();
+                    foreach (var urn in value.Dependencies)
+                    {
+                        dependencies.Add(new DependencyResource(urn));
+                    }
+                    var immutableDependencies = dependencies.ToImmutable();
+
+                    // The inner value could be a Secret, deserialise _that_ into an Input<T> recursively then
+                    // bind it with the data at this level, adding the extra dependencies.
+                    var inner = DeserializeValue(value.WithDependencies(ImmutableHashSet<Urn>.Empty), targetType, path);
+                    var withDependencies = outputType.GetMethod(
+                        "WithDependencies", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+                    var outputWithDependencies = withDependencies.Invoke(
+                        inputToOutputCast.Invoke(null, new[] { inner }),
+                        new object[] { immutableDependencies });
+
+                    return CreateInput(outputWithDependencies);
+                }
+
+                if (value.IsSecret)
+                {
+                    var inner = DeserializeValue(value.WithSecret(false), targetType, path);
                     // Combine the inner result (which we _know_ will be an Input<T>) with the secret flag.
 
                     var createSecret =
@@ -603,46 +607,13 @@ namespace Pulumi.Experimental.Provider
                     return CreateInput(secretOutput);
                 }
 
-                if (value.TryGetOutput(out var outputValue))
-                {
-                    var dependencies = ImmutableHashSet.CreateBuilder<Resource>();
-                    foreach (var urn in outputValue.Dependencies)
-                    {
-                        dependencies.Add(new DependencyResource(urn));
-                    }
-                    var immutableDependencies = dependencies.ToImmutable();
+                var deserialized = value.IsComputed ? null : DeserializeValue(value, elementType, path);
 
-                    if (outputValue.Value == null)
-                    {
-                        // If the inner value is null this is simply an unknown output, we just need to track in the dependencies from this level.
-                        return CreateInput(CreateOutput(createOutputData.Invoke(new object?[]
-                        {
-                            immutableDependencies, // resources
-                            null, // value
-                            false, // isKnown
-                            false // isSecret
-                        })));
-                    }
-
-                    // The inner value could be a Secret or a nested OutputReference, deserialise _that_ into
-                    // an Input<T> recursively then bind it with the data at this level, adding the extra dependencies.
-                    var inner = DeserializeValue(outputValue.Value, targetType, path);
-                    var withDependencies = outputType.GetMethod(
-                        "WithDependencies", BindingFlags.NonPublic | BindingFlags.Instance)!;
-
-                    var outputWithDependencies = withDependencies.Invoke(
-                        inputToOutputCast.Invoke(null, new[] { inner }),
-                        new object[] { immutableDependencies });
-
-                    return CreateInput(outputWithDependencies);
-                }
-
-                var deserialized = DeserializeValue(value, elementType, path);
                 var outputDataValue = createOutputData.Invoke(new object?[]
                 {
                     ImmutableHashSet<Resource>.Empty,
                     deserialized,
-                    true,
+                    !value.IsComputed,
                     false
                 });
 

--- a/sdk/Pulumi/Provider/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Provider/PropertyValueSerializer.cs
@@ -882,7 +882,7 @@ namespace Pulumi.Experimental.Provider
 
             if (targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(Dictionary<,>))
             {
-                if (value.TryGetObject(out var values))
+                if (value.TryGetMap(out var values))
                 {
                     var dictionary = Activator.CreateInstance(targetType);
                     var addMethod =
@@ -903,7 +903,7 @@ namespace Pulumi.Experimental.Provider
                     return dictionary;
                 }
 
-                ThrowTypeMismatchError(PropertyValueType.Object);
+                ThrowTypeMismatchError(PropertyValueType.Map);
             }
 
             if (targetType.IsGenericType && targetType.GetGenericTypeDefinition() == typeof(ImmutableDictionary<,>))
@@ -924,7 +924,7 @@ namespace Pulumi.Experimental.Provider
                     .GetMethod(nameof(ImmutableDictionary<int, int>.Builder.ToImmutable))!;
                 var valueType = targetType.GenericTypeArguments[1];
 
-                if (value.TryGetObject(out var values))
+                if (value.TryGetMap(out var values))
                 {
                     foreach (var pair in values)
                     {
@@ -938,12 +938,12 @@ namespace Pulumi.Experimental.Provider
                     return builderToImmutable.Invoke(builder, Array.Empty<object>());
                 }
 
-                ThrowTypeMismatchError(PropertyValueType.Object);
+                ThrowTypeMismatchError(PropertyValueType.Map);
             }
 
             if (targetType.IsClass || targetType.IsValueType)
             {
-                if (value.TryGetObject(out var objectProperties))
+                if (value.TryGetMap(out var objectProperties))
                 {
                     return DeserializeObject(objectProperties, targetType, path);
                 }

--- a/sdk/Pulumi/Provider/Provider.cs
+++ b/sdk/Pulumi/Provider/Provider.cs
@@ -1167,9 +1167,8 @@ namespace Pulumi.Experimental.Provider
 
                 if (domArgs.TryGetValue(argDependency.Key, out var currentValue))
                 {
-                    domArgs = domArgs.SetItem(argDependency.Key,
-                        new PropertyValue(new OutputReference(currentValue,
-                            argDependency.Value.Urns.Select(urn => new Urn(urn)).ToImmutableHashSet())));
+                    domArgs = domArgs.SetItem(argDependency.Key, currentValue.WithDependencies(
+                        argDependency.Value.Urns.Select(urn => new Urn(urn)).ToImmutableHashSet()));
                 }
             }
 

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -318,12 +318,6 @@
             Property values will be one of these types.
             </summary>
         </member>
-        <member name="P:Pulumi.Experimental.Provider.OutputReference.Value">
-            <summary>
-            The value of the output, if it is known. This will never be a `Computed` value as that's
-            equivilent to unknown and thus null.
-            </summary>
-        </member>
         <member name="T:Pulumi.Experimental.Provider.ParametersArgs">
             <summary>
             A parameter value, represented as an array of strings, as might be provided by a command-line invocation, such as


### PR DESCRIPTION
This removes `OutputReference` and the nested `PropertyValue` to indicate secrets. Instead every `PropertyValue` tracks secretness and dependencies.