### PR TITLE
Serialize OutputType structs to objects

### DIFF
--- a/.changes/unreleased/Improvements-681.yaml
+++ b/.changes/unreleased/Improvements-681.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Serialize OutputType annotated objects as stack outputs
+time: 2025-08-05T14:55:59.083220484+01:00
+custom:
+    PR: "681"


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-dotnet/issues/409

When the serializer encounters an `OutputType` annotated object it pulls off the public readonly fields, lowercases the first character of the name (the opposite of what codegen does), and returns the fields together in an object.