### PR TITLE
Clarify docs on remote parameter of ComponentResource

### DIFF
--- a/.changes/unreleased/improvements-963.yaml
+++ b/.changes/unreleased/improvements-963.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: improvements
+body: Clarify docs on the `remote` parameter of `ComponentResource` / `Resource`
+time: 2026-04-14T13:45:00.000000-04:00
+custom:
+    PR: "963"

--- a/.changes/unreleased/improvements-963.yaml
+++ b/.changes/unreleased/improvements-963.yaml
@@ -1,5 +1,5 @@
 component: sdk
-kind: improvements
+kind: Improvements
 body: Clarify docs on the `remote` parameter of `ComponentResource` / `Resource`
 time: 2026-04-14T13:45:00.000000-04:00
 custom:

--- a/pulumi-language-dotnet/codegen/gen_program_test.go
+++ b/pulumi-language-dotnet/codegen/gen_program_test.go
@@ -40,7 +40,7 @@ import (
 // PulumiDotnetSDKVersion is the version of the Pulumi .NET SDK to use in program-gen tests
 //
 // It should be kept up to date with this repo's released version.
-const PulumiDotnetSDKVersion = "3.102.0"
+const PulumiDotnetSDKVersion = "3.102.1"
 
 func TestGenerateProgram(t *testing.T) {
 	t.Parallel()

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -2154,7 +2154,13 @@
             <param name="name">The unique name of the resource.</param>
             <param name="args">The arguments to use to populate the new resource.</param>
             <param name="options">A bag of options that control this resource's behavior.</param>
-            <param name="remote">True if this is a remote component resource.</param>
+            <param name="remote">
+            This parameter is intended for use by code-generated component SDKs;
+            end users authoring their own <see cref="T:Pulumi.ComponentResource"/> subclasses
+            should leave this at its default (<c>false</c>). When <c>true</c>, the
+            component's children are constructed by the engine rather than in this
+            process, and the constructor skips local child registration accordingly.
+            </param>
         </member>
         <member name="M:Pulumi.ComponentResource.#ctor(System.String,System.String,Pulumi.ResourceArgs,Pulumi.ComponentResourceOptions,System.Boolean,Pulumi.RegisterPackageRequest)">
             <summary>
@@ -2168,7 +2174,13 @@
             <param name="name">The unique name of the resource.</param>
             <param name="args">The arguments to use to populate the new resource.</param>
             <param name="options">A bag of options that control this resource's behavior.</param>
-            <param name="remote">True if this is a remote component resource.</param>
+            <param name="remote">
+            This parameter is intended for use by code-generated component SDKs;
+            end users authoring their own <see cref="T:Pulumi.ComponentResource"/> subclasses
+            should leave this at its default (<c>false</c>). When <c>true</c>, the
+            component's children are constructed by the engine rather than in this
+            process, and the constructor skips local child registration accordingly.
+            </param>
             <param name="registerPackageRequest">Package parameterization options.</param>
         </member>
         <member name="M:Pulumi.ComponentResource.RegisterOutputs">
@@ -2656,7 +2668,13 @@
             <param name="custom">True to indicate that this is a custom resource, managed by a plugin.</param>
             <param name="args">The arguments to use to populate the new resource.</param>
             <param name="options">A bag of options that control this resource's behavior.</param>
-            <param name="remote">True if this is a remote component resource.</param>
+            <param name="remote">
+            This parameter is intended for use by code-generated component SDKs;
+            end users authoring their own <see cref="T:Pulumi.ComponentResource"/> subclasses
+            should leave this at its default (<c>false</c>). When <c>true</c>, the
+            component's children are constructed by the engine rather than in this
+            process, and the constructor skips local child registration accordingly.
+            </param>
             <param name="dependency">True if this is a synthetic resource used internally for dependency tracking.</param>
             <param name="registerPackageRequest">Options for package parameterization.</param>
         </member>

--- a/sdk/Pulumi/Resources/ComponentResource.cs
+++ b/sdk/Pulumi/Resources/ComponentResource.cs
@@ -44,7 +44,13 @@ namespace Pulumi
         /// <param name="name">The unique name of the resource.</param>
         /// <param name="args">The arguments to use to populate the new resource.</param>
         /// <param name="options">A bag of options that control this resource's behavior.</param>
-        /// <param name="remote">True if this is a remote component resource.</param>
+        /// <param name="remote">
+        /// This parameter is intended for use by code-generated component SDKs;
+        /// end users authoring their own <see cref="ComponentResource"/> subclasses
+        /// should leave this at its default (<c>false</c>). When <c>true</c>, the
+        /// component's children are constructed by the engine rather than in this
+        /// process, and the constructor skips local child registration accordingly.
+        /// </param>
         public ComponentResource(
             string type, string name, ResourceArgs? args, ComponentResourceOptions? options = null, bool remote = false)
             : this(type, name, args ?? ResourceArgs.Empty, options ?? new ComponentResourceOptions(), remote, registerPackageRequest: null)
@@ -63,7 +69,13 @@ namespace Pulumi
         /// <param name="name">The unique name of the resource.</param>
         /// <param name="args">The arguments to use to populate the new resource.</param>
         /// <param name="options">A bag of options that control this resource's behavior.</param>
-        /// <param name="remote">True if this is a remote component resource.</param>
+        /// <param name="remote">
+        /// This parameter is intended for use by code-generated component SDKs;
+        /// end users authoring their own <see cref="ComponentResource"/> subclasses
+        /// should leave this at its default (<c>false</c>). When <c>true</c>, the
+        /// component's children are constructed by the engine rather than in this
+        /// process, and the constructor skips local child registration accordingly.
+        /// </param>
         /// <param name="registerPackageRequest">Package parameterization options.</param>
 #pragma warning disable RS0022 // Constructor make noninheritable base class inheritable
         public ComponentResource(

--- a/sdk/Pulumi/Resources/Resource.cs
+++ b/sdk/Pulumi/Resources/Resource.cs
@@ -122,7 +122,13 @@ namespace Pulumi
         /// <param name="custom">True to indicate that this is a custom resource, managed by a plugin.</param>
         /// <param name="args">The arguments to use to populate the new resource.</param>
         /// <param name="options">A bag of options that control this resource's behavior.</param>
-        /// <param name="remote">True if this is a remote component resource.</param>
+        /// <param name="remote">
+        /// This parameter is intended for use by code-generated component SDKs;
+        /// end users authoring their own <see cref="ComponentResource"/> subclasses
+        /// should leave this at its default (<c>false</c>). When <c>true</c>, the
+        /// component's children are constructed by the engine rather than in this
+        /// process, and the constructor skips local child registration accordingly.
+        /// </param>
         /// <param name="dependency">True if this is a synthetic resource used internally for dependency tracking.</param>
         /// <param name="registerPackageRequest">Options for package parameterization.</param>
         private protected Resource(


### PR DESCRIPTION
## Summary
- Mirrors pulumi/pulumi#22603 for the .NET SDK.
- The `remote` parameter on `Resource` / `ComponentResource` constructors is intended for use by code-generated component SDKs, not by end users. Previous docs ("True if this is a remote component resource.") were circular and gave no guidance.

Related: pulumi/pulumi#21377

## Test plan
- [ ] Docs-only change; no runtime behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)