### PR TITLE
Fix gen-sdk fails if there are dangling references

### DIFF
--- a/.changes/unreleased/bug-fixes-614.yaml
+++ b/.changes/unreleased/bug-fixes-614.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: bug-fixes
+body: Fix gen-sdk fails if there are dangling references
+time: 2025-05-23T08:31:18.608662-04:00
+custom:
+    PR: "614"

--- a/pulumi-language-dotnet/main.go
+++ b/pulumi-language-dotnet/main.go
@@ -1242,7 +1242,9 @@ func (host *dotnetLanguageHost) GeneratePackage(
 		return nil, err
 	}
 
-	pkg, diags, err := schema.BindSpec(spec, loader, schema.ValidationOptions{})
+	pkg, diags, err := schema.BindSpec(spec, loader, schema.ValidationOptions{
+		AllowDanglingReferences: true,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Follow up to https://github.com/pulumi/pulumi/pull/19216

Fixes #613