### PR TITLE
Implement `Language.Link`

### DIFF
--- a/.changes/unreleased/Improvements-737.yaml
+++ b/.changes/unreleased/Improvements-737.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: Implement `Language.Link`
+time: 2025-11-05T09:53:49.574896+01:00
+custom:
+    PR: "737"

--- a/pulumi-language-dotnet/main.go
+++ b/pulumi-language-dotnet/main.go
@@ -1383,3 +1383,105 @@ func (host *dotnetLanguageHost) GenerateProgram(
 		Diagnostics: rpcDiagnostics,
 	}, nil
 }
+
+func (host *dotnetLanguageHost) Link(
+	ctx context.Context, req *pulumirpc.LinkRequest,
+) (*pulumirpc.LinkResponse, error) {
+	logging.V(5).Infof("Linking %+v in %s", req.Packages, req.Info.RootDirectory)
+
+	loader, err := schema.NewLoaderClient(req.LoaderTarget)
+	if err != nil {
+		return nil, err
+	}
+	defer loader.Close()
+	cachedLoader := schema.NewCachedLoader(loader)
+
+	instructions := "Add the following to your .csproj file of the program:\n"
+	instructions += "\n"
+	instructions += "  <DefaultItemExcludes>$(DefaultItemExcludes);sdks/**/*.cs</DefaultItemExcludes>\n"
+	instructions += "\n"
+	if len(req.Packages) == 1 {
+		instructions += "You can then use the SDK in your .NET code with:\n"
+	} else {
+		instructions += "You can then use the SDKs in your .NET code with:\n"
+	}
+
+	for _, dep := range req.Packages {
+		cmd := exec.Command("dotnet", "add", "reference", dep.Path) //nolint:gosec
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		if err := cmd.Run(); err != nil {
+			return nil, fmt.Errorf("dotnet error: %w", err)
+		}
+
+		var version *semver.Version
+		v, err := semver.New(dep.Package.Version)
+		if err != nil {
+			logging.V(5).Infof("Invalid version %s for package %s", dep.Package.Version, dep.Package.Name)
+		} else {
+			version = v
+		}
+		var param *schema.ParameterizationDescriptor
+		if dep.Package.Parameterization != nil {
+			param = &schema.ParameterizationDescriptor{
+				Name:  dep.Package.Parameterization.Name,
+				Value: dep.Package.Parameterization.Value,
+			}
+			if dep.Package.Parameterization.Version != "" {
+				v, err := semver.New(dep.Package.Parameterization.Version)
+				if err != nil {
+					logging.V(5).Infof("Invalid version %s for package %s", dep.Package.Version, dep.Package.Name)
+				} else {
+					param.Version = *v
+				}
+			}
+		}
+		packageDesc := &schema.PackageDescriptor{
+			Name:             dep.Package.Name,
+			Version:          version,
+			DownloadURL:      dep.Package.Server,
+			Parameterization: param,
+		}
+
+		pkgRef, err := schema.LoadPackageReferenceV2(ctx, cachedLoader, packageDesc)
+		if err != nil {
+			return nil, err
+		}
+		pkg, err := pkgRef.Definition()
+		if err != nil {
+			return nil, err
+		}
+		if err := pkg.ImportLanguages(map[string]schema.Language{"csharp": dotnetcodegen.Importer}); err != nil {
+			return nil, err
+		}
+
+		namespace := "Pulumi"
+		if pkg.Namespace != "" {
+			namespace = pkg.Namespace
+		}
+		if info, ok := pkg.Language["csharp"]; ok {
+			if info, ok := info.(dotnetcodegen.CSharpPackageInfo); ok {
+				if info.RootNamespace != "" {
+					namespace = info.RootNamespace
+				}
+			}
+		}
+		instructions += "\n"
+		instructions += fmt.Sprintf("  using %s.%s;\n", csharpPackageName(namespace), csharpPackageName(pkg.Name))
+	}
+	instructions += "\n"
+
+	return &pulumirpc.LinkResponse{
+		ImportInstructions: instructions,
+	}, nil
+}
+
+// csharpPackageName converts a package name to a C#-friendly package name.
+// for example "aws-api-gateway" becomes "AwsApiGateway".
+func csharpPackageName(pkgName string) string {
+	parts := strings.Split(pkgName, "-")
+	for i, part := range parts {
+		parts[i] = dotnetcodegen.Title(part)
+	}
+	return strings.Join(parts, "")
+}


### PR DESCRIPTION
This takes the functionality from https://github.com/pulumi/pulumi/blob/96d8ca5799400653b31926cf3c1574e174c0f46e/pkg/cmd/pulumi/packages/packages.go#L410-L440 and moves them to the `Link` RPC.

There’s a circular dependency in testing this. We need to first update the code here, then update pu/pu (https://github.com/pulumi/home/issues/4376) to use the `Link` RPC. I have tested this locally with a modified pulumi CLI.

Closes https://github.com/pulumi/home/issues/4375
