### PR TITLE
try to fix release process again

### DIFF
--- a/.changes/unreleased/bug-fixes-645.yaml
+++ b/.changes/unreleased/bug-fixes-645.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Fix release process
+time: 2025-06-12T10:48:17.376712484+02:00
+custom:
+    PR: "643"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 builds:
 
 - binary: pulumi-language-dotnet
@@ -29,4 +30,4 @@ checksum:
   name_template: 'checksums.txt'
 
 changelog:
-  skip: false
+  disable: false


### PR DESCRIPTION
The first attempt at this was in
https://github.com/pulumi/pulumi-dotnet/pull/635, but it didn't fix it completely.  I think this brings the .goreleaser.yml to the correct state, but only release CI will tell if I'm right.

Fixes https://github.com/pulumi/pulumi-dotnet/issues/641