### PR TITLE
fix(sdk): Merge ResourceTransforms in CustomResourceOptions.Merge

### DIFF
--- a/.changes/unreleased/bug-fixes-958.yaml
+++ b/.changes/unreleased/bug-fixes-958.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Fix `ResourceTransforms` being silently dropped when `CustomResourceOptions.Merge` is called (affects all generated SDK resources using the `MakeResourceOptions` pattern)
+time: 2026-04-10T00:00:00Z
+custom:
+  PR: "958"
+component: sdk

--- a/integration_tests/transformations_remote/Program.cs
+++ b/integration_tests/transformations_remote/Program.cs
@@ -166,6 +166,27 @@ class TransformsStack : Stack
         args.Prefix = "hello";
         args.Length = 135;
         res9.Invoke(args);
+
+        // Scenario #10 - ResourceTransforms survive a MakeResourceOptions-style Merge call.
+        // All generated Pulumi SDK resources call CustomResourceOptions.Merge in their MakeResourceOptions
+        // helper before passing options to the base Resource constructor. This test uses
+        // RandomWithMakeOptions, which replicates that pattern, to verify transforms are not dropped.
+        var res10 = new RandomWithMakeOptions("res10", new RandomArgs { Length = 5 }, new CustomResourceOptions
+        {
+            ResourceTransforms =
+            {
+                async (tfArgs, _) =>
+                {
+                    if (tfArgs.Type == "testprovider:index:Random")
+                    {
+                        var resultArgs = tfArgs.Args;
+                        resultArgs = resultArgs.SetItem("prefix", "make-options-transform");
+                        return new ResourceTransformResult(resultArgs, tfArgs.Options);
+                    }
+                    return null;
+                }
+            }
+        });
     }
 
     // Scenario #3 - apply a transformation to the Stack to transform all (future) resources in the stack

--- a/integration_tests/transformations_remote/Program.cs
+++ b/integration_tests/transformations_remote/Program.cs
@@ -180,7 +180,9 @@ class TransformsStack : Stack
                     if (tfArgs.Type == "testprovider:index:Random")
                     {
                         var resultArgs = tfArgs.Args;
-                        resultArgs = resultArgs.SetItem("prefix", "make-options-transform");
+                        // Use length (not prefix) because the stack transform (Scenario #3) sets
+                        // prefix="stackDefault" last and would overwrite a prefix change here.
+                        resultArgs = resultArgs.SetItem("length", 100);
                         return new ResourceTransformResult(resultArgs, tfArgs.Options);
                     }
                     return null;

--- a/integration_tests/transformations_remote/Random.cs
+++ b/integration_tests/transformations_remote/Random.cs
@@ -29,6 +29,28 @@ public sealed class RandomArgs : Pulumi.ResourceArgs
 	}
 }
 
