### PR TITLE
skip CA1824 analyzer as it can crash

### DIFF
--- a/sdk/Directory.Build.targets
+++ b/sdk/Directory.Build.targets
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <!-- The CA1824 analyzer in the .NET 8 SDK has a race condition that intermittently
+         crashes builds (AD0001 NullReferenceException). Suppressing its only rule makes
+         Roslyn skip the analyzer entirely; it can never fire here anyway (no .resx). -->
+    <NoWarn>$(NoWarn);CA1824</NoWarn>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This analyzer has a race condition in .NET8.0, and can crash intermittently, leading to test failures, e.g. in https://github.com/pulumi/pulumi-dotnet/actions/runs/30601902134/job/91066218184.

As far as I understand this analyzer is not relevant to us, because we don't have ResX-based resources.  Just disable it to avoid tests flaking.

Fixes #1095 