### PR TITLE
Pass secret values as Outputs to hooks

### DIFF
--- a/.changes/unreleased/bug-fixes-730.yaml
+++ b/.changes/unreleased/bug-fixes-730.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Pass secret values as Output objects to resource hooks to properly maintain their secretness. Previously hooks received an internal representation for secret values.
+time: 2025-10-23T12:55:44.123435+02:00
+custom:
+  PR: "730"

--- a/integration_tests/custom_resource_hooks/step1-create/Program.cs
+++ b/integration_tests/custom_resource_hooks/step1-create/Program.cs
@@ -22,6 +22,7 @@ class ResourceHooksStack : Stack
         var u = new Updatable("updatable", new UpdatableArgs
         {
             Value = "step1",
+            Secret = Output.CreateSecret("hello secret"),
         }, new CustomResourceOptions
         {
             Hooks = {
@@ -29,6 +30,11 @@ class ResourceHooksStack : Stack
                 {
                     new("beforeCreate", async (args, cancellationToken) => {
                         Console.WriteLine($"BeforeCreate: value is {args.NewInputs?["value"]}");
+                        var secret = (Output<object>)args.NewInputs?["secret"]!;
+                        if (await Output.IsSecretAsync(secret)) {
+                            Console.WriteLine($"BeforeCreate: secret is secret");
+                        }
+                        secret.Apply(value => { Console.WriteLine($"BeforeCreate: secret is {value}"); return true; });
                     }),
                 },
                 AfterCreate =

--- a/integration_tests/custom_resource_hooks/step1-create/Updatable.cs
+++ b/integration_tests/custom_resource_hooks/step1-create/Updatable.cs
@@ -21,6 +21,9 @@ public sealed class UpdatableArgs : Pulumi.ResourceArgs
     [Input("value", required: true)]
     public Input<string> Value { get; set; } = null!;
 
+    [Input("secret")]
+    public Input<string> Secret { get; set; } = null;
+
     public UpdatableArgs()
     {
     }

--- a/integration_tests/resource_hooks_test.go
+++ b/integration_tests/resource_hooks_test.go
@@ -43,6 +43,8 @@ func TestDotnetCustomResourceHooks(t *testing.T) {
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			requirePrinted(t, stack, "info", "BeforeCreate: value is step1")
 			requirePrinted(t, stack, "info", "AfterCreate: value is step1")
+			requirePrinted(t, stack, "info", "BeforeCreate: secret is secret")
+			requirePrinted(t, stack, "info", "BeforeCreate: secret is hello secret")
 		},
 		EditDirs: []integration.EditDir{
 			// Step 2 -- update the resource to test update hooks.

--- a/sdk/Pulumi/Deployment/Deployment_RegisterResourceHook.cs
+++ b/sdk/Pulumi/Deployment/Deployment_RegisterResourceHook.cs
@@ -90,7 +90,14 @@ namespace Pulumi
             foreach (var kv in s.Fields)
             {
                 var outputData = Serialization.Deserializer.Deserialize(kv.Value);
-                builder.Add(kv.Key, outputData.Value);
+                if (outputData.IsSecret)
+                {
+                    builder.Add(kv.Key, Output.CreateSecret(outputData.Value));
+                }
+                else
+                {
+                    builder.Add(kv.Key, outputData.Value);
+                }
             }
 
             return builder.ToImmutable();


### PR DESCRIPTION
Dotnet part of https://github.com/pulumi/pulumi/issues/20520

Secret values should be Outputs marked as secret, instead of the JSON wire representation of secret values.
