### PR TITLE
`Makefile` migration: `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,3 @@
-# Clean all generated SDK files
-clean::
-	cd sdk && dotnet clean
-	rm -rf sdk/*/{bin,obj}
-
 GO := go
 
 # Try to get the dev version using changie, otherwise fall back
@@ -19,6 +14,10 @@ build::
 
 changelog::
 	changie new
+
+clean:
+	cd sdk && dotnet clean
+	rm -rf {bin,obj} sdk/*/{bin,obj}
 
 test_integration:: build
 	cd integration_tests && gotestsum -- --parallel 1 --timeout 60m ./...
@@ -39,4 +38,4 @@ lint::
 			--path-prefix $(pkg)) \
 		&&) true
 
-.PHONY: install build
+.PHONY: install build clean

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+# Clean all generated SDK files
+clean::
+	cd sdk && dotnet clean
+	rm -rf sdk/*/{bin,obj}
+
 GO := go
 
 # Try to get the dev version using changie, otherwise fall back

--- a/build/Program.fs
+++ b/build/Program.fs
@@ -47,7 +47,7 @@ let getDevVersion() =
 let cleanSdk() =
     printfn "Deprecated: calling `make clean` instead"
     let cmd = Cli.Wrap("make").WithArguments("clean").WithWorkingDirectory(repositoryRoot)
-    let output = cmd.ExecuteAsync().GetAwaiter().GetResult()
+    let output = cmd.ExecuteBufferedAsync().GetAwaiter().GetResult()
     if output.ExitCode <> 0 then
         failwith "Clean failed"
 

--- a/build/Program.fs
+++ b/build/Program.fs
@@ -45,22 +45,11 @@ let getDevVersion() =
 /// Runs `dotnet clean` command against the solution file,
 /// then proceeds to delete the `bin` and `obj` directory of each project in the solution
 let cleanSdk() =
-    let cmd = Cli.Wrap("dotnet").WithArguments("clean").WithWorkingDirectory(sdk)
+    printfn "Deprecated: calling `make clean` instead"
+    let cmd = Cli.Wrap("make").WithArguments("clean").WithWorkingDirectory(repositoryRoot)
     let output = cmd.ExecuteAsync().GetAwaiter().GetResult()
     if output.ExitCode <> 0 then
         failwith "Clean failed"
-
-    let projects = [
-        pulumiSdk
-        pulumiSdkTests
-        pulumiAutomationSdk
-        pulumiAutomationSdkTests
-        pulumiFSharp
-    ]
-
-    for project in projects do
-        Shell.deleteDir (Path.Combine(project, "bin"))
-        Shell.deleteDir (Path.Combine(project, "obj"))
 
 /// Runs `dotnet restore` against the solution file without using cache
 let restoreSdk() =


### PR DESCRIPTION
A conversation I had with @lunaris recently: our repositories should have common commands for common actions (code quality, changelog, release, etc). Currently, `pulumi-dotnet` has an awkward split between `Makefile` and `build/Project.fs`, and this PR is the start of an attempt to bring everything possible over to the `Makefile`. I'll leave pass-through calls in the `Project.fs` file for now so all previous commands will still work.