### PR TITLE
Don’t remove bin,obj from the root during clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ changelog::
 
 clean:
 	cd sdk && dotnet clean
-	rm -rf {bin,obj} sdk/*/{bin,obj}
+	rm -rf sdk/*/{bin,obj}
 
 test_integration:: build
 	cd integration_tests && gotestsum -- --parallel 1 --timeout 60m ./...


### PR DESCRIPTION
This holds the build and deps of the scripts in `Program.fs`, don’t delete this, as we might be calling `make clean` in the middle of some script.

The FSharp implementation prior to https://github.com/pulumi/pulumi-dotnet/pull/629 did not remove these files.