### PR TITLE
Skip update checks when calling `pulumi version` in autoapi

### DIFF
--- a/.changes/unreleased/Improvements-696.yaml
+++ b/.changes/unreleased/Improvements-696.yaml
@@ -1,0 +1,6 @@
+component: sdk/auto
+kind: Improvements
+body: Skip update checks when looking up the currently installed pulumi version
+time: 2025-09-15T12:04:05.358309+01:00
+custom:
+    PR: "696"

--- a/sdk/Pulumi.Automation/Commands/LocalPulumiCommand.cs
+++ b/sdk/Pulumi.Automation/Commands/LocalPulumiCommand.cs
@@ -87,8 +87,13 @@ namespace Pulumi.Automation.Commands
 
         private static async Task<SemVersion?> GetPulumiVersionAsync(SemVersion minimumVersion, string command, bool optOut, CancellationToken cancellationToken)
         {
+            var env = System.Environment.GetEnvironmentVariables()
+                .Cast<System.Collections.DictionaryEntry>()
+                .ToDictionary(de => de.Key.ToString()!, de => de.Value?.ToString());
+            env["PULUMI_SKIP_UPDATE_CHECK"] = "true";
             var result = await Cli.Wrap(command)
                 .WithArguments("version")
+                .WithEnvironmentVariables(env)
                 .WithValidation(CommandResultValidation.None)
                 .ExecuteBufferedAsync(cancellationToken);
             if (result.ExitCode != 0)


### PR DESCRIPTION
dotnet change to match https://github.com/pulumi/pulumi/pull/20502