### PR TITLE
upgrade golangci-lint to v2

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,7 @@ env:
   AWS_REGION: us-west-2
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PULUMI_TEST_OWNER: "moolumi"
+  GOLANGCI_LINT_VERSION: v2.1.6
   ESC_ACTION_OIDC_AUTH: true
   ESC_ACTION_OIDC_ORGANIZATION: pulumi
   ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,22 +1,16 @@
+version: "2"
 run:
-  timeout: 10m
-  # Enable checking the by default skipped "examples" dirs
   build-tags:
-  - all
+    - all
 linters:
-  enable-all: false
   enable:
-    - durationcheck
     - depguard
-    - errcheck
+    - durationcheck
     - exhaustive
-    - gofumpt
     - goheader
     - goprintffuncname
     - gosec
-    - govet
     - importas
-    - ineffassign
     - lll
     - misspell
     - nakedret
@@ -25,106 +19,96 @@ linters:
     - perfsprint
     - prealloc
     - revive
-    - tenv
     - unconvert
-    - unused
     - wastedassign
     - whitespace
+  settings:
+    depguard:
+      rules:
+        protobuf:
+          deny:
+            - pkg: github.com/golang/protobuf
+              desc: Use google.golang.org/protobuf instead
+    goheader:
+      values:
+        regexp:
+          COPYRIGHT_YEARS: (\d{4}-)?\d{4}
+          WHITESPACE: \s*
+      template: |-
+        Copyright {{ COPYRIGHT_YEARS }}, Pulumi Corporation.
 
-linters-settings:
-  nakedret:
-    # Make an issue if func has more lines of code than this setting, and it has naked returns.
-    # Default: 30
-    max-func-lines: 60
-  nolintlint:
-    # Some linter exclusions are added to generated or templated files
-    # pre-emptively.
-    # Don't complain about these.
-    allow-unused: true
-  govet:
-    enable:
-      - nilness
-      # Reject comparisons of reflect.Value with DeepEqual or '=='.
-      - reflectvaluecompare
-      # Reject sort.Slice calls with a non-slice argument.
-      - sortslice
-      # Detect write to struct/arrays by-value that aren't read again.
-      - unusedwrite
-  depguard:
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        {{ WHITESPACE }}http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    govet:
+      enable:
+        - nilness
+        - reflectvaluecompare
+        - sortslice
+        - unusedwrite
+    importas:
+      alias:
+        - pkg: github.com/pulumi/pulumi/sdk/v3/proto/go
+          alias: pulumirpc
+        - pkg: github.com/pulumi/pulumi/sdk/v3/proto/go/testing
+          alias: testingrpc
+        - pkg: github.com/deckarep/golang-set/v2
+          alias: mapset
+        - pkg: github.com/pulumi/pulumi/sdk/v3/go/common/testing
+          alias: ptesting
+    nakedret:
+      max-func-lines: 60
+    nolintlint:
+      allow-unused: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      protobuf:
-        deny:
-          - pkg: "github.com/golang/protobuf"
-            desc: Use google.golang.org/protobuf instead
-  importas:
-    alias:
-    - pkg: github.com/pulumi/pulumi/sdk/v3/proto/go
-      alias: pulumirpc
-    - pkg: github.com/pulumi/pulumi/sdk/v3/proto/go/testing
-      alias: testingrpc
-    - pkg: github.com/deckarep/golang-set/v2
-      alias: mapset
-    - pkg: github.com/pulumi/pulumi/sdk/v3/go/common/testing
-      alias: ptesting
-  goheader:
-    values:
-      regexp:
-        COPYRIGHT_YEARS: (\d{4}-)?\d{4}
-        WHITESPACE: \s*
-    template: |-
-      Copyright {{ COPYRIGHT_YEARS }}, Pulumi Corporation.
-
-      Licensed under the Apache License, Version 2.0 (the "License");
-      you may not use this file except in compliance with the License.
-      You may obtain a copy of the License at
-
-      {{ WHITESPACE }}http://www.apache.org/licenses/LICENSE-2.0
-
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      See the License for the specific language governing permissions and
-      limitations under the License.
-
-issues:
-  exclude-rules:
-    # Don't warn on unused parameters.
-    # Parameter names are useful; replacing them with '_' is undesirable.
-    - linters: [revive]
-      text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'
-
-    # staticcheck already has smarter checks for empty blocks.
-    # revive's empty-block linter has false positives.
-    # For example, as of writing this, the following is not allowed.
-    #   for foo() { }
-    - linters: [revive]
-      text: 'empty-block: this block is empty, you can remove it'
-
-    # We *frequently* use the term 'new' in the context of properties
-    # (new and old properties),
-    # and we rarely use the 'new' built-in function.
-    # It's fine to ignore these cases.
-    - linters: [revive]
-      text: 'redefines-builtin-id: redefinition of the built-in function new'
-
-  exclude:
-    # https://github.com/pulumi/pulumi/issues/9469
-    - 'Name is deprecated: Name returns the variable or declaration name of the resource'
-
-    # https://github.com/pulumi/pulumi/issues/11869
-    - '"github.com/golang/protobuf/[\w/]+" is deprecated'
-
-    # https://github.com/pulumi/pulumi/issues/11870
-    - 'strings.Title has been deprecated'
-
-    # https://github.com/pulumi/pulumi/issues/12328
-    - 'deprecated: Please use types in:? cloud.google.com/go/logging/apiv2/loggingpb'
-
-  exclude-dirs:
-    - Godeps$
-    - builtin$
-    - node_modules
-    - testdata$
-    - third_party$
-    - vendor$
-  exclude-dirs-use-default: false
+      - linters:
+          - revive
+        text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'
+      - linters:
+          - revive
+        text: 'empty-block: this block is empty, you can remove it'
+      - linters:
+          - revive
+        text: 'redefines-builtin-id: redefinition of the built-in function new'
+      - path: (.+)\.go$
+        text: 'Name is deprecated: Name returns the variable or declaration name of the resource'
+      - path: (.+)\.go$
+        text: '"github.com/golang/protobuf/[\w/]+" is deprecated'
+      - path: (.+)\.go$
+        text: strings.Title has been deprecated
+      - path: (.+)\.go$
+        text: 'deprecated: Please use types in:? cloud.google.com/go/logging/apiv2/loggingpb'
+    paths:
+      - Godeps$
+      - builtin$
+      - node_modules
+      - testdata$
+      - third_party$
+      - vendor$
+formatters:
+  enable:
+    - gofumpt
+  exclusions:
+    generated: lax
+    paths:
+      - Godeps$
+      - builtin$
+      - node_modules
+      - testdata$
+      - third_party$
+      - vendor$

