### PR TITLE
Pick versioned artifacts when publishing

### DIFF
--- a/.changes/unreleased/bug-fixes-667.yaml
+++ b/.changes/unreleased/bug-fixes-667.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Pick versioned artifacts when publishing
+time: 2025-07-11T11:59:03.640419499+01:00
+custom:
+    PR: "667"

--- a/build/Publish.fs
+++ b/build/Publish.fs
@@ -22,7 +22,7 @@ type PublishResult =
     | Ok of project:string
     | Failed of project:string * error: string
     | AlreadyPublished of project:string
-    
+
     member this.ProjectName() =
         match this with
         | Ok project -> projectName project
@@ -47,10 +47,12 @@ let publishSdk (projectDir: string) (version: string) (nugetApiKey: string) (goS
     else
         let releaseDir = Path.Combine(projectDir, "bin", "Release")
         let releaseArtifacts = Directory.EnumerateFiles(releaseDir)
-        if not (releaseArtifacts.Any()) then
+        let nugetPackageFile = releaseArtifacts.FirstOrDefault(
+            (fun path -> path.Contains(version)), "")
+
+        if nugetPackageFile = "" then
             PublishResult.Failed(projectDir, "couldn't find the nuget package")
         else
-            let nugetPackageFile = releaseArtifacts.First()
             let publishNugetCmd = String.concat " " [
                 "nuget"
                 "push"


### PR DESCRIPTION
When publishing artifacts to NuGet, the release script currently just picks the first package it finds on the filesystem. This works fine when we know there will be exactly one, but is not robust to e.g. changes to our build process that forget to clean things up. We can of course keep alert to changes to our builds that add development artifacts, but we should probably also just make the script pickier, attempting instead to find the precise version we have been asked to publish. This change does just that.