### PR TITLE
Add source artifacts to our build

### DIFF
--- a/Build.fsproj
+++ b/Build.fsproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Fake.Core.Environment" Version="5.23.1" />
     <PackageReference Include="Fake.Core.Target" Version="5.23.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="Pulumi" Version="3.89.0" />
   </ItemGroup>
 
 </Project>

--- a/pulumi-language-dotnet/main.go
+++ b/pulumi-language-dotnet/main.go
@@ -1212,7 +1212,7 @@ func (host *dotnetLanguageHost) Pack(ctx context.Context, req *pulumirpc.PackReq
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("failed to pack: %w. CombinedOutput:\n%s", err, string(output))
+		return nil, fmt.Errorf("failed to pack: %w. Dotnet pack output:\n%s", err, string(output))
 	}
 
 	var nugetFilePath string


### PR DESCRIPTION
In addition to adding the source artifacts I refactored the command output and how it is printed in case of error. When doing local development it was failing but all of the output was locked away on the process actually running the language runtime. The only return was "Exit value 1" or some such. 

By making this change (which I would recommend all the language runtime follow) I was able to quickly and easily see the actual problem.

Tested by observing that after building we now see both expected artifacts output. We needed to manually ask for .snupkg as it will default to using the older "symbols.nupkg" format otherwise. 


 Pulumi.Random.4.0.0-alpha.0.nupkg	Pulumi.Random.4.0.0-alpha.0.snupkg