### PR TITLE
ci: pin mise to 2026.6.9 to fix Windows dotnet install

### DIFF
--- a/.github/workflows/attempt-release.yml
+++ b/.github/workflows/attempt-release.yml
@@ -34,6 +34,9 @@ jobs:
 
       - name: Setup mise and install tools
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
+        with:
+          # Pin mise: 2026.6.10 broke the vfox:dotnet install on Windows (jdx/mise#10323).
+          version: 2026.6.9
 
       - name: Check for unreleased changes
         id: check

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,6 +14,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup mise and install tools
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
+        with:
+          # Pin mise: 2026.6.10 broke the vfox:dotnet install on Windows (jdx/mise#10323).
+          version: 2026.6.9
       - name: Verify
         run: |
           if ! gh release list | grep -q "$(changie latest)"; then

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,6 +46,9 @@ jobs:
           submodules: 'recursive'
       - name: Setup mise and install tools
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
+        with:
+          # Pin mise: 2026.6.10 broke the vfox:dotnet install on Windows (jdx/mise#10323).
+          version: 2026.6.9
       - name: Run `make format_check`
         run: make format_check
 
@@ -60,6 +63,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup mise and install tools
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
+        with:
+          # Pin mise: 2026.6.10 broke the vfox:dotnet install on Windows (jdx/mise#10323).
+          version: 2026.6.9
       - name: Run `make lint_language_host`
         run: make lint_language_host GOLANGCI_LINT_ARGS=--output.text.path=stdout
       - name: Run `make lint_integration_tests`
@@ -76,6 +82,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup mise and install tools
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
+        with:
+          # Pin mise: 2026.6.10 broke the vfox:dotnet install on Windows (jdx/mise#10323).
+          version: 2026.6.9
       - name: Check if folder is empty
         id: folder_check
         run: |
@@ -168,6 +177,9 @@ jobs:
           submodules: recursive
       - name: Setup mise and install tools
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
+        with:
+          # Pin mise: 2026.6.10 broke the vfox:dotnet install on Windows (jdx/mise#10323).
+          version: 2026.6.9
       - name: Set dotnet version from matrix
         run: mise use vfox:dotnet@${{ matrix.dotnet-version }}
       - name: Create global.json
@@ -221,6 +233,9 @@ jobs:
           submodules: recursive
       - name: Setup mise and install tools
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
+        with:
+          # Pin mise: 2026.6.10 broke the vfox:dotnet install on Windows (jdx/mise#10323).
+          version: 2026.6.9
       - name: Set dotnet version from matrix
         run: mise use vfox:dotnet@${{ matrix.dotnet-version }}
       - name: Install Pulumi CLI
@@ -252,6 +267,9 @@ jobs:
           submodules: recursive
       - name: Setup mise and install tools
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
+        with:
+          # Pin mise: 2026.6.10 broke the vfox:dotnet install on Windows (jdx/mise#10323).
+          version: 2026.6.9
       - name: Set dotnet version from matrix
         run: mise use vfox:dotnet@${{ matrix.dotnet-version }}
       - name: Install Pulumi CLI
@@ -277,6 +295,9 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup mise and install tools
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
+        with:
+          # Pin mise: 2026.6.10 broke the vfox:dotnet install on Windows (jdx/mise#10323).
+          version: 2026.6.9
       - name: Get version info
         id: version
         run: |


### PR DESCRIPTION
## Problem

Every Windows CI job currently fails at the **"Setup mise and install tools"** step, before any code runs:

```
Processing -File '"C:\...\vfox-dotnet\8.0.422\dotnet-install.ps1"' failed:
Illegal characters in path. Specify a valid path for the -File parameter.
mise ERROR Failed to install vfox:dotnet@8.0: ... dotnet binary not found
```

The runner installs the **latest** mise, which is now `2026.6.10` (released 2026-06-14). That release regressed how mise invokes the `vfox:dotnet` plugin's PowerShell post-install on Windows: the script path reaches `powershell -File` wrapped in literal double quotes (`-File '"…"'`), which PowerShell rejects as *"Illegal characters in path"*. dotnet is never installed and the job dies.

The bug only triggers on a mise **cache miss** (a fresh `mise install`), which is why `main` has stayed green — its recent runs restore a pre-existing dotnet tool cache and never re-run the broken post-install. Any branch that gets a cache miss fails identically.

## Why pin instead of changing `mise.toml`

The failure is inside the `vfox-dotnet` plugin's own post-install hook, which mise mis-quotes — we author neither the plugin's command string nor mise's quoting layer, so it can't be worked around from our tool config. Pinning the mise binary is the only effective, surgical lever.

## Change

Add `version: 2026.6.9` (the last release before the regression) to the `jdx/mise-action` `version` input in all workflows that install tools — `pr.yml` (7 steps), `changelog.yml`, `attempt-release.yml`.

This is reversible: delete the `version:` lines once mise ships a fix (suspected culprit: jdx/mise#10323, "preserve inner quotes for remaining cmd /c call sites on windows").

## Validation

If this PR's Windows jobs go green, it confirms mise `2026.6.10` is the cause.