### PR TITLE
Don't overwrite component Output properties with unknown

### DIFF
--- a/.changes/unreleased/Bug Fixes-595.yaml
+++ b/.changes/unreleased/Bug Fixes-595.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Component output properties are no longer overwritten with `unknown`
+time: 2025-05-13T12:10:47.339155938+01:00
+custom:
+  PR: "595"

--- a/integration_tests/resource_refs_get_resource/Program.cs
+++ b/integration_tests/resource_refs_get_resource/Program.cs
@@ -60,6 +60,7 @@ class Child : ComponentResource
     {
         if (opts?.Urn is null)
         {
+            Message = Output.Create(args.Message);
             RegisterOutputs(new Dictionary<string, object?>
             {
                 { "message", args.Message },
@@ -85,6 +86,7 @@ class Container : ComponentResource
     {
         if (opts?.Urn is null)
         {
+            Child = Output.Create(args.Child);
             RegisterOutputs(new Dictionary<string, object?>
             {
                 { "child", args.Child },

--- a/sdk/Pulumi.Tests/Mocks/MocksTests.cs
+++ b/sdk/Pulumi.Tests/Mocks/MocksTests.cs
@@ -69,6 +69,23 @@ namespace Pulumi.Tests.Mocks
         }
 
         [Fact]
+        public async Task TestTwoOutputStack()
+        {
+            var resources = await Testing.RunAsync<TwoOutputStack>();
+
+            var stack = resources.OfType<TwoOutputStack>().FirstOrDefault();
+            Assert.NotNull(stack);
+
+            var output1 = stack.Output1;
+            Assert.NotNull(output1);
+            Assert.Equal("output1", await output1.GetValueAsync(whenUnknown: default!));
+
+            var output2 = stack.Output2;
+            Assert.NotNull(output2);
+            Assert.Equal("output2", await output2.GetValueAsync(whenUnknown: default!));
+        }
+
+        [Fact]
         public async Task TestCustomWithResourceReference()
         {
             var resources = await Testing.RunAsync<MyStack>();
@@ -170,9 +187,8 @@ namespace Pulumi.Tests.Mocks
             catch (Exception ex)
             {
                 Assert.Contains(
-                    "System.InvalidOperationException: " +
-                    "[Output] Pulumi.Tests.Mocks.MocksTests+NullOutputStack.Foo " +
-                    "did not have a 'set' method",
+                    "Pulumi.RunException: Output(s) 'foo' have no value assigned." +
+                    " [Output] attributed properties must be assigned inside Stack constructor.",
                     ex.ToString());
                 return;
             }

--- a/sdk/Pulumi.Tests/Mocks/TestStack.cs
+++ b/sdk/Pulumi.Tests/Mocks/TestStack.cs
@@ -1,5 +1,7 @@
 // Copyright 2016-2020, Pulumi Corporation
 
+using System;
+
 namespace Pulumi.Tests.Mocks
 {
     [ResourceType("aws:ec2/instance:Instance", null)]
@@ -45,6 +47,21 @@ namespace Pulumi.Tests.Mocks
             var myInstance = new Instance("instance", new InstanceArgs());
             new MyCustom("mycustom", new MyCustomArgs { Instance = myInstance });
             this.PublicIp = myInstance.PublicIp;
+        }
+    }
+
+    // Regression test data for https://github.com/pulumi/pulumi-dotnet/issues/594
+    public class TwoOutputStack : Stack
+    {
+        [Output("output1")]
+        public Output<string> Output1 { get; set; } = Output.Create<string>("output1");
+
+        [Output("output2")]
+        public Output<string> Output2 { get; set; }
+
+        public TwoOutputStack()
+        {
+            Output2 = Output.Create<string>("output2");
         }
     }
 }

--- a/sdk/Pulumi/Resources/Resource.cs
+++ b/sdk/Pulumi/Resources/Resource.cs
@@ -152,7 +152,7 @@ namespace Pulumi
             // `CompletionSources`. This needs to happen before
             // partially initialized `this` is exposed to other
             // threads via `parentResource.ChildResources`.
-            CompletionSources = OutputCompletionSource.InitializeOutputs(this);
+            CompletionSources = OutputCompletionSource.InitializeOutputs(this, options.Urn != null || remote);
 
             // Before anything else - if there are transformations registered, invoke them in order
             // to transform the properties and options assigned to this resource.


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-dotnet/issues/594

The base `Resource` constructor was always overwriting every `[Output]` attributed property with a new output instance that it resolved after `RegisterResource` with the data returned from that, or `unknown`. 

This doesn't make sense for local component resource which never return any properties from `RegisterResource`, and meant that assigning outputs in property initialisers (which run before constructors) would get overwritten with `unknown`.