### PR TITLE
`Makefile` migration: `make build_language_host`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,12 +87,4 @@ lint::
 			--path-prefix $(pkg)) \
 		&&) true
 
-# Build the language plugin
-build-language-plugin::
-	@echo "Building pulumi-language-dotnet Plugin"
-	rm -f pulumi-language-dotnet/pulumi-language-dotnet
-	$(eval DEV_VERSION := $(shell if command -v changie > /dev/null; then changie next patch -p dev.0; else echo "3.0.0-dev.0"; fi))
-	cd pulumi-language-dotnet && ${GO} build -ldflags "-X github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3/version.Version=$(DEV_VERSION)" .
-	@echo "Built binary pulumi-language-dotnet/pulumi-language-dotnet"
-
 .PHONY: install build

--- a/Makefile
+++ b/Makefile
@@ -86,3 +86,13 @@ lint::
 			--timeout 5m \
 			--path-prefix $(pkg)) \
 		&&) true
+
+# Build the language plugin
+build-language-plugin::
+	@echo "Building pulumi-language-dotnet Plugin"
+	rm -f pulumi-language-dotnet/pulumi-language-dotnet
+	$(eval DEV_VERSION := $(shell if command -v changie > /dev/null; then changie next patch -p dev.0; else echo "3.0.0-dev.0"; fi))
+	cd pulumi-language-dotnet && ${GO} build -ldflags "-X github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3/version.Version=$(DEV_VERSION)" .
+	@echo "Built binary pulumi-language-dotnet/pulumi-language-dotnet"
+
+.PHONY: install build

--- a/Makefile
+++ b/Makefile
@@ -86,5 +86,3 @@ lint::
 			--timeout 5m \
 			--path-prefix $(pkg)) \
 		&&) true
-
-.PHONY: install build

--- a/build/Program.fs
+++ b/build/Program.fs
@@ -131,14 +131,11 @@ let cleanLanguagePlugin() =
     if File.Exists plugin then File.Delete plugin
 
 let buildLanguagePlugin() =
-    cleanLanguagePlugin()
-    let devVersion = getDevVersion()
-    printfn $"Building pulumi-language-dotnet Plugin {devVersion}"
-    let ldflags = $"-ldflags \"-X github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3/version.Version={devVersion}\""
-    if Shell.Exec("go", $"build {ldflags}", pulumiLanguageDotnet) <> 0
-    then failwith "Building pulumi-language-dotnet failed"
-    let output = Path.Combine(pulumiLanguageDotnet, "pulumi-language-dotnet")
-    printfn $"Built binary {output}"
+    printfn "Deprecated: calling `make build-language-plugin` instead"
+    let cmd = Cli.Wrap("make").WithArguments("build-language-plugin").WithWorkingDirectory(repositoryRoot)
+    let output = cmd.ExecuteAsync().GetAwaiter().GetResult()
+    if output.ExitCode <> 0 then
+        failwith "Building pulumi-language-dotnet failed"
 
 let testLanguagePlugin() =
     cleanLanguagePlugin()

--- a/build/Program.fs
+++ b/build/Program.fs
@@ -131,9 +131,9 @@ let cleanLanguagePlugin() =
     if File.Exists plugin then File.Delete plugin
 
 let buildLanguagePlugin() =
-    printfn "Deprecated: calling `make build-language-plugin` instead"
-    let cmd = Cli.Wrap("make").WithArguments("build-language-plugin").WithWorkingDirectory(repositoryRoot)
-    let output = cmd.ExecuteAsync().GetAwaiter().GetResult()
+    printfn "Deprecated: calling `make build_language_host` instead"
+    let cmd = Cli.Wrap("make").WithArguments("build_language_host").WithWorkingDirectory(repositoryRoot)
+    let output = cmd.ExecuteBufferedAsync().GetAwaiter().GetResult()
     if output.ExitCode <> 0 then
         failwith "Building pulumi-language-dotnet failed"
 


### PR DESCRIPTION
I actually already did the `Makefile` work in #631, so this is just deprecating the F# command.