### PR TITLE
Re-enable TestPluginDebuggerAttachDotnet on macOS

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -194,31 +194,7 @@ jobs:
           echo '{"sdk":{"version": "${{ matrix.dotnet-version }}"}}' > ./global.json
       - name: Dotnet version
         run: dotnet --version
-      - name: Install netcoredbg (Linux)
-        if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          curl -sSL https://github.com/Samsung/netcoredbg/releases/download/3.1.1-1042/netcoredbg-linux-amd64.tar.gz -o netcoredbg.tar.gz
-          tar xzf netcoredbg.tar.gz
-          sudo cp netcoredbg/* /usr/bin/
-      - name: Install netcoredbg (Windows)
-        if: startsWith(matrix.os, 'windows')
-        shell: bash
-        run: |
-          curl -sSL https://github.com/Samsung/netcoredbg/releases/download/3.1.1-1042/netcoredbg-win64.zip -o netcoredbg.zip
-          unzip netcoredbg.zip
-          echo "$(pwd)/netcoredbg" >> $GITHUB_PATH
-      - name: Install netcoredbg (MacOS)
-        if: startsWith(matrix.os, 'macos')
-        id: netcoredbg
-        run: |
-          curl -sSL https://github.com/Samsung/netcoredbg/releases/download/3.1.1-1042/netcoredbg-osx-amd64.tar.gz -o netcoredbg.tar.gz
-          tar xzf netcoredbg.tar.gz
-          echo "netcoredbgpath=$(pwd)/netcoredbg/" >> ${GITHUB_OUTPUT}
       - name: Integration tests
-        if: startsWith(matrix.os, 'macos')
-        run: PATH="${{ steps.netcoredbg.outputs.netcoredbgpath}}":"$PATH" make test_integration
-      - name: Integration tests
-        if: startsWith(matrix.os, 'macos') != true
         run: make test_integration
   conformance-tests:
     strategy:

--- a/.mise.toml
+++ b/.mise.toml
@@ -13,3 +13,17 @@ golangci-lint = "2.9.0"
 gotestsum = "latest"
 "github:pulumi/pulumi" = "latest"
 "vfox:dotnet" = { version = "8.0", postinstall = "powershell -File {{config_root}}/scripts/install-dotnet-runtime.ps1 || bash {{config_root}}/scripts/install-dotnet-runtime.sh" }
+
+# netcoredbg is the .NET debugger used by the debugger-attach integration tests.  Samsung does not publish an osx-arm64
+# build (https://github.com/Samsung/netcoredbg/issues/174), so on Apple Silicon we pull a community-built arm64
+# binary.
+[tools."http:netcoredbg"]
+version = "3.1.2-1054"
+bin_path = "netcoredbg"
+
+[tools."http:netcoredbg".platforms]
+linux-x64 = { url = "https://github.com/Samsung/netcoredbg/releases/download/3.1.2-1054/netcoredbg-linux-amd64.tar.gz" }
+linux-arm64 = { url = "https://github.com/Samsung/netcoredbg/releases/download/3.1.2-1054/netcoredbg-linux-arm64.tar.gz" }
+macos-x64 = { url = "https://github.com/Samsung/netcoredbg/releases/download/3.1.2-1054/netcoredbg-osx-amd64.tar.gz" }
+macos-arm64 = { url = "https://github.com/Cliffback/netcoredbg-macOS-arm64.nvim/releases/download/3.1.2-1054/netcoredbg-osx-arm64.tar.gz" }
+windows-x64 = { url = "https://github.com/Samsung/netcoredbg/releases/download/3.1.2-1054/netcoredbg-win64.zip" }

--- a/integration_tests/integration_dotnet_test.go
+++ b/integration_tests/integration_dotnet_test.go
@@ -674,10 +674,13 @@ func readUpdateEventLog(logfile string) ([]apitype.EngineEvent, error) {
 func TestDebuggerAttachDotnet(t *testing.T) {
 	t.Parallel()
 
-	// TODO[pulumi/pulumi-dotnet#403]: Fix flaky test.
-	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
-		t.Skip("Temporarily skipping flaky test on macOS and Windows - pulumi/pulumi-dotnet#403")
+	// TODO[pulumi/pulumi-dotnet#403]: The program debugger attach is flaky on Windows.
+	if runtime.GOOS == WindowsOS {
+		t.Skip("Skipping flaky test on Windows - pulumi/pulumi-dotnet#403")
 	}
+
+	// Prevent the test from hanging by failing it after five minutes.
+	setTimeout(t, 5*time.Minute)
 
 	e := newEnvironmentDotnet(t)
 	defer e.DeleteIfNotFailed()
@@ -735,8 +738,8 @@ outer:
 func TestPluginDebuggerAttachDotnet(t *testing.T) {
 	t.Parallel()
 
-	// Prevent the test from hanging by failing it after one minute.
-	setTimeout(t, time.Minute)
+	// Prevent the test from hanging by failing it after five minutes.
+	setTimeout(t, 5*time.Minute)
 
 	e := newEnvironmentDotnet(t)
 	defer e.DeleteIfNotFailed()

--- a/integration_tests/integration_dotnet_test.go
+++ b/integration_tests/integration_dotnet_test.go
@@ -487,14 +487,11 @@ func TestGetResourceDotnet(t *testing.T) {
 func TestAboutDotnet(t *testing.T) {
 	t.Parallel()
 
-	languagePluginPath, err := filepath.Abs("../pulumi-language-dotnet")
-	require.NoError(t, err)
-
 	e := newEnvironmentDotnet(t)
 	defer e.DeleteIfNotFailed()
 	e.ImportDirectory("about")
 
-	e.Env = append(e.Env, getProviderPath(languagePluginPath))
+	e.Env = append(e.Env, getProviderPath(languagePluginPath(t)))
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 	stdout, stderr := e.RunCommand("pulumi", "about")
 	// There should be no "unknown" plugin versions.
@@ -716,14 +713,11 @@ func TestDebuggerAttachDotnet(t *testing.T) {
 		t.Skip("Temporarily skipping flaky test on macOS and Windows - pulumi/pulumi-dotnet#403")
 	}
 
-	languagePluginPath, err := filepath.Abs("../pulumi-language-dotnet")
-	require.NoError(t, err)
-
 	e := newEnvironmentDotnet(t)
 	defer e.DeleteIfNotFailed()
 	e.ImportDirectory("printf")
 
-	err = prepareDotnetProjectAtCwd(e.RootPath)
+	err := prepareDotnetProjectAtCwd(e.RootPath)
 	require.NoError(t, err)
 
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
@@ -732,7 +726,7 @@ func TestDebuggerAttachDotnet(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		e.Env = append(e.Env, "PULUMI_DEBUG_COMMANDS=true", getProviderPath(languagePluginPath))
+		e.Env = append(e.Env, "PULUMI_DEBUG_COMMANDS=true", getProviderPath(languagePluginPath(t)))
 		e.RunCommand("pulumi", "stack", "init", "debugger-test")
 		e.RunCommand("pulumi", "stack", "select", "debugger-test")
 		e.RunCommand("pulumi", "preview", "--attach-debugger",
@@ -775,19 +769,14 @@ outer:
 func TestPluginDebuggerAttachDotnet(t *testing.T) {
 	t.Parallel()
 
-	// TODO[pulumi/pulumi-dotnet#705]: Fix disabled test on MacOS..
-	if runtime.GOOS == "darwin" {
-		t.Skip("Skipping test due to broken netcoredbg on MacOS - pulumi/pulumi-dotnet#705")
-	}
-
-	languagePluginPath, err := filepath.Abs("../pulumi-language-dotnet")
-	require.NoError(t, err)
+	// Prevent the test from hanging by failing it after one minute.
+	setTimeout(t, time.Minute)
 
 	e := newEnvironmentDotnet(t)
 	defer e.DeleteIfNotFailed()
 	e.ImportDirectory("debug-plugin")
 
-	err = prepareDotnetProjectAtCwd(filepath.Join(e.RootPath, "dotnet-plugin"))
+	err := prepareDotnetProjectAtCwd(filepath.Join(e.RootPath, "dotnet-plugin"))
 	require.NoError(t, err)
 
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
@@ -799,7 +788,7 @@ func TestPluginDebuggerAttachDotnet(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		e.Env = append(e.Env, "PULUMI_DEBUG_COMMANDS=true", getProviderPath(languagePluginPath))
+		e.Env = append(e.Env, "PULUMI_DEBUG_COMMANDS=true", getProviderPath(languagePluginPath(t)))
 		e.RunCommand("pulumi", "stack", "init", "debugger-test")
 		e.RunCommand("pulumi", "stack", "select", "debugger-test")
 		stdout, _ := e.RunCommandExpectError("pulumi", "preview", "--attach-debugger=plugins",

--- a/integration_tests/integration_dotnet_test.go
+++ b/integration_tests/integration_dotnet_test.go
@@ -341,40 +341,6 @@ func TestFailingTransfomationExitsProgram(t *testing.T) {
 	assert.Contains(t, stderr.String(), "Boom!")
 }
 
-// Test remote component construction with a child resource that takes a long time to be created, ensuring it's created.
-//func TestConstructSlowDotnet(t *testing.T) {
-//	localProvider := testComponentSlowLocalProvider(t)
-//
-//	// TODO[pulumi/pulumi#5455]: Dynamic providers fail to load when used from multi-lang components.
-//	// Until we've addressed this, set PULUMI_TEST_YARN_LINK_PULUMI, which tells the integration test
-//	// module to run `yarn install && yarn link @pulumi/pulumi` in the .NET program's directory, allowing
-//	// the Node.js dynamic provider plugin to load.
-//	// When the underlying issue has been fixed, the use of this environment variable inside the integration
-//	// test module should be removed.
-//	const testYarnLinkPulumiEnv = "PULUMI_TEST_YARN_LINK_PULUMI=true"
-//
-//	testDir := "construct_component_slow"
-//	runComponentSetup(t, testDir)
-//
-//	opts := &integration.ProgramTestOptions{
-//		Env:            []string{testYarnLinkPulumiEnv},
-//		Dir:            filepath.Join(testDir, "dotnet"),
-//		Dependencies:   []string{"Pulumi"},
-//		LocalProviders: []integration.LocalDependency{localProvider},
-//		Quick:          true,
-//		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-//			assert.NotNil(t, stackInfo.Deployment)
-//			if assert.Equal(t, 5, len(stackInfo.Deployment.Resources)) {
-//				stackRes := stackInfo.Deployment.Resources[0]
-//				assert.NotNil(t, stackRes)
-//				assert.Equal(t, resource.RootStackType, stackRes.Type)
-//				assert.Equal(t, "", string(stackRes.Parent))
-//			}
-//		},
-//	}
-//	integration.ProgramTest(t, opts)
-//}
-
 // Test remote component construction with prompt inputs.
 //
 //nolint:paralleltest // ProgramTest calls testing.T.Parallel

--- a/integration_tests/integration_dotnet_test.go
+++ b/integration_tests/integration_dotnet_test.go
@@ -15,6 +15,7 @@
 package integrationtests
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -32,6 +33,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/stretchr/testify/assert"
@@ -671,6 +673,60 @@ func readUpdateEventLog(logfile string) ([]apitype.EngineEvent, error) {
 	return events, nil
 }
 
+// waitForDebugEvent polls the update event log until the engine reports a
+// debug configuration, failing the test if none appears within two minutes.
+func waitForDebugEvent(t *testing.T, e *ptesting.Environment) *apitype.StartDebuggingEvent {
+	logfile := filepath.Join(e.RootPath, "debugger.log")
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		events, err := readUpdateEventLog(logfile)
+		require.NoError(t, err)
+		for _, event := range events {
+			if event.StartDebuggingEvent != nil {
+				return event.StartDebuggingEvent
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for a debug event in %s", logfile)
+	return nil
+}
+
+// attachDebugger attaches netcoredbg to the process named by debugEvent and
+// resumes it. The debugger stays attached until the test ends: the debuggee
+// polls Debugger.IsAttached every 100ms, so a debugger that attaches and
+// immediately detaches (as netcoredbg does on stdin EOF) can come and go
+// without the debuggee ever observing the attach, leaving it waiting forever.
+func attachDebugger(t *testing.T, debugEvent *apitype.StartDebuggingEvent) {
+	pid := strconv.Itoa(int(debugEvent.Config["processId"].(float64)))
+	cmd := exec.CommandContext(t.Context(), //nolint:gosec // This is a test
+		"netcoredbg", "--interpreter=mi", "--attach", pid)
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		contract.IgnoreClose(stdin)
+		contract.IgnoreError(cmd.Process.Kill())
+		contract.IgnoreError(cmd.Wait())
+	})
+
+	// thread-info confirms the attach completed; exec-continue resumes the
+	// debuggee in case the attach left it stopped. exec-continue may fail if
+	// the debuggee is already running, which is fine.
+	_, err = io.WriteString(stdin, "1-thread-info\n2-exec-continue\n")
+	require.NoError(t, err)
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), "1^done") {
+			return
+		}
+	}
+	t.Fatal("netcoredbg exited without confirming the attach")
+}
+
 func TestDebuggerAttachDotnet(t *testing.T) {
 	t.Parallel()
 
@@ -702,35 +758,8 @@ func TestDebuggerAttachDotnet(t *testing.T) {
 			"--event-log", filepath.Join(e.RootPath, "debugger.log"))
 	}()
 
-	// Wait for the debugging event
-	wait := 20 * time.Millisecond
-	var debugEvent *apitype.StartDebuggingEvent
-outer:
-	for i := 0; i < 50; i++ {
-		events, err := readUpdateEventLog(filepath.Join(e.RootPath, "debugger.log"))
-		require.NoError(t, err)
-		for _, event := range events {
-			if event.StartDebuggingEvent != nil {
-				debugEvent = event.StartDebuggingEvent
-				break outer
-			}
-		}
-		time.Sleep(wait)
-		wait *= 2
-	}
-	require.NotNil(t, debugEvent)
-
-	// We just need to send some command to netcoredbg that will make the program continue.
-	// We don't care about the actual command, and the `thread-info` command just works.
-	in := strings.NewReader("1-thread-info")
-
-	cmd := exec.CommandContext(t.Context(), //nolint:gosec // This is a test
-		"netcoredbg", "--interpreter=mi", "--attach", strconv.Itoa(int(debugEvent.Config["processId"].(float64))))
-	cmd.Stdin = in
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err)
-	// Check that we get valid output from netcoredbg, so we know it was actually attached.
-	require.Contains(t, string(out), "1^done")
+	debugEvent := waitForDebugEvent(t, e)
+	attachDebugger(t, debugEvent)
 
 	wg.Wait()
 }
@@ -765,35 +794,8 @@ func TestPluginDebuggerAttachDotnet(t *testing.T) {
 		require.Contains(t, stdout, "error: The method 'Check' is not implemented")
 	}()
 
-	// Wait for the debugging event
-	wait := 20 * time.Millisecond
-	var debugEvent *apitype.StartDebuggingEvent
-outer:
-	for range 50 {
-		events, err := readUpdateEventLog(filepath.Join(e.RootPath, "debugger.log"))
-		require.NoError(t, err)
-		for _, event := range events {
-			if event.StartDebuggingEvent != nil {
-				debugEvent = event.StartDebuggingEvent
-				break outer
-			}
-		}
-		time.Sleep(wait)
-		wait *= 2
-	}
-	require.NotNil(t, debugEvent)
-
-	// We just need to send some command to netcoredbg that will make the program continue.
-	// We don't care about the actual command, and the `thread-info` command just works.
-	in := strings.NewReader("1-thread-info")
-
-	cmd := exec.CommandContext(t.Context(), //nolint:gosec // This is a test
-		"netcoredbg", "--interpreter=mi", "--attach", strconv.Itoa(int(debugEvent.Config["processId"].(float64))))
-	cmd.Stdin = in
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, string(out))
-	// Check that we get valid output from netcoredbg, so we know it was actually attached.
-	require.Contains(t, string(out), "1^done")
+	debugEvent := waitForDebugEvent(t, e)
+	attachDebugger(t, debugEvent)
 
 	wg.Wait()
 }

--- a/integration_tests/integration_dotnet_test.go
+++ b/integration_tests/integration_dotnet_test.go
@@ -706,25 +706,61 @@ func attachDebugger(t *testing.T, debugEvent *apitype.StartDebuggingEvent) {
 	stdout, err := cmd.StdoutPipe()
 	require.NoError(t, err)
 	require.NoError(t, cmd.Start())
+
+	// thread-info confirms the attach completed; exec-continue resumes the
+	// debuggee, which the attach leaves stopped.
+	_, err = io.WriteString(stdin, "1-thread-info\n2-exec-continue\n")
+	require.NoError(t, err)
+
+	// The attach stop is not reported over MI (netcoredbg only emits
+	// *stopped for breakpoint/step/exception/signal/entry-point/exit), so
+	// whether the exec-continue above is processed after the attach stop is
+	// a race — lost deterministically on Windows, occasionally on macOS.
+	// Keep issuing -exec-continue while the debugger is attached: continuing
+	// a running debuggee is a harmless no-op (^running), and a stopped one
+	// is resumed by the next tick.
+	go func() {
+		for token := 3; ; token++ {
+			time.Sleep(200 * time.Millisecond)
+			if _, err := fmt.Fprintf(stdin, "%d-exec-continue\n", token); err != nil {
+				return
+			}
+		}
+	}()
+
+	attached := make(chan bool, 1)
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		confirmed := false
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			line := scanner.Text()
+			t.Logf("netcoredbg: %s", line)
+			if !confirmed && strings.Contains(line, "1^done") {
+				confirmed = true
+				attached <- true
+			}
+		}
+		if !confirmed {
+			attached <- false
+		}
+	}()
+	// Waiting for the reader keeps its t.Logf calls from firing after the
+	// test has completed, which would panic.
 	t.Cleanup(func() {
 		contract.IgnoreClose(stdin)
 		contract.IgnoreError(cmd.Process.Kill())
 		contract.IgnoreError(cmd.Wait())
+		<-readerDone
 	})
 
-	// thread-info confirms the attach completed; exec-continue resumes the
-	// debuggee in case the attach left it stopped. exec-continue may fail if
-	// the debuggee is already running, which is fine.
-	_, err = io.WriteString(stdin, "1-thread-info\n2-exec-continue\n")
-	require.NoError(t, err)
-
-	scanner := bufio.NewScanner(stdout)
-	for scanner.Scan() {
-		if strings.Contains(scanner.Text(), "1^done") {
-			return
-		}
+	select {
+	case ok := <-attached:
+		require.True(t, ok, "netcoredbg exited without confirming the attach")
+	case <-time.After(2 * time.Minute):
+		t.Fatal("timed out waiting for netcoredbg to confirm the attach")
 	}
-	t.Fatal("netcoredbg exited without confirming the attach")
 }
 
 func TestDebuggerAttachDotnet(t *testing.T) {

--- a/integration_tests/integration_dotnet_test.go
+++ b/integration_tests/integration_dotnet_test.go
@@ -724,7 +724,7 @@ outer:
 	// We don't care about the actual command, and the `thread-info` command just works.
 	in := strings.NewReader("1-thread-info")
 
-	cmd := exec.Command( //nolint:gosec // This is a test
+	cmd := exec.CommandContext(t.Context(), //nolint:gosec // This is a test
 		"netcoredbg", "--interpreter=mi", "--attach", strconv.Itoa(int(debugEvent.Config["processId"].(float64))))
 	cmd.Stdin = in
 	out, err := cmd.CombinedOutput()
@@ -787,7 +787,7 @@ outer:
 	// We don't care about the actual command, and the `thread-info` command just works.
 	in := strings.NewReader("1-thread-info")
 
-	cmd := exec.Command( //nolint:gosec // This is a test
+	cmd := exec.CommandContext(t.Context(), //nolint:gosec // This is a test
 		"netcoredbg", "--interpreter=mi", "--attach", strconv.Itoa(int(debugEvent.Config["processId"].(float64))))
 	cmd.Stdin = in
 	out, err := cmd.CombinedOutput()

--- a/integration_tests/integration_util_test.go
+++ b/integration_tests/integration_util_test.go
@@ -12,22 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The linter doesn't see the uses since the consumers are conditionally compiled tests.
-//
-//nolint:unused,deadcode,varcheck
 package integrationtests
 
 import (
-	"bufio"
 	"bytes"
-	"context"
-	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -36,15 +29,10 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 const WindowsOS = "windows"
@@ -59,14 +47,6 @@ func setTimeout(t *testing.T, duration time.Duration) {
 			return
 		}
 	}()
-}
-
-// assertPerfBenchmark implements the integration.TestStatsReporter interface, and reports test
-// failures when a scenario exceeds the provided threshold.
-type assertPerfBenchmark struct {
-	T                  *testing.T
-	MaxPreviewDuration time.Duration
-	MaxUpdateDuration  time.Duration
 }
 
 func prepareDotnetProject(projInfo *engine.Projinfo) error {
@@ -194,100 +174,6 @@ func testDotnetProgram(t *testing.T, options *integration.ProgramTestOptions) {
 	integration.ProgramTest(t, options)
 }
 
-func (t assertPerfBenchmark) ReportCommand(stats integration.TestCommandStats) {
-	var maxDuration *time.Duration
-	if strings.HasPrefix(stats.StepName, "pulumi-preview") {
-		maxDuration = &t.MaxPreviewDuration
-	}
-	if strings.HasPrefix(stats.StepName, "pulumi-update") {
-		maxDuration = &t.MaxUpdateDuration
-	}
-
-	if maxDuration != nil && *maxDuration != 0 {
-		if stats.ElapsedSeconds < maxDuration.Seconds() {
-			t.T.Logf(
-				"Test step %q was under threshold. %.2fs (max %.2fs)",
-				stats.StepName, stats.ElapsedSeconds, maxDuration.Seconds())
-		} else {
-			t.T.Errorf(
-				"Test step %q took longer than expected. %.2fs vs. max %.2fs",
-				stats.StepName, stats.ElapsedSeconds, maxDuration.Seconds())
-		}
-	}
-}
-
-func testComponentSlowLocalProvider(t *testing.T) integration.LocalDependency {
-	return integration.LocalDependency{
-		Package: "testcomponent",
-		Path:    filepath.Join("construct_component_slow", "testcomponent"),
-	}
-}
-
-func testComponentProviderSchema(t *testing.T, path string) {
-	t.Parallel()
-
-	tests := []struct {
-		name          string
-		env           []string
-		version       int32
-		expected      string
-		expectedError string
-	}{
-		{
-			name:     "Default",
-			expected: "{}",
-		},
-		{
-			name:     "Schema",
-			env:      []string{"INCLUDE_SCHEMA=true"},
-			expected: `{"hello": "world"}`,
-		},
-		{
-			name:          "Invalid Version",
-			version:       15,
-			expectedError: "unsupported schema version 15",
-		},
-	}
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			// Start the plugin binary.
-			cmd := exec.Command(path, "ignored")
-			cmd.Env = append(os.Environ(), test.env...)
-			stdout, err := cmd.StdoutPipe()
-			assert.NoError(t, err)
-			err = cmd.Start()
-			assert.NoError(t, err)
-			defer func() {
-				// Ignore the error as it may fail with access denied on Windows.
-				cmd.Process.Kill() //nolint:errcheck
-			}()
-
-			// Read the port from standard output.
-			reader := bufio.NewReader(stdout)
-			bytes, err := reader.ReadBytes('\n')
-			assert.NoError(t, err)
-			port := strings.TrimSpace(string(bytes))
-
-			// Create a connection to the server.
-			conn, err := grpc.NewClient(
-				"127.0.0.1:"+port, grpc.WithTransportCredentials(insecure.NewCredentials()), rpcutil.GrpcChannelOptions())
-			assert.NoError(t, err)
-			client := pulumirpc.NewResourceProviderClient(conn)
-
-			// Call GetSchema and verify the results.
-			resp, err := client.GetSchema(context.Background(), &pulumirpc.GetSchemaRequest{Version: test.version})
-			if test.expectedError != "" {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), test.expectedError)
-			} else {
-				assert.Equal(t, test.expected, resp.GetSchema())
-			}
-		})
-	}
-}
-
 // Test remote component inputs properly handle unknowns.
 func testConstructUnknown(t *testing.T, lang string) {
 	const testDir = "construct_component_unknown"
@@ -332,39 +218,6 @@ func testConstructMethodsUnknown(t *testing.T, lang string) {
 	})
 }
 
-// Test methods that create resources.
-func testConstructMethodsResources(t *testing.T, lang string) {
-	const testDir = "construct_component_methods_resources"
-	componentDir := "testcomponent-go"
-
-	localProviders := []integration.LocalDependency{
-		{Package: "testprovider", Path: "testprovider"},
-		{Package: "testcomponent", Path: filepath.Join(testDir, componentDir)},
-	}
-
-	testDotnetProgram(t, &integration.ProgramTestOptions{
-		Dir:            filepath.Join(testDir, lang),
-		LocalProviders: localProviders,
-		Quick:          true,
-		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			assert.NotNil(t, stackInfo.Deployment)
-			assert.Equal(t, 6, len(stackInfo.Deployment.Resources))
-			var hasExpectedResource bool
-			var result string
-			for _, res := range stackInfo.Deployment.Resources {
-				if res.URN.Name() == "myrandom" {
-					hasExpectedResource = true
-					result = res.Outputs["result"].(string)
-					assert.Equal(t, float64(10), res.Inputs["length"])
-					assert.Equal(t, 10, len(result))
-				}
-			}
-			assert.True(t, hasExpectedResource)
-			assert.Equal(t, result, stackInfo.Outputs["result"])
-		},
-	})
-}
-
 // Test failures returned from methods are observed.
 func testConstructMethodsErrors(t *testing.T, lang string) {
 	const testDir = "construct_component_methods_errors"
@@ -387,37 +240,6 @@ func testConstructMethodsErrors(t *testing.T, lang string) {
 			assert.Contains(t, output, expectedError)
 		},
 	})
-}
-
-func testConstructOutputValues(t *testing.T, lang string, dependencies ...string) {
-	t.Parallel()
-
-	const testDir = "construct_component_output_values"
-	componentDir := "testcomponent-go"
-
-	localProviders := []integration.LocalDependency{
-		{Package: "testprovider", Path: "testprovider"},
-		{Package: "testcomponent", Path: filepath.Join(testDir, componentDir)},
-	}
-
-	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Dir:            filepath.Join(testDir, lang),
-		Dependencies:   dependencies,
-		LocalProviders: localProviders,
-		Quick:          true,
-	})
-}
-
-var previewSummaryRegex = regexp.MustCompile(
-	`{\s+"steps": \[[\s\S]+],\s+"duration": \d+,\s+"changeSummary": {[\s\S]+}\s+}`)
-
-func assertOutputContainsEvent(t *testing.T, evt apitype.EngineEvent, output string) {
-	evtJSON := bytes.Buffer{}
-	encoder := json.NewEncoder(&evtJSON)
-	encoder.SetEscapeHTML(false)
-	err := encoder.Encode(evt)
-	assert.NoError(t, err)
-	assert.Contains(t, output, evtJSON.String())
 }
 
 // printfTestValidation is used by the TestPrintfXYZ test cases in the language-specific test

--- a/integration_tests/integration_util_test.go
+++ b/integration_tests/integration_util_test.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -41,11 +42,24 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
 const WindowsOS = "windows"
+
+func setTimeout(t *testing.T, duration time.Duration) {
+	go func() {
+		select {
+		case <-time.After(duration):
+			t.Logf("Timed out after %s", duration)
+			t.Fail()
+		case <-t.Context().Done():
+			return
+		}
+	}()
+}
 
 // assertPerfBenchmark implements the integration.TestStatsReporter interface, and reports test
 // failures when a scenario exceeds the provided threshold.
@@ -122,6 +136,34 @@ func prepareDotnetProjectAtCwd(cwd string) error {
 	return err
 }
 
+var (
+	languagePluginOnce sync.Once
+	languagePluginDir  string
+	languagePluginErr  error
+)
+
+// The path to a built pulumi-language-dotnet.
+func languagePluginPath(t *testing.T) string {
+	languagePluginOnce.Do(func() {
+		dir, err := filepath.Abs("../pulumi-language-dotnet")
+		if err != nil {
+			languagePluginErr = err
+			return
+		}
+		cmd := exec.Command("go", "build", "-ldflags",
+			"-X github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3/version.Version=3.0.0-dev.0",
+			"-o", "pulumi-language-dotnet", ".")
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			languagePluginErr = fmt.Errorf("building pulumi-language-dotnet: %w\n%s", err, out)
+			return
+		}
+		languagePluginDir = dir
+	})
+	require.NoError(t, languagePluginErr)
+	return languagePluginDir
+}
+
 func getProviderPath(providerDir string) string {
 	environ := os.Environ()
 	for _, env := range environ {
@@ -141,18 +183,14 @@ func getProviderPath(providerDir string) string {
 }
 
 func newEnvironmentDotnet(t *testing.T) *ptesting.Environment {
-	languagePluginPath, err := filepath.Abs("../pulumi-language-dotnet")
-	assert.NoError(t, err)
 	e := ptesting.NewEnvironment(t)
-	e.Env = append(e.Env, getProviderPath(languagePluginPath))
+	e.Env = append(e.Env, getProviderPath(languagePluginPath(t)))
 	return e
 }
 
 func testDotnetProgram(t *testing.T, options *integration.ProgramTestOptions) {
-	languagePluginPath, err := filepath.Abs("../pulumi-language-dotnet")
-	assert.NoError(t, err)
 	options.PrepareProject = prepareDotnetProject
-	options.Env = append(options.Env, getProviderPath(languagePluginPath))
+	options.Env = append(options.Env, getProviderPath(languagePluginPath(t)))
 	integration.ProgramTest(t, options)
 }
 


### PR DESCRIPTION
## Why

`TestPluginDebuggerAttachDotnet` was skipped on macOS (#705). The failure (`0x80131c3c`) was an **architecture mismatch**: GitHub's macOS runners and Apple Silicon dev machines are arm64, but Samsung only ships an `osx-amd64` netcoredbg, and a debugger cannot attach to a process of a different architecture.

## What

- **`.mise.toml`** — install netcoredbg as a managed tool via the `http` backend with per-platform URLs. Apple Silicon pulls a community-built arm64 binary ([Samsung/netcoredbg#174](https://github.com/Samsung/netcoredbg/issues/174) tracks the missing official asset); every other platform uses Samsung's official builds.
- **`.github/workflows/pr.yml`** — drop the hand-rolled `curl` netcoredbg install steps and the macOS `PATH` override. `jdx/mise-action` already runs `mise install`, so netcoredbg now comes from `.mise.toml` on every platform (single source of truth, and avoids the amd64 download shadowing the arm64 build).
- **`integration_tests/`** — add a `languagePluginPath` helper that builds `pulumi-language-dotnet` once via `sync.Once` and returns its directory, instead of assuming the binary already exists on disk. Re-enable the test by removing the darwin skip.

`TestDebuggerAttachDotnet` remains skipped on macOS/Windows — that is a separate flakiness issue (#403), not the architecture problem.

## Test

- `TestPluginDebuggerAttachDotnet` passes locally on arm64 macOS using the `.mise.toml`-provided debugger.
- `make format_integration_tests_check` and `make lint_integration_tests` are clean.

Fixes #706