### PR TITLE
Include inner message on LogException

### DIFF
--- a/.changes/unreleased/Improvements-700.yaml
+++ b/.changes/unreleased/Improvements-700.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Include inner exception message in LogException messages
+time: 2025-09-19T08:40:27.57344+01:00
+custom:
+    PR: "700"

--- a/sdk/Pulumi/Exceptions/LogException.cs
+++ b/sdk/Pulumi/Exceptions/LogException.cs
@@ -12,7 +12,7 @@ namespace Pulumi
     public class LogException : Exception
     {
         public LogException(Exception exception)
-            : base("Error occurred during logging", exception)
+            : base("Error occurred during logging: " + exception.Message, exception)
         {
         }
     }


### PR DESCRIPTION
To help with issues like https://github.com/pulumi/pulumi-dotnet/issues/697, lets include the message from the inner exception in the LogException message so we can see what failed.