### PR TITLE
Skip l1-builtin-string

### DIFF
--- a/pulumi-language-dotnet/language_test.go
+++ b/pulumi-language-dotnet/language_test.go
@@ -178,6 +178,8 @@ var expectedFailures = map[string]string{
 
 	"l2-resource-read":        "Fail after updating to 3.234: read resource codegen not implemented",
 	"l2-component-call-plain": "Fail after updating to 3.234: plain method call codegen not implemented",
+
+	"l1-builtin-string": "https://github.com/pulumi/pulumi-dotnet/issues/995",
 }
 
 // Add program overrides here for programs that can't yet be generated correctly due to programgen bugs.


### PR DESCRIPTION
The .NET codegen translates `length()` on strings to `s.Length`, which returns UTF-16 code units rather than grapheme clusters. The new conformance test added in v3.236.0 fails on the emoji case. See #995 for the underlying bug and a suggested fix.