### PR TITLE
Retry package discovery commands in the language host

### DIFF
--- a/.changes/unreleased/bug-fixes-1035.yaml
+++ b/.changes/unreleased/bug-fixes-1035.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: bug-fixes
+body: Retry package discovery commands ('dotnet list package', 'dotnet nuget locals') when they are killed on resource-starved machines
+time: 2026-06-12T11:50:52.723079+02:00
+custom:
+    PR: "1035"

--- a/pulumi-language-dotnet/main.go
+++ b/pulumi-language-dotnet/main.go
@@ -314,7 +314,7 @@ func (host *dotnetLanguageHost) DeterminePossiblePulumiPackages(
 	project := resolveProjectPath(programDirectory, entryPoint)
 	args := []string{"list", project, "package", "--include-transitive"}
 	commandStr := strings.Join(args, " ")
-	commandOutput, err := RunDotnetCommand(ctx, dotnetExec, engineClient, args, false /*logToUser*/, programDirectory)
+	commandOutput, err := runDiscoveryCommand(ctx, dotnetExec, engineClient, args, programDirectory)
 	if err != nil {
 		return nil, err
 	}
@@ -383,7 +383,7 @@ func (host *dotnetLanguageHost) DetermineDotnetPackageDirectory(
 	// plugin is installed locally and not need to do anything.
 	args := []string{"nuget", "locals", "global-packages", "--list"}
 	commandStr := strings.Join(args, " ")
-	commandOutput, err := RunDotnetCommand(ctx, dotnetExec, engineClient, args, false /*logToUser*/, programDirectory)
+	commandOutput, err := runDiscoveryCommand(ctx, dotnetExec, engineClient, args, programDirectory)
 	if err != nil {
 		return "", err
 	}
@@ -525,6 +525,29 @@ func (host *dotnetLanguageHost) DotnetBuild(
 
 	host.dotnetBuildSucceeded = true
 	return nil
+}
+
+// runDiscoveryCommand runs a read-only, idempotent dotnet command used for package
+// discovery, retrying on failure. These commands are occasionally killed on
+// resource-starved machines (for example, OOM-killed on CI runners), and since they
+// have no side effects it is safe to run them again.
+func runDiscoveryCommand(
+	ctx context.Context,
+	dotnetExec string,
+	engineClient pulumirpc.EngineClient,
+	args []string,
+	programDirectory string,
+) (string, error) {
+	const tries = 3
+	for attempt := 1; ; attempt++ {
+		output, err := RunDotnetCommand(ctx, dotnetExec, engineClient, args, false /*logToUser*/, programDirectory)
+		if err == nil || attempt == tries || ctx.Err() != nil {
+			return output, err
+		}
+		logging.V(5).Infof("'dotnet %v' failed (attempt %d of %d), retrying: %v",
+			strings.Join(args, " "), attempt, tries, err)
+		time.Sleep(time.Duration(attempt) * time.Second)
+	}
 }
 
 func RunDotnetCommand(


### PR DESCRIPTION
> [!NOTE]
> This PR was AI generated (by Claude Code), then reviewed by a human.

The language host shells out to `dotnet list package --include-transitive` and `dotnet nuget locals global-packages --list` during package discovery. These processes are occasionally killed on resource-starved machines — for example, OOM-killed with exit code 137 on macOS CI runners — which fails the whole `pulumi up` with:

```
error: failed to discover package requirements: 'dotnet nuget locals global-packages --list' exited with non-zero exit code: 137
```

Both commands are read-only and idempotent, so this wraps them in a small retry loop (3 tries with a short backoff, skipped when the context is canceled). `dotnet build` and `dotnet run` are intentionally not retried.

Fixes #1034
Fixes #990
