### PR TITLE
Force a release to bump `pulumi/pulumi`

### DIFF
--- a/.changes/unreleased/Improvements-123.yaml
+++ b/.changes/unreleased/Improvements-123.yaml
@@ -3,4 +3,4 @@ kind: Improvements
 body: Bump the `pulumi/pulumi` version
 time: 2026-07-23T15:25:28.062722+01:00
 custom:
-    PR: "123"
+    PR: "1084"

--- a/.changes/unreleased/Improvements-123.yaml
+++ b/.changes/unreleased/Improvements-123.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Bump the `pulumi/pulumi` version
+time: 2026-07-23T15:25:28.062722+01:00
+custom:
+    PR: "123"


### PR DESCRIPTION
We need a PR with a changelog to trigger a new release, and Renovate currently doesn't produce a changelog when it bumps versions. This PR is nothing but a changelog, which is something we can deploy.