### PR TITLE
fix release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To release a new version use `changie` to update the changelog file, open a PR f
 ```bash
 changie batch auto
 changie merge
-git add .changes
+git add .changes CHANGELOG.md
 git commit -m "Changelog for $(changie latest)"
 ```
 


### PR DESCRIPTION
During release we also need to add `CHANGELOG.md`, not just `.changes`. Update `CONTRIBUTING.md` to include that.