### PR TITLE
`Makefile` migration: `make lint`/`make lint_fix`/`make format`/`make format_check`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,6 +51,12 @@ jobs:
         with:
           # Install 8.0 for Build.fsproj
           dotnet-version: 8.0.x
+      - name: Set up Go 1.24.x
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.x
+      - name: Install `gofumpt`
+        run: go install mvdan.cc/gofumpt@latest
       - name: Run `make format_check`
         run: make format_check
 
@@ -67,6 +73,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.24.x
+      - name: Install `gofumpt`
+        run: go install mvdan.cc/gofumpt@latest
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,16 +72,12 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --help
-      - name: Setup dotnet SDK
-        uses: actions/setup-dotnet@v4
-        with:
-          # Install 8.0 for Build.fsproj
-          dotnet-version: 8.0.x
 
-      - name: Run `make lint`
-        # Print GitHub Actions-friendly output so that errors get marked
-        # in the pull request.
-        run: make lint GOLANGCI_LINT_ARGS=--output.text.path=stdout
+      - name: Run `make lint_language_host`
+        run: make lint_language_host GOLANGCI_LINT_ARGS=--output.text.path=stdout
+
+      - name: Run `make lint_integration_tests`
+        run: make lint_integration_tests GOLANGCI_LINT_ARGS=--output.text.path=stdout
 
   lint-changelog:
     name: Lint Changelog

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           # Install 8.0 for Build.fsproj
           dotnet-version: 8.0.x
-      - name: Format Pulumi SDK
+      - name: Run `make format_check`
         run: make format_check
 
   lint:
@@ -72,8 +72,13 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --help
+      - name: Setup dotnet SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          # Install 8.0 for Build.fsproj
+          dotnet-version: 8.0.x
 
-      - name: Run golangci-lint
+      - name: Run `make lint`
         # Print GitHub Actions-friendly output so that errors get marked
         # in the pull request.
         run: make lint GOLANGCI_LINT_ARGS=--output.text.path=stdout

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,7 +52,7 @@ jobs:
           # Install 8.0 for Build.fsproj
           dotnet-version: 8.0.x
       - name: Format Pulumi SDK
-        run: make format
+        run: make format_check
 
   lint:
     name: Lint Go

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ format_sdk:
 
 .PHONY: format_language_host_check
 format_language_host_check:
-	@problems=$(gofumpt -l pulumi-language-dotnet); \
+	@problems=$$(gofumpt -l pulumi-language-dotnet || exit 1); \
 	if [ -n "$$problems" ]; then \
 		echo "$$problems"; \
 		exit 1; \
@@ -58,7 +58,7 @@ format_language_host:
 
 .PHONY: format_integration_tests_check
 format_integration_tests_check:
-	@problems=$$(gofumpt -l integration_tests); \
+	@problems=$$(gofumpt -l integration_tests || exit 1); \
 	if [ -n "$$problems" ]; then \
 		echo "$$problems"; \
 		exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,6 @@ format_integration_tests_check:
 format_integration_tests:
 	gofumpt -w integration_tests
 
-###
-
 .PHONY: lint
 lint: lint_sdk lint_language_host lint_integration_tests
 

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ format_sdk:
 
 .PHONY: format_language_host_check
 format_language_host_check:
-	@problems=$$(gofumpt -l pulumi-language-dotnet || exit 1); \
-	if [ -n "$$problems" ]; then \
+	@problems=$$(gofumpt -l pulumi-language-dotnet); \
+	if [ $$? -ne 0 ]; then \
 		echo "$$problems"; \
 		exit 1; \
 	fi
@@ -58,8 +58,8 @@ format_language_host:
 
 .PHONY: format_integration_tests_check
 format_integration_tests_check:
-	@problems=$$(gofumpt -l integration_tests || exit 1); \
-	if [ -n "$$problems" ]; then \
+	@problems=$$(gofumpt -l integration_tests); \
+	if [ $$? -ne 0 ]; then \
 		echo "$$problems"; \
 		exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -84,19 +84,19 @@ lint_sdk_fix: format_sdk
 
 .PHONY: lint_language_host
 lint_language_host: format_language_host_check
-	cd pulumi-language-dotnet && golangci-lint run --config ../.golangci.yml --timeout 5m --path-prefix pulumi-language-dotnet
+	cd pulumi-language-dotnet && golangci-lint run $(GOLANGCI_LINT_ARGS) --config ../.golangci.yml --timeout 5m --path-prefix pulumi-language-dotnet
 
 .PHONY: lint_language_host_fix
 lint_language_host_fix: format_language_host
-	cd pulumi-language-dotnet && golangci-lint run --fix --config ../.golangci.yml --timeout 5m --path-prefix pulumi-language-dotnet
+	cd pulumi-language-dotnet && golangci-lint run $(GOLANGCI_LINT_ARGS) --fix --config ../.golangci.yml --timeout 5m --path-prefix pulumi-language-dotnet
 
 .PHONY: lint_integration_tests
 lint_integration_tests: format_integration_tests_check
-	cd integration_tests && golangci-lint run --config ../.golangci.yml --timeout 5m --path-prefix integration_tests
+	cd integration_tests && golangci-lint run $(GOLANGCI_LINT_ARGS) --config ../.golangci.yml --timeout 5m --path-prefix integration_tests
 
 .PHONY: lint_integration_tests_fix
 lint_integration_tests_fix: format_integration_tests
-	cd integration_tests && golangci-lint run --fix --config ../.golangci.yml --timeout 5m --path-prefix integration_tests
+	cd integration_tests && golangci-lint run $(GOLANGCI_LINT_ARGS) --fix --config ../.golangci.yml --timeout 5m --path-prefix integration_tests
 
 test_integration:: build
 	cd integration_tests && gotestsum -- --parallel 1 --timeout 60m ./...


### PR DESCRIPTION
After some discussion on Slack, here's where we are:

- `make format` will apply formatting changes and write to disk.
- `make lint` will report errors (including formatting errors) without writing to disk.
- `make format_check` will report formatting errors without writing to disk.
- `make lint_fix` will apply linting changes and write to disk.