### PR TITLE
Don't throw when registering hooks/transforms in mocks

### DIFF
--- a/.changes/unreleased/bug-fixes-742.yaml
+++ b/.changes/unreleased/bug-fixes-742.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Fix error being thrown from using hooks/transforms in mock tests
+time: 2025-11-06T11:42:45.52386442Z
+custom:
+    PR: "742"

--- a/sdk/Pulumi/Testing/MockMonitor.cs
+++ b/sdk/Pulumi/Testing/MockMonitor.cs
@@ -227,12 +227,12 @@ namespace Pulumi.Testing
 
         public Task RegisterStackInvokeTransform(Pulumirpc.Callback callback)
         {
-            throw new NotImplementedException();
+            return Task.CompletedTask;
         }
 
         public Task RegisterResourceHookAsync(RegisterResourceHookRequest request)
         {
-            throw new NotImplementedException();
+            return Task.CompletedTask;
         }
 
         public Task SignalAndWaitForShutdownAsync()


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/20874

While we advertised support for hooks/transforms from the mock server, our implementation threw a `NotImplemented` exception rather than just returning successfully. This meant using these features in tests would error.