### PR TITLE
Build and publish Pulumi.Esc.Sdk synced from pulumi/pulumi

### DIFF
--- a/.changes/unreleased/Improvements-0.yaml
+++ b/.changes/unreleased/Improvements-0.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Add the Pulumi.Esc.Sdk package, synced from pulumi/pulumi at build time via GitSync
+time: 2026-06-02T11:01:16.684158+02:00
+custom:
+  PR: 0

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -67,6 +67,10 @@ jobs:
         uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7
         with:
           pulumi-version: dev
+      - name: Sync ESC SDK from pulumi/pulumi
+        # Copies the generated Pulumi.Esc.Sdk into sdk/ so it can be packed and
+        # published alongside the other SDKs (see build/EscSdk.fs).
+        run: dotnet run --project Build.fsproj sync-esc-sdk
       - name: Build Pulumi SDK
         run: make build_sdk
       - name: Test Pulumi SDK

--- a/.gitignore
+++ b/.gitignore
@@ -462,3 +462,7 @@ pulumi-resource-testprovider
 # Ignore user-provided go.work files.
 /go.work
 /go.work.sum
+
+# Pulumi.Esc.Sdk is synced from pulumi/pulumi at build time via `dotnet run
+# sync-esc-sdk` (see build/EscSdk.fs); the generated source is not committed here.
+/sdk/Pulumi.Esc.Sdk/

--- a/Build.fsproj
+++ b/Build.fsproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <Compile Include="build\GitSync.fs" />
+    <Compile Include="build\EscSdk.fs" />
     <Compile Include="build\Nuget.fs" />
     <Compile Include="build\PulumiSdkVersion.fs" />
     <Compile Include="build\Publish.fs" />

--- a/build/EscSdk.fs
+++ b/build/EscSdk.fs
@@ -1,0 +1,32 @@
+module EscSdk
+
+// Syncs the generated ESC C# SDK (Pulumi.Esc.Sdk) from the pulumi/pulumi monorepo
+// into this repo, where it is built and published to NuGet alongside the other
+// Pulumi packages. The generated source lives in pulumi/pulumi at
+// sdk/esc/dotnet/Pulumi.Esc.Sdk (produced by `make generate-esc-sdk-csharp`).
+//
+// See: https://www.notion.so/Merging-ESC-into-the-Pulumi-monorepo (Decision 6).
+
+let private pulumiRepo = "https://github.com/pulumi/pulumi"
+
+// The pulumi/pulumi ref that contains the generated ESC C# SDK.
+//
+// TODO(esc-merge): pin this to the pulumi release tag once the monorepo merge
+// ships. Until then we sync from the merge branch. This mirrors how
+// PulumiSdkVersion pins the Go SDK version from pulumi-language-dotnet/go.mod.
+let pulumiRef = "merge-esc-into-monorepo"
+
+/// Clone pulumi/pulumi at the pinned ref and copy the generated Pulumi.Esc.Sdk
+/// project into sdk/Pulumi.Esc.Sdk.
+let syncEscSdk (repositoryRoot: string) =
+    GitSync.repository {
+        // git clone <options> <repo> <dir>; cloneRepository appends the temp dir.
+        remoteRepository = $"--branch {pulumiRef} --depth 1 {pulumiRepo}"
+        localRepositoryPath = repositoryRoot
+        contents = [
+            GitSync.folder {
+                sourcePath = [ "sdk"; "esc"; "dotnet"; "Pulumi.Esc.Sdk" ]
+                destinationPath = [ "sdk"; "Pulumi.Esc.Sdk" ]
+            }
+        ]
+    }

--- a/build/Program.fs
+++ b/build/Program.fs
@@ -24,6 +24,7 @@ let pulumiSdkTests = Path.Combine(sdk, "Pulumi.Tests")
 let pulumiAutomationSdk = Path.Combine(sdk, "Pulumi.Automation")
 let pulumiAutomationSdkTests = Path.Combine(sdk, "Pulumi.Automation.Tests")
 let pulumiFSharp = Path.Combine(sdk, "Pulumi.FSharp")
+let pulumiEscSdk = Path.Combine(sdk, "Pulumi.Esc.Sdk")
 let integrationTests = Path.Combine(repositoryRoot, "integration_tests")
 let pulumiLanguageDotnet = Path.Combine(repositoryRoot, "pulumi-language-dotnet")
 
@@ -97,6 +98,7 @@ let publishSdks() =
         pulumiSdk;
         pulumiAutomationSdk;
         pulumiFSharp;
+        pulumiEscSdk;
     ]
     // perform the publishing (idempotent)
     let publishResults = publishSdks projectDirs pulumiLanguageDotnet
@@ -183,6 +185,7 @@ let main(args: string[]) : int =
     | [| "test-automation-sdk" |] -> testPulumiAutomationSdk false
     | [| "test-automation-sdk"; "coverage" |] -> testPulumiAutomationSdk true
     | [| "publish-sdks" |] -> publishSdks()
+    | [| "sync-esc-sdk" |] -> EscSdk.syncEscSdk repositoryRoot
     | [| "integration"; "test"; testName |] -> runSpecificIntegrationTest testName
     | [| "all-integration-tests" |] -> runAllIntegrationTests()
 


### PR DESCRIPTION
> **Draft.** Part of the [ESC → pulumi monorepo merge](https://www.notion.so/Merging-ESC-into-the-Pulumi-monorepo-35efdbdf1cce81f79bc8ecfa13b6a0e2) (Phase 5 / Decision 6). Pairs with pulumi/pulumi#23405. No release.

Wires up the (previously-unused) `build/GitSync.fs` to sync the generated **Pulumi.Esc.Sdk** C# client from `pulumi/pulumi` (`sdk/esc/dotnet/Pulumi.Esc.Sdk`) into this repo at build time, then build and publish it to NuGet alongside the other Pulumi packages. The NuGet package name `Pulumi.Esc.Sdk` is preserved — zero user impact.

### Changes
- **`build/EscSdk.fs`** (new): `syncEscSdk` clones `pulumi/pulumi` at a pinned ref and copies `Pulumi.Esc.Sdk` into `sdk/`. Exposed as the `sync-esc-sdk` build command. Mirrors how `PulumiSdkVersion.fs` pins the Go SDK version.
- **`Build.fsproj`**: compile `EscSdk.fs`.
- **`build/Program.fs`**: add `Pulumi.Esc.Sdk` to the publish project list + `sync-esc-sdk` command.
- **`release-sdk.yml`**: sync the ESC SDK before build/publish.
- **`.gitignore`**: the synced `sdk/Pulumi.Esc.Sdk` is generated, not committed.
- **changie** entry.

### Verified end-to-end
- `dotnet build Build.fsproj` — 0 errors.
- `dotnet run sync-esc-sdk` — cloned the merge branch and copied the C# SDK.
- `dotnet build sdk/Pulumi.Esc.Sdk/Pulumi.Esc.Sdk.csproj` — **0 errors** (generated C# is valid and builds here).

### Finalize after merge
- Pin the `pulumiRef` in `EscSdk.fs` to the pulumi release tag (currently the `merge-esc-into-monorepo` branch).
- Optional follow-up: add `Pulumi.Esc.Sdk` to `Pulumi.sln` and wire `sync-esc-sdk` into `make build_sdk` (kept out here so non-synced checkouts of the main solution still build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
