### PR TITLE
Fix dotnet codegen for nested InputMap literals

### DIFF
--- a/.changes/unreleased/bug-fixes-970.yaml
+++ b/.changes/unreleased/bug-fixes-970.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: bug-fixes
+body: Fix codegen for nested `InputMap` literals so the produced C# compiles (#833)
+time: 2026-04-19T00:00:00.000000+00:00
+custom:
+    PR: "970"

--- a/pulumi-language-dotnet/codegen/gen_program_expressions.go
+++ b/pulumi-language-dotnet/codegen/gen_program_expressions.go
@@ -1020,11 +1020,51 @@ func (g *generator) genObjectConsExpressionWithTypeName(
 		g.Fgenf(w, "\n%s{\n", g.Indent)
 		g.Indented(func() {
 			for _, item := range expr.Items {
-				g.Fgenf(w, "%s{ %.v, %.v },\n", g.Indent, item.Key, item.Value)
+				if mapT, ok := nestedMapLiteralType(item.Value); ok {
+					elem := componentInputElementType(mapT.ElementType)
+					g.Fgenf(w, "%s{ %.v, new InputMap<%s>%.v },\n", g.Indent, item.Key, elem, item.Value)
+				} else {
+					g.Fgenf(w, "%s{ %.v, %.v },\n", g.Indent, item.Key, item.Value)
+				}
 			}
 		})
 		g.Fgenf(w, "%s}", g.Indent)
 	}
+}
+
+// nestedMapLiteralType returns the MapType of a value expression when it is a
+// nested map literal (e.g. a value inside a Map(Map(T)) initializer). C# cannot
+// infer the type of an anonymous collection initializer nested inside another
+// collection initializer, so callers prefix the value with `new InputMap<T>` in
+// that case.
+func nestedMapLiteralType(value model.Expression) (*model.MapType, bool) {
+	if _, ok := unwrapIntrinsicConvert(value).(*model.ObjectConsExpression); !ok {
+		return nil, false
+	}
+	return findMapType(value.Type())
+}
+
+// findMapType searches a PCL model type for a MapType, peeling off output
+// wrappers and option/union members. Nested map literals are bound with their
+// target type carrying the outer container's shape (e.g. `union(map(T), none)`
+// for an optional map input), so we resolve through those wrappers to find it.
+//
+// When a union contains multiple MapType variants (e.g. both `map(T)` and
+// `output(map(T))`), they share an element type in every bound input we emit,
+// so returning the first match is safe.
+func findMapType(t model.Type) (*model.MapType, bool) {
+	t = pcl.UnwrapOption(model.ResolveOutputs(t))
+	switch t := t.(type) {
+	case *model.MapType:
+		return t, true
+	case *model.UnionType:
+		for _, elem := range t.ElementTypes {
+			if mapT, ok := findMapType(elem); ok {
+				return mapT, true
+			}
+		}
+	}
+	return nil, false
 }
 
 func (g *generator) genRelativeTraversal(w io.Writer,

--- a/pulumi-language-dotnet/codegen/gen_program_test.go
+++ b/pulumi-language-dotnet/codegen/gen_program_test.go
@@ -362,6 +362,70 @@ func TestGenerateProgramWithFunctionNamespaceCollision(t *testing.T) {
 		"generated code should use PulumiOutput alias for function")
 }
 
+// Regression test for https://github.com/pulumi/pulumi-dotnet/issues/833.
+//
+// A property typed as Map(Map(T)) previously generated nested collection
+// initializers with no type annotation on the inner map, producing code that
+// did not compile. The generator must now emit `new InputMap<T>` in front of
+// the nested map literal.
+func TestGenerateProgramWithNestedMapInput(t *testing.T) {
+	t.Parallel()
+
+	source := `
+resource "r" "nested:index:Resource" {
+    tableConfigurations = {
+        "COST_AND_USAGE_REPORT" = {
+            "TIME_GRANULARITY" = "HOURLY"
+            "INCLUDE_RESOURCES" = "FALSE"
+        }
+    }
+}
+`
+
+	parser := syntax.NewParser()
+	err := parser.ParseFile(strings.NewReader(source), "main.pp")
+	require.NoError(t, err)
+	require.False(t, parser.Diagnostics.HasErrors(), "parse diagnostics: %v", parser.Diagnostics)
+
+	stringType := schema.TypeSpec{Type: "string"}
+	innerMap := schema.TypeSpec{Type: "object", AdditionalProperties: &stringType}
+	outerMap := schema.TypeSpec{Type: "object", AdditionalProperties: &innerMap}
+
+	loader := &inlineLoader{
+		schemas: map[string]schema.PackageSpec{
+			"nested": {
+				Name:    "nested",
+				Version: "1.0.0",
+				Resources: map[string]schema.ResourceSpec{
+					"nested:index:Resource": {
+						InputProperties: map[string]schema.PropertySpec{
+							"tableConfigurations": {TypeSpec: outerMap},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	program, diags, err := pcl.BindProgram(parser.Files, pcl.Loader(loader))
+	require.NoError(t, err)
+	require.False(t, diags.HasErrors(), "bind diagnostics: %v", diags)
+	require.NotNil(t, program)
+
+	files, diags, err := GenerateProgram(program)
+	require.NoError(t, err)
+	require.False(t, diags.HasErrors(), "codegen diagnostics: %v", diags)
+
+	programFile, ok := files["Program.cs"]
+	require.True(t, ok, "Program.cs should be generated")
+	programText := string(programFile)
+	t.Logf("Generated Program.cs:\n%s", programText)
+
+	require.Contains(t, programText, `{ "COST_AND_USAGE_REPORT", new InputMap<string>`,
+		"nested map literal must be prefixed with an explicit InputMap<T> type annotation "+
+			"immediately before the nested initializer")
+}
+
 type inlineLoader struct {
 	schemas map[string]schema.PackageSpec
 }


### PR DESCRIPTION
## Summary

- The program code generator emitted bare collection initializers for values inside a `Map(Map(T))` property, producing C# that does not compile because the inner `{ ... }` is an anonymous collection initializer with no target type for C# to infer.
- In the map-style branch of `genObjectConsExpressionWithTypeName`, detect when the item's value is itself a nested map literal and emit an explicit `new InputMap<T>` annotation before the nested initializer. The element type is recovered from the value's bound type by peeling off output/option/union wrappers — the inner object literal itself binds as `ObjectType`, so the map shape must come from the containing convert's target type.
- Added a regression test using an inline schema exercising a `Map(Map(string))` input property.

Fixes #833.

## Before

```csharp
TableConfigurations = {
    { "COST_AND_USAGE_REPORT",
    {
        { "TIME_GRANULARITY", "HOURLY" },
    } },
};
```

## After

```csharp
TableConfigurations = {
    { "COST_AND_USAGE_REPORT", new InputMap<string>
    {
        { "TIME_GRANULARITY", "HOURLY" },
    } },
};
```

## Test plan

- [x] New unit test `TestGenerateProgramWithNestedMapInput` fails before the fix and passes after
- [x] `make test_codegen` passes with no regressions
- [x] `gofumpt` and `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)