### PR TITLE
Don't run conformance tests concurrently with the dev release

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -335,7 +335,7 @@ jobs:
 
   release-dev-sdk:
     name: release-dev-sdk
-    needs: [build, integration-tests, info]
+    needs: [build, integration-tests, conformance-tests, info]
     uses: ./.github/workflows/release-sdk.yml
     if: ${{ github.event_name == 'merge_group' }}
     with:


### PR DESCRIPTION
`make conformance-tests` depends on the `build` target. Prior to https://github.com/pulumi/pulumi-dotnet/pull/631 this would only build the language runtime plugin, but now it also builds the .NET SDK.

Since the `conformance-tests` job can run concurrently with the `release-dev-sdk` job, it is now possible that it will create a `Pulumi.1.0.0.nupkg` inside the `sdk/Pulumi/bin/Release` folder, next to the `Pulumi.${DEV_VERSION}.nupkg` built by the publish script. The publish script uploads the /first/ file it finds in that folder, so if this build races the publish script, as it often does, we try to publish v1.0.0.

Arguably waiting for the conformance tests to pass successfully before publishing the dev release is the better behaviour in any case.