### PR TITLE
remove CHANGELOG_PENDING file

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,1 +1,0 @@
-* Add conformance for rootDirectory to the sdk


### PR DESCRIPTION
We have been using changie for the changelog in this repo for a while, but never deleted the CHANGELOG_PENDING file.  It still has an old entry in there, but that's long been released already.  Just remove the file to avoid any possible confusion.