+/// <summary>
+/// A Random resource that simulates the MakeResourceOptions pattern used by all generated Pulumi SDK
+/// resources. The constructor merges caller-supplied options with a set of defaults via
+/// <see cref="CustomResourceOptions.Merge"/>, which is the code path that previously dropped
+/// <see cref="ResourceOptions.ResourceTransforms"/>.
+/// </summary>
+public partial class RandomWithMakeOptions : Pulumi.CustomResource
+{
+    public RandomWithMakeOptions(string name, RandomArgs args, CustomResourceOptions? options = null)
+        : base("testprovider:index:Random", name, args, MakeResourceOptions(options, ""))
+    {
+    }
+
+    private static CustomResourceOptions MakeResourceOptions(CustomResourceOptions? options, Input<string>? id)
+    {
+        var defaultOptions = new CustomResourceOptions();
+        var merged = CustomResourceOptions.Merge(defaultOptions, options);
+        merged.Id = id ?? merged.Id;
+        return merged;
+    }
+}
+
 public partial class RandomProvider : global::Pulumi.ProviderResource
 {
 	public RandomProvider(string name, RandomProviderArgs? args = null, CustomResourceOptions? options = null)

--- a/integration_tests/transformations_simple_test.go
+++ b/integration_tests/transformations_simple_test.go
@@ -124,6 +124,7 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 	foundRes6 := false
 	foundRes7 := false
 	foundRes8 := false
+	foundRes10 := false
 	for _, res := range stack.Deployment.Resources {
 		// "res1" has a transformation which adds additionalSecretOutputs
 		if res.URN.Name() == "res1" {
@@ -201,6 +202,16 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			assert.Equal(t, res.Type, tokens.Type(randomResName))
 			assert.NotContains(t, res.Provider, "default")
 		}
+		// "res10" uses RandomWithMakeOptions which calls CustomResourceOptions.Merge in its
+		// constructor (matching the MakeResourceOptions pattern in all generated SDK resources).
+		// The transform should survive the merge and set the prefix.
+		if res.URN.Name() == "res10" {
+			foundRes10 = true
+			assert.Equal(t, res.Type, tokens.Type(randomResName))
+			prefix := res.Inputs["prefix"]
+			assert.NotNil(t, prefix)
+			assert.Equal(t, "make-options-transform", prefix.(string))
+		}
 	}
 	assert.True(t, foundRes1)
 	assert.True(t, foundRes2Child)
@@ -210,4 +221,5 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 	assert.True(t, foundRes6)
 	assert.True(t, foundRes7)
 	assert.True(t, foundRes8)
+	assert.True(t, foundRes10)
 }

--- a/integration_tests/transformations_simple_test.go
+++ b/integration_tests/transformations_simple_test.go
@@ -204,13 +204,14 @@ func Validator(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 		}
 		// "res10" uses RandomWithMakeOptions which calls CustomResourceOptions.Merge in its
 		// constructor (matching the MakeResourceOptions pattern in all generated SDK resources).
-		// The transform should survive the merge and set the prefix.
+		// The transform sets length=100 (not prefix, because the stack transform overwrites
+		// prefix="stackDefault" last). Verifying length confirms the transform survived Merge.
 		if res.URN.Name() == "res10" {
 			foundRes10 = true
 			assert.Equal(t, res.Type, tokens.Type(randomResName))
-			prefix := res.Inputs["prefix"]
-			assert.NotNil(t, prefix)
-			assert.Equal(t, "make-options-transform", prefix.(string))
+			length := res.Inputs["length"]
+			assert.NotNil(t, length)
+			assert.Equal(t, 100.0, length.(float64))
 		}
 	}
 	assert.True(t, foundRes1)

--- a/sdk/Pulumi.Tests/Resources/MergeResourceOptionsTests.cs
+++ b/sdk/Pulumi.Tests/Resources/MergeResourceOptionsTests.cs
@@ -1,5 +1,8 @@
 // Copyright 2016-2022, Pulumi Corporation
 
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using System.Collections.Generic;
 
