### PR TITLE
Install netcoredbg on Windows via curl

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -176,15 +176,13 @@ jobs:
           curl -sSL https://github.com/Samsung/netcoredbg/releases/download/3.1.1-1042/netcoredbg-linux-amd64.tar.gz -o netcoredbg.tar.gz
           tar xzf netcoredbg.tar.gz
           sudo cp netcoredbg/* /usr/bin/
-      - uses: MinoruSekine/setup-scoop@v4.0.2
-        if: startsWith(matrix.os, 'windows')
-        with:
-          buckets: extras
-          apps: doxygen plantuml
       - name: Install netcoredbg (Windows)
         if: startsWith(matrix.os, 'windows')
+        shell: bash
         run: |
-          scoop install netcoredbg
+          curl -sSL https://github.com/Samsung/netcoredbg/releases/download/3.1.1-1042/netcoredbg-win64.zip -o netcoredbg.zip
+          unzip netcoredbg.zip
+          echo "$(pwd)/netcoredbg" >> $GITHUB_PATH
       - name: Install netcoredbg (MacOS)
         if: startsWith(matrix.os, 'macos')
         id: netcoredbg


### PR DESCRIPTION
We were using scoop to install this, but we're seeing a lot of flakes
when setting up scoop itself due to 503 or 403s.

Download the binary release from GitHub instead and add it to our path.