### PR TITLE
Allow non-custom child resources to override provider list

### DIFF
--- a/.changes/unreleased/bug-fixes-731.yaml
+++ b/.changes/unreleased/bug-fixes-731.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Allow non-custom child resources to override parent provider list
+time: 2025-10-25T16:34:49.50326-07:00
+custom:
+    PR: "731"

--- a/sdk/Pulumi/Resources/Resource.cs
+++ b/sdk/Pulumi/Resources/Resource.cs
@@ -261,7 +261,7 @@ namespace Pulumi
                     ? new List<ProviderResource> { options.Provider }
                     : componentOpts?.Providers;
 
-                this._providers = this._providers.AddRange(ConvertToProvidersMap(providerList));
+                this._providers = this._providers.SetItems(ConvertToProvidersMap(providerList));
             }
 
             this._protect = options.Protect;


### PR DESCRIPTION
Currently, if you have a setup like this, it will throw an error when running `pulumi up`:

```cs
Deployment.RunAsync( () => {
  var rootProvider = new Provider( "root-provider", new ProviderArgs {} );
  var resource = new A( "a", new ComponentResourceOptions { Provider = rootProvider } );
});

public class A : ComponentResource {
  public A ( string name, ComponentResourceOptions? options = null ) : base( "test:a", name, options ) {
    var b = new B( "b", new ComponentResourceOptions { Parent = this } ); // children implicitly inherit providers
  } 
}

public class B : ComponentResource {
  public B ( string name, ComponentResourceOptions? options = null ) : base( "test:b", name, options ) {
    var provider = new Provider( "b-provider", new ProviderArgs {}, new CustomResourceOptions { Parent = this } );
    var c = new C( "c", new ComponentResourceOptions { Parent = this, Provider = provider } ); // this will error
  }
}

public class C : ComponentResource {
  public C ( string name, ComponentResourceOptions? options = null ) : base( "test:c", name, options ) {
    // ...
  } 
}
```

The relevant bits of the resulting exception (using the kubernetes provider for the example):
```
error: Running program '...' failed with an unhandled exception:
    System.ArgumentException: An element with the same key but a different value already exists. Key: 'kubernetes'
       at HashBucket System.Collections.Immutable.ImmutableDictionary<TKey, TValue>+HashBucket.Add(TKey key, TValue value, IEqualityComparer<KeyValuePair<TKey, TValue>> keyOnlyComparer, IEqualityComparer<TValue> valueComparer, KeyCollisionBehavior behavior, out OperationResult result)
       at MutationResult System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.AddRange(IEnumerable<KeyValuePair<TKey, TValue>> items, MutationInput origin, KeyCollisionBehavior collisionBehavior) x 2
       at new Pulumi.Resource(string type, string name, bool custom, ResourceArgs args, ResourceOptions options, bool remote, bool dependency, RegisterPackageRequest registerPackageRequest)
```

Since Resource uses AddRange internally, it will attempt to combine the inherited providers list and the new provider, resulting in a conflict. If we use SetItems instead, it allows the child to override the provider without an error.

This change is backwards compatible as far as I can tell, as it doesn't affect previously working situations where non-conflicting providers are added to the dictionary.