@@ -7,6 +10,85 @@ namespace Pulumi.Tests.Resources
 {
     public class MergeResourceOptionsTests
     {
+        // Regression test for https://github.com/pulumi/pulumi-dotnet/issues/957
+        // ResourceTransforms must survive CustomResourceOptions.Merge (used by all generated SDK resources
+        // via their MakeResourceOptions pattern).
+
+        [Fact]
+        public void MergeCustom_ResourceTransforms_FromOptions2_ArePropagated()
+        {
+            ResourceTransform transform = (_, _) => Task.FromResult<ResourceTransformResult?>(null);
+
+            var o1 = new CustomResourceOptions();
+            var o2 = new CustomResourceOptions { ResourceTransforms = { transform } };
+
+            var result = CustomResourceOptions.Merge(o1, o2);
+
+            Assert.Single(result.ResourceTransforms);
+            Assert.Contains(transform, result.ResourceTransforms);
+        }
+
+        [Fact]
+        public void MergeCustom_ResourceTransforms_FromBothOptions_AreCombined()
+        {
+            ResourceTransform transform1 = (_, _) => Task.FromResult<ResourceTransformResult?>(null);
+            ResourceTransform transform2 = (_, _) => Task.FromResult<ResourceTransformResult?>(null);
+
+            var o1 = new CustomResourceOptions { ResourceTransforms = { transform1 } };
+            var o2 = new CustomResourceOptions { ResourceTransforms = { transform2 } };
+
+            var result = CustomResourceOptions.Merge(o1, o2);
+
+            Assert.Equal(2, result.ResourceTransforms.Count);
+            Assert.Contains(transform1, result.ResourceTransforms);
+            Assert.Contains(transform2, result.ResourceTransforms);
+        }
+
+        [Fact]
+        public void MergeCustom_ResourceTransforms_FromOptions1_ArePreservedWhenOptions2IsEmpty()
+        {
+            ResourceTransform transform = (_, _) => Task.FromResult<ResourceTransformResult?>(null);
+
+            var o1 = new CustomResourceOptions { ResourceTransforms = { transform } };
+            var o2 = new CustomResourceOptions();
+
+            var result = CustomResourceOptions.Merge(o1, o2);
+
+            Assert.Single(result.ResourceTransforms);
+            Assert.Contains(transform, result.ResourceTransforms);
+        }
+
+        [Fact]
+        public void MergeComponent_ResourceTransforms_FromOptions2_ArePropagated()
+        {
+            ResourceTransform transform = (_, _) => Task.FromResult<ResourceTransformResult?>(null);
+
+            var o1 = new ComponentResourceOptions();
+            var o2 = new ComponentResourceOptions { ResourceTransforms = { transform } };
+
+            var result = ComponentResourceOptions.Merge(o1, o2);
+
+            Assert.Single(result.ResourceTransforms);
+            Assert.Contains(transform, result.ResourceTransforms);
+        }
+
+        [Fact]
+        public void MergeComponent_ResourceTransforms_FromBothOptions_AreCombined()
+        {
+            ResourceTransform transform1 = (_, _) => Task.FromResult<ResourceTransformResult?>(null);
+            ResourceTransform transform2 = (_, _) => Task.FromResult<ResourceTransformResult?>(null);
+
+            var o1 = new ComponentResourceOptions { ResourceTransforms = { transform1 } };
+            var o2 = new ComponentResourceOptions { ResourceTransforms = { transform2 } };
+
+            var result = ComponentResourceOptions.Merge(o1, o2);
+
+            Assert.Equal(2, result.ResourceTransforms.Count);
+            Assert.Contains(transform1, result.ResourceTransforms);
+            Assert.Contains(transform2, result.ResourceTransforms);
+        }
+
+
         [Fact]
         public void MergeCustom()
         {

--- a/sdk/Pulumi/Resources/ResourceOptions_Merge.cs
+++ b/sdk/Pulumi/Resources/ResourceOptions_Merge.cs
@@ -20,6 +20,7 @@ namespace Pulumi
 
             options1.IgnoreChanges.AddRange(options2.IgnoreChanges);
             options1.ResourceTransformations.AddRange(options2.ResourceTransformations);
+            options1.ResourceTransforms.AddRange(options2.ResourceTransforms);
             options1.Aliases.AddRange(options2.Aliases);
             options1.ReplaceOnChanges.AddRange(options2.ReplaceOnChanges);
             options1.HideDiffs.AddRange(options2.HideDiffs);


### PR DESCRIPTION
ResourceTransforms were being silently dropped when CustomResourceOptions.Merge was called. This affected all generated Pulumi SDK resources that use the MakeResourceOptions pattern to merge default options before passing to the base Resource constructor.

Add the missing line to merge ResourceTransforms in MergeNormalOptions, mirroring the existing behavior for ResourceTransformations (the older synchronous API).

Includes comprehensive unit tests and an integration test scenario (RandomWithMakeOptions) that validates transforms survive the merge.

Fixes #957
