### PR TITLE
Add a couple of missing implict casts to InputUnion

### DIFF
--- a/.changes/unreleased/Improvements-744.yaml
+++ b/.changes/unreleased/Improvements-744.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Add a couple of missing implict casts to InputUnion
+time: 2025-11-07T13:19:30.699748689Z
+custom:
+    PR: "744"

--- a/sdk/Pulumi/Core/InputUnion.cs
+++ b/sdk/Pulumi/Core/InputUnion.cs
@@ -30,6 +30,12 @@ namespace Pulumi
         public static implicit operator InputUnion<T0, T1>(T1 value)
             => Output.Create(value);
 
+        public static implicit operator InputUnion<T0, T1>(Input<T0> value)
+            => new InputUnion<T0, T1>(value.Apply(Union<T0, T1>.FromT0));
+
+        public static implicit operator InputUnion<T0, T1>(Input<T1> value)
+            => new InputUnion<T0, T1>(value.Apply(Union<T0, T1>.FromT1));
+
         public static implicit operator InputUnion<T0, T1>(Output<Union<T0, T1>> value)
             => new InputUnion<T0, T1>(value);
 


### PR DESCRIPTION
Pointed out on community slack. We were missing a couple of implicit casts to go from for example `Input<string>` to `InputUnion<string, int>`.