### PR TITLE
Don't force Auto API regeneration as part of regular CI

### DIFF
--- a/.changes/unreleased/Improvements-1106.yaml
+++ b/.changes/unreleased/Improvements-1106.yaml
@@ -1,0 +1,6 @@
+component: sdk/auto
+kind: Improvements
+body: Stop regenerating the Automation API during PR CI, so unrelated PRs are not blocked by codegen drift
+time: 2026-08-06T17:30:27.28377+02:00
+custom:
+    PR: "1106"

--- a/.changes/unreleased/Improvements-1106.yaml
+++ b/.changes/unreleased/Improvements-1106.yaml
@@ -1,6 +1,0 @@
-component: sdk/auto
-kind: Improvements
-body: Stop regenerating the Automation API during PR CI, so unrelated PRs are not blocked by codegen drift
-time: 2026-08-06T17:30:27.28377+02:00
-custom:
-    PR: "1106"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -140,11 +140,6 @@ jobs:
           pulumi-version: dev
       - name: Build Pulumi SDK
         run: make build_sdk
-      - name: Test Automation API codegen
-        # Regenerates the Automation API interface from the pinned submodule's
-        # CLI specification, so the workspace check below also catches
-        # generated code that was not regenerated after a submodule bump.
-        run: make test_automation_codegen
       - name: Workspace clean (are xml doc and generated file updates committed?)
         uses: pulumi/git-status-check-action@0d90c81496aa8d6a31d9c6a0d6297feea2f54057 # v2
         with:


### PR DESCRIPTION
We want the Automation API to update at the speed of engine releases, not at the speed of SDK releases. Engine also opens fresh PRs for these changes already, so we don't need to enforce this as part of unrelated work's CI processes.