### PR TITLE
Fix docs publishing workflow filename

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -24,7 +24,7 @@ jobs:
         uses: pulumi/esc-action@197ccaa42ab49560ce838a3010eb8345ce086896 # v1
       - name: Trigger pulumi/docs workflow
         run: |
-          gh workflow run pulumi-dotnet-sdk.yml \
+          gh workflow run pulumi-sdk-dotnet-docs.yml \
             --repo pulumi/docs \
             --ref master \
             -f version=${{ github.event.release.tag_name }}


### PR DESCRIPTION
The workflow in pulumi/docs was renamed from pulumi-dotnet-sdk.yml to pulumi-sdk-dotnet-docs.yml.