### PR TITLE
`Makefile` migration: `make build-sdk`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,17 @@ lint::
 			--path-prefix $(pkg)) \
 		&&) true
 
+# Clean all generated SDK files
+clean::
+	cd sdk && dotnet clean
+	rm -rf sdk/*/{bin,obj}
+
+# Build the SDK
+build-sdk::
+	@echo "Building Pulumi SDK"
+	$(MAKE) clean-sdk
+	cd sdk && dotnet restore --no-cache
+	$(eval SDK_VERSION := $(shell cd pulumi-language-dotnet && grep -oP 'github.com/pulumi/pulumi/sdk/v3 v\K[0-9.]+' go.mod))
+	cd sdk && dotnet build --configuration Release -p:PulumiSdkVersion=$(SDK_VERSION)
+
 .PHONY: install build

--- a/build/Program.fs
+++ b/build/Program.fs
@@ -92,15 +92,11 @@ let listIntegrationTests() =
         printfn $"{testName}"
 
 let buildSdk() =
-    cleanSdk()
-    restoreSdk()
-    match findGoSDKVersion(pulumiLanguageDotnet) with
-    | None -> failwith "Could not find the Pulumi SDK version in go.mod"
-    | Some(version) ->
-        printfn "Building Pulumi SDK"
-        if Shell.Exec("dotnet", "build --configuration Release -p:PulumiSdkVersion=" + version, sdk) <> 0
-
-        then failwith "build failed"
+    printfn "Deprecated: calling `make build-sdk` instead"
+    let cmd = Cli.Wrap("make").WithArguments("build-sdk").WithWorkingDirectory(repositoryRoot)
+    let output = cmd.ExecuteAsync().GetAwaiter().GetResult()
+    if output.ExitCode <> 0 then
+        failwith "Build failed"
 
 /// Publishes packages for Pulumi, Pulumi.Automation and Pulumi.FSharp to nuget.
 /// Requires NUGET_PUBLISH_KEY and PULUMI_VERSION environment variables.


### PR DESCRIPTION
Following on from #629, this PR lifts `buildSdk` into the `Makefile`. I'm going with `build-sdk` rather than `build` because it seems that most of our repos (even language-specific ones) have more than one type of project in them. Hence, I guess we'll end up with `make-sdk`, `make-language-server`, and so on.