### PR TITLE
Remove l2-rtti test from expected failures list

### DIFF
--- a/pulumi-language-dotnet/language_test.go
+++ b/pulumi-language-dotnet/language_test.go
@@ -124,7 +124,6 @@ var expectedFailures = map[string]string{
 	"l2-map-keys":                   "dotnet build failed",
 	"l2-resource-secret":            "test hanging",
 	"l1-builtin-project-root":       "#466",
-	"l2-rtti":                       "codegen not implemented",
 	"l2-namespaced-provider":        "error CS0117: 'ResourceArgs' does not contain a definition for 'ResourceRef'", //nolint:lll
 	"l2-union":                      "dotnet build failed",
 	"l2-resource-option-alias":      "aliases not recognized: expected 0 create operations but got 3",


### PR DESCRIPTION
We removed this test from the conformance suite.