### PR TITLE
Split codegen tests into a separate CI job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -227,6 +227,37 @@ jobs:
       - name: Conformance tests
         run: make test_conformance
 
+  codegen-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        dotnet-version: [8.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        continue-on-error: true
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
+      - name: Set TARGET_FRAMEWORK
+        run: echo "TARGET_FRAMEWORK=net${{ matrix.dotnet-version }}" >> $GITHUB_ENV
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Setup mise and install tools
+        uses: jdx/mise-action@v3.6.1
+      - name: Set dotnet version from matrix
+        run: mise use vfox:dotnet@${{ matrix.dotnet-version }}
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6
+        with:
+          pulumi-version: dev
+      - name: Dotnet version
+        run: dotnet --version
+      - name: Codegen tests
+        run: make test_codegen
+
   info:
     name: gather
     runs-on: ubuntu-latest
@@ -256,7 +287,7 @@ jobs:
 
   release-dev-sdk:
     name: release-dev-sdk
-    needs: [build, integration-tests, conformance-tests, info]
+    needs: [build, integration-tests, conformance-tests, codegen-tests, info]
     uses: ./.github/workflows/release-sdk.yml
     if: ${{ github.event_name == 'merge_group' }}
     with:

--- a/Makefile
+++ b/Makefile
@@ -103,14 +103,18 @@ lint_integration_tests_fix: format_integration_tests
 	cd integration_tests && golangci-lint run $(GOLANGCI_LINT_ARGS) --fix --config ../.golangci.yml --timeout 5m --path-prefix integration_tests
 
 .PHONY: test
-test: test_conformance test_integration test_sdk test_sdk_automation
+test: test_conformance test_codegen test_integration test_sdk test_sdk_automation
 
 .PHONY: test_fast
 test_fast: test_sdk test_sdk_automation
 
 .PHONY: test_conformance
 test_conformance: build
-	cd pulumi-language-dotnet && gotestsum -- $(GO_TEST_FILTER_FLAG) --timeout 60m ./...
+	cd pulumi-language-dotnet && gotestsum -- $(GO_TEST_FILTER_FLAG) --timeout 60m .
+
+.PHONY: test_codegen
+test_codegen: build
+	cd pulumi-language-dotnet && gotestsum -- $(GO_TEST_FILTER_FLAG) --timeout 60m ./codegen/...
 
 .PHONY: test_integration
 test_integration: build


### PR DESCRIPTION
The conformance test job previously ran all tests under `pulumi-language-dotnet/...` including both the language tests and the codegen tests (`TestGeneratePackage`, `TestGenerateProgram`). We're seeing a large amount of flakes when these run together, mostly due concurrent uses of nuget tripping over themselves.