### PR TITLE
Make `changie` version check match `check-changelog` logic

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -270,7 +270,11 @@ jobs:
       - name: Get version info
         id: version
         run: |
-          TAG="$(changie next auto || changie next patch)"
+          if [ -n "$(ls .changes/unreleased 2>/dev/null)" ]; then
+            TAG="$(changie next auto)"
+          else
+            TAG="$(changie next patch)"
+          fi
           TAG="${TAG#v}" # remove prefix
           OID="$(git rev-parse --short HEAD)"
           PULUMI_VERSION="$TAG-alpha.$OID"


### PR DESCRIPTION
This currently fails because `changie next auto` outputs an error message. However, we can be explicit about the logic for whether `auto` is going to work based on the same logic we're now using in `check-changelog` from #721.