### PR TITLE
Tag the module on release

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -38,3 +38,11 @@ jobs:
       version: ${{ needs.info.outputs.version }}
       release-notes: ${{ github.event.release.body }}
     secrets: inherit
+
+  release-language-plugin:
+    name: release language plugin
+    needs: [info]
+    uses: ./.github/workflows/release-language-plugin.yml
+    with:
+      ref: ${{ github.event.release.tag_name }}
+      version: ${{ needs.info.outputs.version }}

--- a/.github/workflows/release-language-plugin.yml
+++ b/.github/workflows/release-language-plugin.yml
@@ -1,0 +1,30 @@
+name: Release Language Plugin
+
+permissions:
+  contents: write
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        description: "GitHub ref to use"
+        type: string
+      version:
+        required: true
+        description: "Version to produce"
+        type: string
+
+jobs:
+  tag-language-plugin:
+    name: Tag language plugin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - run: git tag pulumi-language-dotnet/v${{ inputs.version }}
+      - run: git push origin pulumi-language-dotnet/v${{ inputs.version }}


### PR DESCRIPTION
[`pulumi-language-dotnet`](https://github.com/pulumi/pulumi-dotnet/tree/main/pulumi-language-dotnet) is now a module that needs to be consumed downstream, so it should be tagged on release.