### PR TITLE
Add `RemoveStackOptions` to Automation API

### DIFF
--- a/.changes/unreleased/Improvements-682.yaml
+++ b/.changes/unreleased/Improvements-682.yaml
@@ -1,0 +1,6 @@
+component: sdk/auto
+kind: Improvements
+body: Add `RemoveStackOptions` to Automation API
+time: 2025-08-05T11:58:50.374862-07:00
+custom:
+    PR: "682"

--- a/sdk/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/Pulumi.Automation/LocalWorkspace.cs
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation
+// Copyright 2016-2025, Pulumi Corporation
 
 using System;
 using System.Collections.Generic;
@@ -726,7 +726,35 @@ namespace Pulumi.Automation
 
         /// <inheritdoc/>
         public override Task RemoveStackAsync(string stackName, CancellationToken cancellationToken = default)
-            => this.RunCommandAsync(new[] { "stack", "rm", "--yes", stackName }, cancellationToken);
+            => RemoveStackAsync(stackName, null, cancellationToken);
+
+        /// <inheritdoc/>
+        public override Task RemoveStackAsync(string stackName, RemoveStackOptions? options, CancellationToken cancellationToken = default)
+        {
+            var args = new List<string> { "stack", "rm", "--yes", stackName };
+
+            if (options is not null)
+            {
+                if (options.Force)
+                {
+                    args.Add("--force");
+                }
+                if (options.PreserveConfig)
+                {
+                    args.Add("--preserve-config");
+                }
+                if (options.RemoveBackups)
+                {
+                    if (!SupportsCommand(new SemVersion(3, 188, 0)))
+                    {
+                        throw new InvalidOperationException($"The Pulumi CLI version does not support {nameof(options.RemoveBackups)}. Please update the Pulumi CLI.");
+                    }
+                    args.Add("--remove-backups");
+                }
+            }
+
+            return RunCommandAsync(args, cancellationToken);
+        }
 
         /// <inheritdoc/>
         public override async Task<ImmutableList<StackSummary>> ListStacksAsync(CancellationToken cancellationToken = default)

--- a/sdk/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/Pulumi.Automation/Pulumi.Automation.xml
@@ -813,6 +813,9 @@
         <member name="M:Pulumi.Automation.LocalWorkspace.RemoveStackAsync(System.String,System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
+        <member name="M:Pulumi.Automation.LocalWorkspace.RemoveStackAsync(System.String,Pulumi.Automation.RemoveStackOptions,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
         <member name="M:Pulumi.Automation.LocalWorkspace.ListStacksAsync(System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
@@ -1444,6 +1447,26 @@
             supported for local backends.
             </summary>
         </member>
+        <member name="T:Pulumi.Automation.RemoveStackOptions">
+            <summary>
+            Options to pass into <see cref="M:Pulumi.Automation.Workspace.RemoveStackAsync(System.String,Pulumi.Automation.RemoveStackOptions,System.Threading.CancellationToken)"/>.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoveStackOptions.Force">
+            <summary>
+            Forces deletion of the stack, leaving behind any resources managed by the stack
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoveStackOptions.PreserveConfig">
+            <summary>
+            Do not delete the corresponding Pulumi.&lt;stack-name&gt;.yaml configuration file for the stack
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.RemoveStackOptions.RemoveBackups">
+            <summary>
+            Remove backups of the stack, if using the DIY backend
+            </summary>
+        </member>
         <member name="T:Pulumi.Automation.SecretsProviderOptions">
             <summary>
             Options to pass into <see cref="M:Pulumi.Automation.WorkspaceStack.ChangeSecretsProviderAsync(System.String,Pulumi.Automation.SecretsProviderOptions,System.Threading.CancellationToken)"/>.
@@ -1892,6 +1915,14 @@
             Deletes the stack and all associated configuration and history.
             </summary>
             <param name="stackName">The stack to remove.</param>
+            <param name="cancellationToken">A cancellation token.</param>
+        </member>
+        <member name="M:Pulumi.Automation.Workspace.RemoveStackAsync(System.String,Pulumi.Automation.RemoveStackOptions,System.Threading.CancellationToken)">
+            <summary>
+            Deletes the stack and all associated configuration and history.
+            </summary>
+            <param name="stackName">The stack to remove.</param>
+            <param name="options">Options to pass into the remove stack operation.</param>
             <param name="cancellationToken">A cancellation token.</param>
         </member>
         <member name="M:Pulumi.Automation.Workspace.ListStacksAsync(System.Threading.CancellationToken)">

--- a/sdk/Pulumi.Automation/RemoveStackOptions.cs
+++ b/sdk/Pulumi.Automation/RemoveStackOptions.cs
@@ -1,0 +1,25 @@
+// Copyright 2016-2025, Pulumi Corporation
+
+namespace Pulumi.Automation
+{
+    /// <summary>
+    /// Options to pass into <see cref="Workspace.RemoveStackAsync(string, RemoveStackOptions, System.Threading.CancellationToken)"/>.
+    /// </summary>
+    public class RemoveStackOptions
+    {
+        /// <summary>
+        /// Forces deletion of the stack, leaving behind any resources managed by the stack
+        /// </summary>
+        public bool Force { get; set; }
+
+        /// <summary>
+        /// Do not delete the corresponding Pulumi.&lt;stack-name&gt;.yaml configuration file for the stack
+        /// </summary>
+        public bool PreserveConfig { get; set; }
+
+        /// <summary>
+        /// Remove backups of the stack, if using the DIY backend
+        /// </summary>
+        public bool RemoveBackups { get; set; }
+    }
+}

--- a/sdk/Pulumi.Automation/Workspace.cs
+++ b/sdk/Pulumi.Automation/Workspace.cs
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation
+// Copyright 2016-2025, Pulumi Corporation
 
 using System;
 using System.Collections.Generic;
@@ -333,6 +333,17 @@ namespace Pulumi.Automation
         /// <param name="stackName">The stack to remove.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         public abstract Task RemoveStackAsync(string stackName, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes the stack and all associated configuration and history.
+        /// </summary>
+        /// <param name="stackName">The stack to remove.</param>
+        /// <param name="options">Options to pass into the remove stack operation.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public virtual Task RemoveStackAsync(string stackName, RemoveStackOptions? options, CancellationToken cancellationToken = default)
+            => options is not null ?
+                throw new NotSupportedException($"{nameof(RemoveStackAsync)} with {nameof(RemoveStackOptions)} is not supported") :
+                RemoveStackAsync(stackName, cancellationToken);
 
         /// <summary>
         /// Returns all stacks created under the current project.


### PR DESCRIPTION
This change adds `RemoveStackOptions` to Automation API, with support for `Force`, `PreserveConfig`, and `RemoveBackups` options. `RemoveBackups` requires v3.188.0 or later of the Pulumi CLI.

Part of https://github.com/pulumi/pulumi/issues/9474
Follow-up of https://github.com/pulumi/pulumi/pull/20203

This is blocked on the v3.188.0 release of the CLI. The `RemoveBackups` test will fail until that version of the CLI is released.