### PR TITLE
CI: use dev version instead of latest

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/actions@df5a93ad715135263c732ba288301bd044c383c0 # v6
         with:
-          pulumi-version: latest
+          pulumi-version: dev
       - name: Build Pulumi SDK
         run: dotnet run build-sdk
       - name: Workspace clean (are xml doc file updates committed?)
@@ -200,7 +200,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/actions@df5a93ad715135263c732ba288301bd044c383c0 # v6
         with:
-          pulumi-version: latest
+          pulumi-version: dev
       - name: Install gotestsum
         uses: jaxxstorm/action-install-gh-release@v2.0.0
         env:
@@ -282,7 +282,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/actions@df5a93ad715135263c732ba288301bd044c383c0 # v6
         with:
-          pulumi-version: latest
+          pulumi-version: dev
       - name: Install gotestsum
         uses: jaxxstorm/action-install-gh-release@v2.0.0
         env:

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/actions@df5a93ad715135263c732ba288301bd044c383c0 # v6
         with:
-          pulumi-version: latest
+          pulumi-version: dev
       - name: Build Pulumi SDK
         run: dotnet run build-sdk
       - name: Test Pulumi SDK


### PR DESCRIPTION
We should always be running the dev version of the CLI in CI when we can, both for early testing and so we can use the latest features in PRs to this repo. Update actions to always install the latest dev version.