### PR TITLE
Fix deserialising deep computed values

### DIFF
--- a/.changes/unreleased/bug-fixes-1093.yaml
+++ b/.changes/unreleased/bug-fixes-1093.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Fix deserialisation of deeply nested computed values
+time: 2026-07-30T13:35:14.952768+01:00
+custom:
+    PR: "1093"

--- a/sdk/Pulumi.Tests/Core/PropertyValueTests.cs
+++ b/sdk/Pulumi.Tests/Core/PropertyValueTests.cs
@@ -408,6 +408,42 @@ public class PropertyValueTests
         Assert.Equal(containerBrightness, args.ContainerBrightness);
     }
 
+    // Repro for https://github.com/pulumi/pulumi-dotnet/issues/1092: Deserializing an InputList<string> whose element
+    // is a Computed (unknown) value fails with: "Error while deserializing value of type String from property value of
+    // type Computed. Expected String instead at path [$, index[0]]."
+    [Fact]
+    public async Task DeserializingInputListWithUnknownStringElementWorks()
+    {
+        var serializer = CreateSerializer();
+        var listWithUnknown = Array(PropertyValue.Computed);
+        var deserialized = await serializer.Deserialize<InputList<string>>(listWithUnknown);
+        var output = deserialized.ToOutput();
+        var data = await output.DataTask;
+        Assert.False(data.IsKnown);
+        Assert.False(data.IsSecret);
+    }
+
+    // Nested-Input case for #1092: an InputList<Input<string>> element can represent unknown per-slot, so the top-level
+    // Input<T> should NOT collapse to unknown — only the specific slot should.
+    [Fact]
+    public async Task DeserializingListOfInputStringPreservesKnownElements()
+    {
+        var serializer = CreateSerializer();
+        var listWithMixed = Array(new PropertyValue("hi"), PropertyValue.Computed);
+        var deserialized = await serializer.Deserialize<InputList<Input<string>>>(listWithMixed);
+        var output = deserialized.ToOutput();
+        var data = await output.DataTask;
+        Assert.True(data.IsKnown);
+        Assert.Equal(2, data.Value.Length);
+
+        var firstData = await data.Value[0].ToOutput().DataTask;
+        Assert.True(firstData.IsKnown);
+        Assert.Equal("hi", firstData.Value);
+
+        var secondData = await data.Value[1].ToOutput().DataTask;
+        Assert.False(secondData.IsKnown);
+    }
+
     [Fact]
     public async Task DeserializingUnknownInputsWorks()
     {

--- a/sdk/Pulumi/Core/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Core/PropertyValueSerializer.cs
@@ -401,7 +401,18 @@ namespace Pulumi.Experimental
         public object? Deserialize(PropertyValue value, Type targetType)
         {
             var rootPath = new[] { "$" };
-            return DeserializeValue(value, targetType, rootPath);
+            try {
+                return DeserializeValue(value, targetType, rootPath);
+            } catch(UnhandledUnknownException exc) {
+                throw exc.InnerException!;
+            }
+        }
+
+        private sealed class UnhandledUnknownException : Exception
+        {
+            public UnhandledUnknownException(InvalidOperationException innerException) : base("Unhandled unknown value", innerException)
+            {
+            }
         }
 
         private object? DeserializeValue(PropertyValue value, Type targetType, string[] path)
@@ -422,7 +433,12 @@ namespace Pulumi.Experimental
                     targetType: targetType,
                     path: path);
 
-                throw new InvalidOperationException(error);
+                var inner =  new InvalidOperationException(error);
+                if (value.IsComputed)
+                {
+                    throw new UnhandledUnknownException(inner);
+                }
+                throw inner;
             }
 
             if (targetType == typeof(PropertyValue))
@@ -607,13 +623,20 @@ namespace Pulumi.Experimental
                     return CreateInput(secretOutput);
                 }
 
-                var deserialized = value.IsComputed ? null : DeserializeValue(value, elementType, path);
+                object? deserialized;
+                var known = !value.IsComputed;
+                try {
+                    deserialized = value.IsComputed ? null : DeserializeValue(value, elementType, path);
+                } catch (UnhandledUnknownException) {
+                    deserialized = null;
+                    known = false;
+                }
 
                 var outputDataValue = createOutputData.Invoke(new object?[]
                 {
                     ImmutableHashSet<Resource>.Empty,
                     deserialized,
-                    !value.IsComputed,
+                    known,
                     false
                 });
 

--- a/sdk/Pulumi/Core/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Core/PropertyValueSerializer.cs
@@ -401,9 +401,12 @@ namespace Pulumi.Experimental
         public object? Deserialize(PropertyValue value, Type targetType)
         {
             var rootPath = new[] { "$" };
-            try {
+            try
+            {
                 return DeserializeValue(value, targetType, rootPath);
-            } catch(UnhandledUnknownException exc) {
+            }
+            catch (UnhandledUnknownException exc)
+            {
                 throw exc.InnerException!;
             }
         }
@@ -433,7 +436,7 @@ namespace Pulumi.Experimental
                     targetType: targetType,
                     path: path);
 
-                var inner =  new InvalidOperationException(error);
+                var inner = new InvalidOperationException(error);
                 if (value.IsComputed)
                 {
                     throw new UnhandledUnknownException(inner);
@@ -625,9 +628,12 @@ namespace Pulumi.Experimental
 
                 object? deserialized;
                 var known = !value.IsComputed;
-                try {
+                try
+                {
                     deserialized = value.IsComputed ? null : DeserializeValue(value, elementType, path);
-                } catch (UnhandledUnknownException) {
+                }
+                catch (UnhandledUnknownException)
+                {
                     deserialized = null;
                     known = false;
                 }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-dotnet/issues/1092

This fixes `DeserializeValue` to handle computed values deeply underneath an `Input/Output` type. It used to be that we'd only look and handle computed directly at the `Input/Output` layer, so something like `DeserializeValue<Input<string>>(computed)` would work. Now we also handle it if the computed value is nested deeper, for example `DeserializeValue<Input<List<String>>>(["hi", computed])`.

We do this by tracking a special internal exception (`UnhandledUnknownException`) which if we see while building an `Output<T>` return the whole output as unknown. If `UnhandledUnknownException` bubbles all the way to the top level we just pull of the internal `InvalidOperationException` that we would have thrown before this change.