--- a/pulumi-language-dotnet/main.go
+++ b/pulumi-language-dotnet/main.go
@@ -308,7 +308,7 @@ func (host *dotnetLanguageHost) DeterminePossiblePulumiPackages(
 	//    Transitive Package                                       Resolved
 	//    > Google.Protobuf                                        3.10.0
 	//    > Grpc                                                   2.24.0
-	outputLines := strings.Split(strings.Replace(commandOutput, "\r\n", "\n", -1), "\n")
+	outputLines := strings.Split(strings.ReplaceAll(commandOutput, "\r\n", "\n"), "\n")
 
 	sawPulumi := false
 	packages := [][]string{}
@@ -819,7 +819,6 @@ func (host *dotnetLanguageHost) constructEnv(req *pulumirpc.RunRequest, config, 
 	maybeAppendEnv("stack", req.GetStack())
 	maybeAppendEnv("pwd", req.GetPwd())
 	maybeAppendEnv("dry_run", strconv.FormatBool(req.GetDryRun()))
-	maybeAppendEnv("query_mode", strconv.FormatBool(req.GetQueryMode()))
 	maybeAppendEnv("parallel", strconv.Itoa(int(req.GetParallel())))
 	maybeAppendEnv("tracing", host.tracing)
 	maybeAppendEnv("config", config)
@@ -1142,7 +1141,7 @@ func (host *dotnetLanguageHost) Pack(ctx context.Context, req *pulumirpc.PackReq
 			return nil, err
 		}
 
-		cmd := exec.Command( //nolint:gas // intentionally running dynamic program name.
+		cmd := exec.Command( //nolint:gosec // intentionally running dynamic program name.
 			opts.dotnetExec, "build", "-c", "Release")
 		cmd.Dir = req.PackageDirectory
 		return cmd.CombinedOutput()
@@ -1154,7 +1153,7 @@ func (host *dotnetLanguageHost) Pack(ctx context.Context, req *pulumirpc.PackReq
 
 	destination := filepath.Join(req.DestinationDirectory, filepath.Base(projectFile))
 
-	cmd := exec.Command( //nolint:gas // intentionally running dynamic program name.
+	cmd := exec.Command( //nolint:gosec // intentionally running dynamic program name.
 		opts.dotnetExec, "pack", "-c", "Release", "-o", destination)
 	cmd.Dir = req.PackageDirectory
 


### PR DESCRIPTION
We've upgraded this in `pulumi/pulumi` already.  Upgrade it here as well, to make running golangci-lint easier locally across our repos.