### PR TITLE
Fix changelog job

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           if ! gh release list | grep -q "$(changie latest)"; then
             # The changie latest isn't yet published, i.e. we're going to publish it so check ".changes/unreleased" is empty
-            if [ -n "$(ls -A .changes/unreleased 2>/dev/null)" ]; then
+            if [ -n "$(ls .changes/unreleased 2>/dev/null)" ]; then
               echo "Unreleased changes are not empty"
               exit 1
             fi


### PR DESCRIPTION
A little embarrassing: the `check-changelog` job has in fact never worked due to a syntax error in the Bash[^1]. I fixed it this week, and now it's breaking the deploy because the working syntax has a bug: it will always find `.gitkeep` in the unreleased changes directory, and therefore `ls -A` will never be empty. This PR fixes this by noting that changes are never dot-prefixed, and thus removing the `-A` flag is enough.

[^1]: Here's an example: https://github.com/pulumi/pulumi-dotnet/actions/runs/18226052479/job/51897500373#step:4:13