### PR TITLE
use macos-latest instead of macos-13

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -173,7 +173,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         dotnet-version: [8.0.x, 9.0.x]
     runs-on: ${{ matrix.os }}
     steps:
@@ -256,7 +256,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-latest]
         dotnet-version: [8.0.x]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
macos-13 runners will be retired soon, see
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/.

The brownout is not supposed to happen until november 4th, but for some reason jobs are not being acquired right now anyway.

Note that this also switches the architecture to arm64 instead of x86_64.  I'd expect most MacOS users to be on that now anyway, so that's probably a good thing to test either way.