### PR TITLE
Ensure 'main' is always used to select project to use

### DIFF
--- a/.changes/unreleased/bug-fixes-55.yaml
+++ b/.changes/unreleased/bug-fixes-55.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: bug-fixes
+body: Ensure that 'main' is always respected for selecting projects to run
+time: 2026-04-15T20:19:01.497071+01:00
+custom:
+    PR: "55"

--- a/integration_tests/integration_dotnet_test.go
+++ b/integration_tests/integration_dotnet_test.go
@@ -559,6 +559,29 @@ func TestSlnMultipleNested(t *testing.T) {
 	})
 }
 
+// TestSlnMainEntrypoint tests that an explicit csproj "main" entrypoint is honored
+// when a sibling .sln file is present.
+//
+//nolint:paralleltest // ProgramTest calls testing.T.Parallel
+func TestSlnMainEntrypoint(t *testing.T) {
+	validation := func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+		var foundStdout int
+		for _, ev := range stack.Events {
+			if de := ev.DiagnosticEvent; de != nil {
+				if strings.Contains(de.Message, "With sln main") {
+					foundStdout++
+				}
+			}
+		}
+		assert.Equal(t, 1, foundStdout)
+	}
+	testDotnetProgram(t, &integration.ProgramTestOptions{
+		Dir:                    "sln_main_entrypoint",
+		Quick:                  true,
+		ExtraRuntimeValidation: validation,
+	})
+}
+
 //nolint:paralleltest // ProgramTest calls testing.T.Parallel
 func TestProvider(t *testing.T) {
 	testDotnetProgram(t, &integration.ProgramTestOptions{

--- a/integration_tests/sln_main_entrypoint/.gitignore
+++ b/integration_tests/sln_main_entrypoint/.gitignore
@@ -1,0 +1,3 @@
+/.pulumi/
+[Bb]in/
+[Oo]bj/

--- a/integration_tests/sln_main_entrypoint/Program.cs
+++ b/integration_tests/sln_main_entrypoint/Program.cs
@@ -1,0 +1,15 @@
+// Copyright 2021, Pulumi Corporation.  All rights reserved.
+
+using System;
+using System.Threading.Tasks;
+using Pulumi;
+
+class Program
+{
+    static Task<int> Main(string[] args)
+    {
+        return Deployment.RunAsync(() => {
+            Console.WriteLine("With sln main");
+        });
+    }
+}

--- a/integration_tests/sln_main_entrypoint/Pulumi.yaml
+++ b/integration_tests/sln_main_entrypoint/Pulumi.yaml
@@ -1,0 +1,4 @@
+name: sln_main_entrypoint
+description: A Pulumi program with an .sln file and explicit main csproj entrypoint.
+runtime: dotnet
+main: Sln.csproj

--- a/integration_tests/sln_main_entrypoint/Sln.csproj
+++ b/integration_tests/sln_main_entrypoint/Sln.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' != '' ">$(TARGET_FRAMEWORK)</TargetFramework>
+    <TargetFramework Condition=" '$(TARGET_FRAMEWORK)' == '' ">net8.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/integration_tests/sln_main_entrypoint/Sln.sln
+++ b/integration_tests/sln_main_entrypoint/Sln.sln
@@ -1,0 +1,30 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29411.138
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sln", "Sln.csproj", "{0A2BFED8-13F3-43A4-A38B-B5D1651203EB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0A2BFED8-13F3-43A4-A38B-B5D1651203EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A2BFED8-13F3-43A4-A38B-B5D1651203EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A2BFED8-13F3-43A4-A38B-B5D1651203EB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0A2BFED8-13F3-43A4-A38B-B5D1651203EB}.Debug|x64.Build.0 = Debug|Any CPU
+		{0A2BFED8-13F3-43A4-A38B-B5D1651203EB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0A2BFED8-13F3-43A4-A38B-B5D1651203EB}.Debug|x86.Build.0 = Debug|Any CPU
+		{0A2BFED8-13F3-43A4-A38B-B5D1651203EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A2BFED8-13F3-43A4-A38B-B5D1651203EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A2BFED8-13F3-43A4-A38B-B5D1651203EB}.Release|x64.ActiveCfg = Release|Any CPU
+		{0A2BFED8-13F3-43A4-A38B-B5D1651203EB}.Release|x64.Build.0 = Release|Any CPU
+		{0A2BFED8-13F3-43A4-A38B-B5D1651203EB}.Release|x86.ActiveCfg = Release|Any CPU
+		{0A2BFED8-13F3-43A4-A38B-B5D1651203EB}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/pulumi-language-dotnet/main.go
+++ b/pulumi-language-dotnet/main.go
@@ -256,7 +256,7 @@ func (host *dotnetLanguageHost) GetRequiredPackages(ctx context.Context,
 
 	// now, introspect the user project to see which pulumi resource packages it references.
 	possiblePulumiPackages, err := host.DeterminePossiblePulumiPackages(
-		ctx, opts.dotnetExec, engineClient, req.Info.ProgramDirectory)
+		ctx, opts.dotnetExec, engineClient, req.Info.ProgramDirectory, req.Info.EntryPoint)
 	if err != nil {
 		return nil, err
 	}
@@ -302,6 +302,7 @@ func (host *dotnetLanguageHost) DeterminePossiblePulumiPackages(
 	dotnetExec string,
 	engineClient pulumirpc.EngineClient,
 	programDirectory string,
+	entryPoint string,
 ) ([][]string, error) {
 	logging.V(5).Infof("GetRequiredPlugins: Determining pulumi packages")
 
@@ -309,7 +310,8 @@ func (host *dotnetLanguageHost) DeterminePossiblePulumiPackages(
 	// stream with the extra steps we're performing. This is just so we can determine the required
 	// plugins.  And, after the first time we do this, subsequent runs will see that the plugin is
 	// installed locally and not need to do anything.
-	args := []string{"list", "package", "--include-transitive"}
+	project := resolveProjectPath(programDirectory, entryPoint)
+	args := []string{"list", project, "package", "--include-transitive"}
 	commandStr := strings.Join(args, " ")
 	commandOutput, err := RunDotnetCommand(ctx, dotnetExec, engineClient, args, false /*logToUser*/, programDirectory)
 	if err != nil {
@@ -509,7 +511,8 @@ func DeterminePackageDependency(packageDir, packageName, packageVersion string) 
 func (host *dotnetLanguageHost) DotnetBuild(
 	ctx context.Context, dotnetExec string, req *pulumirpc.GetRequiredPackagesRequest, engineClient pulumirpc.EngineClient,
 ) error {
-	args := []string{"build", "-nologo"}
+	project := resolveProjectPath(req.Info.ProgramDirectory, req.Info.EntryPoint)
+	args := []string{"build", "-nologo", project}
 
 	// Run the `dotnet build` command.  Importantly, report the output of this to the user
 	// (ephemerally) as it is happening so they're aware of what's going on and can see the progress
@@ -595,6 +598,14 @@ func RunDotnetCommand(
 
 	_, err = infoWriter.LogToUser(fmt.Sprintf("'dotnet %v' completed successfully", commandStr))
 	return infoBuffer.String(), err
+}
+
+func resolveProjectPath(programDirectory string, entryPoint string) string {
+	if entryPoint == "" || entryPoint == "." {
+		return programDirectory
+	}
+
+	return filepath.Join(programDirectory, entryPoint)
 }
 
 type logWriter struct {
@@ -732,6 +743,9 @@ func (host *dotnetLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 		if host.dotnetBuildSucceeded {
 			args = append(args, "--no-build")
 		}
+
+		project := resolveProjectPath(req.Info.ProgramDirectory, req.Info.EntryPoint)
+		args = append(args, "--project", project)
 	}
 
 	if logging.V(5) {
@@ -929,7 +943,8 @@ func (host *dotnetLanguageHost) InstallDependencies(
 		return err
 	}
 
-	cmd := exec.CommandContext(server.Context(), dotnetbin, "build")
+	project := resolveProjectPath(req.Info.ProgramDirectory, req.Info.EntryPoint)
+	cmd := exec.CommandContext(server.Context(), dotnetbin, "build", project)
 	cmd.Dir = req.Info.ProgramDirectory
 	cmd.Stdout, cmd.Stderr = stdout, stderr
 
@@ -1001,7 +1016,8 @@ func (host *dotnetLanguageHost) GetProgramDependencies(
 	if err != nil {
 		return nil, err
 	}
-	cmdArgs := []string{"list", "package"}
+	project := resolveProjectPath(req.Info.ProgramDirectory, req.Info.EntryPoint)
+	cmdArgs := []string{"list", project, "package"}
 	if req.TransitiveDependencies {
 		cmdArgs = append(cmdArgs, "--include-transitive")
 	}
@@ -1090,10 +1106,7 @@ func (host *dotnetLanguageHost) RunPlugin(
 		// Build from source and then run. We build separately so that we can elide the build output from the
 		// user unless there's an error. You would think you could pass something like `-v=q` to `dotnet run`
 		// to get the same effect, but it doesn't work.
-		project := req.Info.ProgramDirectory
-		if req.Info.EntryPoint != "" {
-			project = filepath.Join(project, req.Info.EntryPoint)
-		}
+		project := resolveProjectPath(req.Info.ProgramDirectory, req.Info.EntryPoint)
 
 		buildArgs := []string{"build", project}
 

--- a/pulumi-language-dotnet/main_test.go
+++ b/pulumi-language-dotnet/main_test.go
@@ -264,3 +264,15 @@ func TestBuildDll(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveProjectPath(t *testing.T) {
+	t.Parallel()
+
+	programDirectory := filepath.Join("tmp", "program")
+
+	assert.Equal(t, programDirectory, resolveProjectPath(programDirectory, ""))
+	assert.Equal(t, programDirectory, resolveProjectPath(programDirectory, "."))
+	assert.Equal(t,
+		filepath.Join(programDirectory, "Infra.csproj"),
+		resolveProjectPath(programDirectory, "Infra.csproj"))
+}


### PR DESCRIPTION
Partial fix and tests for https://github.com/pulumi/pulumi-dotnet/issues/55

This updates the runtime to be consistent about always checking the 'main' option to ensure specific project files are used rather than just the current directory which can give errors if multiple project or solution files are present.