### PR TITLE
Dispatch discriminated union deserialization on the discriminator tag

### DIFF
--- a/.changes/unreleased/improvements-1104.yaml
+++ b/.changes/unreleased/improvements-1104.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Deserialize discriminated union values by dispatching on the schema discriminator property via the new DiscriminatedUnionType/DiscriminatedUnionCase attributes, instead of structural first-match
+time: 2026-08-06T10:05:08.437174-04:00
+custom:
+    PR: "1104"

--- a/.changes/unreleased/improvements-1104.yaml
+++ b/.changes/unreleased/improvements-1104.yaml
@@ -1,6 +1,6 @@
 component: sdk
 kind: Improvements
-body: Deserialize discriminated union values by dispatching on the schema discriminator property via the new DiscriminatedUnionType/DiscriminatedUnionCase attributes, instead of structural first-match
+body: Deserialize discriminated union values by dispatching on the schema discriminator property via the new DiscriminatedUnionDiscriminator/DiscriminatedUnionCase attributes, instead of structural first-match
 time: 2026-08-06T10:05:08.437174-04:00
 custom:
     PR: "1104"

--- a/.changes/unreleased/improvements-1107.yaml
+++ b/.changes/unreleased/improvements-1107.yaml
@@ -3,4 +3,4 @@ kind: Improvements
 body: Deserialize discriminated union values by dispatching on the schema discriminator property via the new DiscriminatedUnionDiscriminator/DiscriminatedUnionCase attributes, instead of structural first-match
 time: 2026-08-06T10:05:08.437174-04:00
 custom:
-    PR: "1104"
+    PR: "1107"

--- a/sdk/Pulumi.Tests/Core/PropertyValueTests.cs
+++ b/sdk/Pulumi.Tests/Core/PropertyValueTests.cs
@@ -894,4 +894,60 @@ public class PropertyValueTests
         var tags = await result.Tags.ToOutput().DataTask;
         Assert.False(tags.IsKnown, "tags should be unknown");
     }
+
+    // "password" and "token" share an identical property shape; only the discriminator
+    // can tell them apart.
+    [DiscriminatedUnionType("__type")]
+    [DiscriminatedUnionCase("password", typeof(PasswordCredential))]
+    [DiscriminatedUnionCase("token", typeof(TokenCredential))]
+    [DiscriminatedUnionCase("certificate", typeof(CertificateCredential))]
+    public interface ICredential
+    {
+    }
+
+    public class PasswordCredential : ICredential
+    {
+        public string Data { get; set; } = string.Empty;
+    }
+
+    public class TokenCredential : ICredential
+    {
+        public string Data { get; set; } = string.Empty;
+    }
+
+    public class CertificateCredential : ICredential
+    {
+        public string Data { get; set; } = string.Empty;
+        public string? Thumbprint { get; set; }
+    }
+
+    [Fact]
+    public async Task DeserializingDiscriminatedUnionDispatchesOnTag()
+    {
+        var serializer = CreateSerializer();
+        var data = Object(
+            Pair("__type", new PropertyValue("token")),
+            Pair("Data", new PropertyValue("abc")));
+
+        var credential = await serializer.Deserialize<ICredential>(data);
+
+        var token = Assert.IsType<TokenCredential>(credential);
+        Assert.Equal("abc", token.Data);
+    }
+
+    [Fact]
+    public async Task DeserializingDiscriminatedUnionWithUnknownTagThrows()
+    {
+        var serializer = CreateSerializer();
+        var data = Object(
+            Pair("__type", new PropertyValue("oauth")),
+            Pair("Data", new PropertyValue("abc")));
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            serializer.Deserialize<ICredential>(data));
+
+        Assert.Equal(
+            "unknown \"__type\" value \"oauth\"; expected one of: certificate, password, token",
+            exception.Message);
+    }
 }

--- a/sdk/Pulumi.Tests/Core/PropertyValueTests.cs
+++ b/sdk/Pulumi.Tests/Core/PropertyValueTests.cs
@@ -897,7 +897,7 @@ public class PropertyValueTests
 
     // "password" and "token" share an identical property shape; only the discriminator
     // can tell them apart.
-    [DiscriminatedUnionType("__type")]
+    [DiscriminatedUnionDiscriminator("type")]
     [DiscriminatedUnionCase("password", typeof(PasswordCredential))]
     [DiscriminatedUnionCase("token", typeof(TokenCredential))]
     [DiscriminatedUnionCase("certificate", typeof(CertificateCredential))]
@@ -926,7 +926,7 @@ public class PropertyValueTests
     {
         var serializer = CreateSerializer();
         var data = Object(
-            Pair("__type", new PropertyValue("token")),
+            Pair("type", new PropertyValue("token")),
             Pair("Data", new PropertyValue("abc")));
 
         var credential = await serializer.Deserialize<ICredential>(data);
@@ -940,14 +940,14 @@ public class PropertyValueTests
     {
         var serializer = CreateSerializer();
         var data = Object(
-            Pair("__type", new PropertyValue("oauth")),
+            Pair("type", new PropertyValue("oauth")),
             Pair("Data", new PropertyValue("abc")));
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             serializer.Deserialize<ICredential>(data));
 
         Assert.Equal(
-            "unknown \"__type\" value \"oauth\"; expected one of: certificate, password, token",
+            "unknown \"type\" value \"oauth\"; expected one of: certificate, password, token",
             exception.Message);
     }
 }

--- a/sdk/Pulumi.Tests/Serialization/DiscriminatedUnionConverterTests.cs
+++ b/sdk/Pulumi.Tests/Serialization/DiscriminatedUnionConverterTests.cs
@@ -1,0 +1,205 @@
+// Copyright 2016-2026, Pulumi Corporation
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Pulumi.Serialization;
+using Xunit;
+
+namespace Pulumi.Tests.Serialization
+{
+    public class DiscriminatedUnionConverterTests : ConverterTests
+    {
+        // "basic" and "bearer" deliberately share an identical property shape so that only
+        // discriminator dispatch (not structural first-match) can tell them apart.
+        [DiscriminatedUnionType("discriminantKind")]
+        [DiscriminatedUnionCase("basic", typeof(BasicAuth))]
+        [DiscriminatedUnionCase("bearer", typeof(BearerAuth))]
+        [DiscriminatedUnionCase("apiKey", typeof(ApiKeyAuth))]
+        public interface IAuthConfig
+        {
+        }
+
+        [OutputType]
+        public sealed class BasicAuth : IAuthConfig
+        {
+            public readonly string Value;
+
+            [OutputConstructor]
+            public BasicAuth(string value)
+            {
+                Value = value;
+            }
+        }
+
+        [OutputType]
+        public sealed class BearerAuth : IAuthConfig
+        {
+            public readonly string Value;
+
+            [OutputConstructor]
+            public BearerAuth(string value)
+            {
+                Value = value;
+            }
+        }
+
+        [OutputType]
+        public sealed class ApiKeyAuth : IAuthConfig
+        {
+            public readonly string Header;
+            public readonly string Value;
+
+            [OutputConstructor]
+            public ApiKeyAuth(string header, string value)
+            {
+                Header = header;
+                Value = value;
+            }
+        }
+
+        [OutputType]
+        public sealed class EndpointType
+        {
+            public readonly string Url;
+            public readonly IAuthConfig Auth;
+
+            [OutputConstructor]
+            public EndpointType(string url, IAuthConfig auth)
+            {
+                Url = url;
+                Auth = auth;
+            }
+        }
+
+        [Fact]
+        public async Task DispatchesOnTagEvenWhenEarlierCaseIsStructurallyCompatible()
+        {
+            var data = Converter.ConvertValue<IAuthConfig>(NoWarn, "", await SerializeToValueAsync(new Dictionary<string, object>
+            {
+                { "discriminantKind", "bearer" },
+                { "value", "token" },
+            }));
+
+            var bearer = Assert.IsType<BearerAuth>(data.Value);
+            Assert.Equal("token", bearer.Value);
+            Assert.True(data.IsKnown);
+        }
+
+        [Fact]
+        public async Task BasicTagConverts()
+        {
+            var data = Converter.ConvertValue<IAuthConfig>(NoWarn, "", await SerializeToValueAsync(new Dictionary<string, object>
+            {
+                { "discriminantKind", "basic" },
+                { "value", "hunter2" },
+            }));
+
+            var basic = Assert.IsType<BasicAuth>(data.Value);
+            Assert.Equal("hunter2", basic.Value);
+            Assert.True(data.IsKnown);
+        }
+
+        [Fact]
+        public async Task BearerTagConverts()
+        {
+            var data = Converter.ConvertValue<IAuthConfig>(NoWarn, "", await SerializeToValueAsync(new Dictionary<string, object>
+            {
+                { "discriminantKind", "bearer" },
+                { "value", "token" },
+            }));
+
+            var bearer = Assert.IsType<BearerAuth>(data.Value);
+            Assert.Equal("token", bearer.Value);
+            Assert.True(data.IsKnown);
+        }
+
+        [Fact]
+        public async Task ApiKeyTagConverts()
+        {
+            var data = Converter.ConvertValue<IAuthConfig>(NoWarn, "", await SerializeToValueAsync(new Dictionary<string, object>
+            {
+                { "discriminantKind", "apiKey" },
+                { "header", "X-Api-Key" },
+                { "value", "key" },
+            }));
+
+            var apiKey = Assert.IsType<ApiKeyAuth>(data.Value);
+            Assert.Equal("X-Api-Key", apiKey.Header);
+            Assert.Equal("key", apiKey.Value);
+            Assert.True(data.IsKnown);
+        }
+
+        [Fact]
+        public async Task UnknownTagLogs()
+        {
+            string? loggedError = null;
+            Action<string> warn = error => loggedError = error;
+
+            var data = Converter.ConvertValue<IAuthConfig>(warn, "", await SerializeToValueAsync(new Dictionary<string, object>
+            {
+                { "discriminantKind", "oauth" },
+                { "value", "token" },
+            }));
+
+            Assert.Null(data.Value);
+            Assert.Equal(
+                "unknown \"discriminantKind\" value \"oauth\"; expected one of: apiKey, basic, bearer deserializing ",
+                loggedError);
+        }
+
+        [Fact]
+        public async Task MissingDiscriminatorPropertyLogs()
+        {
+            string? loggedError = null;
+            Action<string> warn = error => loggedError = error;
+
+            var data = Converter.ConvertValue<IAuthConfig>(warn, "", await SerializeToValueAsync(new Dictionary<string, object>
+            {
+                { "value", "token" },
+            }));
+
+            Assert.Null(data.Value);
+            Assert.Equal(
+                "missing discriminator property \"discriminantKind\"; expected one of: apiKey, basic, bearer deserializing ",
+                loggedError);
+        }
+
+        [Fact]
+        public async Task NestedUnionInsideOutputTypeConverts()
+        {
+            var data = Converter.ConvertValue<EndpointType>(NoWarn, "", await SerializeToValueAsync(new Dictionary<string, object>
+            {
+                { "url", "https://example.com" },
+                {
+                    "auth",
+                    new Dictionary<string, object>
+                    {
+                        { "discriminantKind", "bearer" },
+                        { "value", "token" },
+                    }
+                },
+            }));
+
+            Assert.Equal("https://example.com", data.Value.Url);
+            var bearer = Assert.IsType<BearerAuth>(data.Value.Auth);
+            Assert.Equal("token", bearer.Value);
+            Assert.True(data.IsKnown);
+        }
+
+        [Fact]
+        public async Task SecretUnionValueConverts()
+        {
+            var data = Converter.ConvertValue<IAuthConfig>(NoWarn, "", CreateSecretValue(await SerializeToValueAsync(new Dictionary<string, object>
+            {
+                { "discriminantKind", "bearer" },
+                { "value", "token" },
+            })));
+
+            var bearer = Assert.IsType<BearerAuth>(data.Value);
+            Assert.Equal("token", bearer.Value);
+            Assert.True(data.IsKnown);
+            Assert.True(data.IsSecret);
+        }
+    }
+}

--- a/sdk/Pulumi.Tests/Serialization/DiscriminatedUnionConverterTests.cs
+++ b/sdk/Pulumi.Tests/Serialization/DiscriminatedUnionConverterTests.cs
@@ -12,7 +12,7 @@ namespace Pulumi.Tests.Serialization
     {
         // "basic" and "bearer" deliberately share an identical property shape so that only
         // discriminator dispatch (not structural first-match) can tell them apart.
-        [DiscriminatedUnionType("discriminantKind")]
+        [DiscriminatedUnionDiscriminator("discriminantKind")]
         [DiscriminatedUnionCase("basic", typeof(BasicAuth))]
         [DiscriminatedUnionCase("bearer", typeof(BearerAuth))]
         [DiscriminatedUnionCase("apiKey", typeof(ApiKeyAuth))]

--- a/sdk/Pulumi/Core/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Core/PropertyValueSerializer.cs
@@ -972,7 +972,7 @@ namespace Pulumi.Experimental
 
             if (targetType.IsInterface)
             {
-                var unionAttribute = targetType.GetCustomAttribute<DiscriminatedUnionTypeAttribute>();
+                var unionAttribute = targetType.GetCustomAttribute<DiscriminatedUnionDiscriminatorAttribute>();
                 if (unionAttribute != null && value.TryGetMap(out var unionProperties))
                 {
                     var cases = targetType.GetCustomAttributes<DiscriminatedUnionCaseAttribute>().ToArray();

--- a/sdk/Pulumi/Core/PropertyValueSerializer.cs
+++ b/sdk/Pulumi/Core/PropertyValueSerializer.cs
@@ -970,6 +970,32 @@ namespace Pulumi.Experimental
                 ThrowTypeMismatchError(PropertyValueType.Map);
             }
 
+            if (targetType.IsInterface)
+            {
+                var unionAttribute = targetType.GetCustomAttribute<DiscriminatedUnionTypeAttribute>();
+                if (unionAttribute != null && value.TryGetMap(out var unionProperties))
+                {
+                    var cases = targetType.GetCustomAttributes<DiscriminatedUnionCaseAttribute>().ToArray();
+                    var expectedTags = string.Join(", ", cases.Select(c => c.Tag).OrderBy(t => t, StringComparer.Ordinal));
+
+                    if (!unionProperties.TryGetValue(unionAttribute.PropertyName, out var tagValue) ||
+                        !tagValue.TryGetString(out var tag))
+                    {
+                        throw new InvalidOperationException(
+                            $"missing discriminator property \"{unionAttribute.PropertyName}\"; expected one of: {expectedTags}");
+                    }
+
+                    var matchedCase = cases.FirstOrDefault(unionCase => unionCase.Tag == tag);
+                    if (matchedCase == null)
+                    {
+                        throw new InvalidOperationException(
+                            $"unknown \"{unionAttribute.PropertyName}\" value \"{tag}\"; expected one of: {expectedTags}");
+                    }
+
+                    return DeserializeObject(unionProperties, matchedCase.Type, path);
+                }
+            }
+
             if (targetType.IsClass || targetType.IsValueType)
             {
                 if (value.TryGetMap(out var objectProperties))

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -3373,20 +3373,20 @@
                  but is recommended and is what our codegen does.
              </summary>
         </member>
-        <member name="T:Pulumi.DiscriminatedUnionTypeAttribute">
+        <member name="T:Pulumi.DiscriminatedUnionDiscriminatorAttribute">
             <summary>
-            Attribute used by a Pulumi Cloud Provider Package to mark an interface that represents a
-            discriminated union of complex output property types. The interface must also carry one
+            Attribute used to mark an interface that represents a discriminated union of complex
+            output property types. The interface must also carry one
             <see cref="T:Pulumi.DiscriminatedUnionCaseAttribute"/> per union member. When deserializing, the
-            Pulumi runtime reads the discriminator property named by <see cref="P:Pulumi.DiscriminatedUnionTypeAttribute.PropertyName"/> from
+            Pulumi runtime reads the discriminator property named by <see cref="P:Pulumi.DiscriminatedUnionDiscriminatorAttribute.PropertyName"/> from
             the raw value and instantiates the member whose tag matches.
             </summary>
         </member>
         <member name="T:Pulumi.DiscriminatedUnionCaseAttribute">
             <summary>
-            Attribute used by a Pulumi Cloud Provider Package to declare one member of a discriminated
-            union interface marked with <see cref="T:Pulumi.DiscriminatedUnionTypeAttribute"/>. <see cref="P:Pulumi.DiscriminatedUnionCaseAttribute.Tag"/>
-            is the discriminator property value that selects this member, and <see cref="P:Pulumi.DiscriminatedUnionCaseAttribute.Type"/> is the
+            Attribute used to declare one member of a discriminated union interface marked with
+            <see cref="T:Pulumi.DiscriminatedUnionDiscriminatorAttribute"/>. <see cref="P:Pulumi.DiscriminatedUnionCaseAttribute.Tag"/> is the
+            discriminator property value that selects this member, and <see cref="P:Pulumi.DiscriminatedUnionCaseAttribute.Type"/> is the
             concrete <see cref="T:Pulumi.OutputTypeAttribute"/> class to instantiate; it must implement the
             annotated interface.
             </summary>

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -3373,6 +3373,24 @@
                  but is recommended and is what our codegen does.
              </summary>
         </member>
+        <member name="T:Pulumi.DiscriminatedUnionTypeAttribute">
+            <summary>
+            Attribute used by a Pulumi Cloud Provider Package to mark an interface that represents a
+            discriminated union of complex output property types. The interface must also carry one
+            <see cref="T:Pulumi.DiscriminatedUnionCaseAttribute"/> per union member. When deserializing, the
+            Pulumi runtime reads the discriminator property named by <see cref="P:Pulumi.DiscriminatedUnionTypeAttribute.PropertyName"/> from
+            the raw value and instantiates the member whose tag matches.
+            </summary>
+        </member>
+        <member name="T:Pulumi.DiscriminatedUnionCaseAttribute">
+            <summary>
+            Attribute used by a Pulumi Cloud Provider Package to declare one member of a discriminated
+            union interface marked with <see cref="T:Pulumi.DiscriminatedUnionTypeAttribute"/>. <see cref="P:Pulumi.DiscriminatedUnionCaseAttribute.Tag"/>
+            is the discriminator property value that selects this member, and <see cref="P:Pulumi.DiscriminatedUnionCaseAttribute.Type"/> is the
+            concrete <see cref="T:Pulumi.OutputTypeAttribute"/> class to instantiate; it must implement the
+            annotated interface.
+            </summary>
+        </member>
         <member name="F:Pulumi.Serialization.Constants.UnknownValue">
             <summary>
             Unknown values are encoded as a distinguished string value.

--- a/sdk/Pulumi/Serialization/Attributes.cs
+++ b/sdk/Pulumi/Serialization/Attributes.cs
@@ -112,27 +112,27 @@ namespace Pulumi
     }
 
     /// <summary>
-    /// Attribute used by a Pulumi Cloud Provider Package to mark an interface that represents a
-    /// discriminated union of complex output property types. The interface must also carry one
+    /// Attribute used to mark an interface that represents a discriminated union of complex
+    /// output property types. The interface must also carry one
     /// <see cref="DiscriminatedUnionCaseAttribute"/> per union member. When deserializing, the
     /// Pulumi runtime reads the discriminator property named by <see cref="PropertyName"/> from
     /// the raw value and instantiates the member whose tag matches.
     /// </summary>
     [AttributeUsage(AttributeTargets.Interface)]
-    public sealed class DiscriminatedUnionTypeAttribute : Attribute
+    public sealed class DiscriminatedUnionDiscriminatorAttribute : Attribute
     {
         public string PropertyName { get; }
 
-        public DiscriminatedUnionTypeAttribute(string propertyName)
+        public DiscriminatedUnionDiscriminatorAttribute(string propertyName)
         {
             PropertyName = propertyName;
         }
     }
 
     /// <summary>
-    /// Attribute used by a Pulumi Cloud Provider Package to declare one member of a discriminated
-    /// union interface marked with <see cref="DiscriminatedUnionTypeAttribute"/>. <see cref="Tag"/>
-    /// is the discriminator property value that selects this member, and <see cref="Type"/> is the
+    /// Attribute used to declare one member of a discriminated union interface marked with
+    /// <see cref="DiscriminatedUnionDiscriminatorAttribute"/>. <see cref="Tag"/> is the
+    /// discriminator property value that selects this member, and <see cref="Type"/> is the
     /// concrete <see cref="OutputTypeAttribute"/> class to instantiate; it must implement the
     /// annotated interface.
     /// </summary>

--- a/sdk/Pulumi/Serialization/Attributes.cs
+++ b/sdk/Pulumi/Serialization/Attributes.cs
@@ -2,6 +2,7 @@
 
 using System;
 using Google.Protobuf.WellKnownTypes;
+using Type = System.Type;
 
 namespace Pulumi
 {
@@ -108,6 +109,44 @@ namespace Pulumi
     [AttributeUsage(AttributeTargets.Struct)]
     public sealed class EnumTypeAttribute : Attribute
     {
+    }
+
+    /// <summary>
+    /// Attribute used by a Pulumi Cloud Provider Package to mark an interface that represents a
+    /// discriminated union of complex output property types. The interface must also carry one
+    /// <see cref="DiscriminatedUnionCaseAttribute"/> per union member. When deserializing, the
+    /// Pulumi runtime reads the discriminator property named by <see cref="PropertyName"/> from
+    /// the raw value and instantiates the member whose tag matches.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Interface)]
+    public sealed class DiscriminatedUnionTypeAttribute : Attribute
+    {
+        public string PropertyName { get; }
+
+        public DiscriminatedUnionTypeAttribute(string propertyName)
+        {
+            PropertyName = propertyName;
+        }
+    }
+
+    /// <summary>
+    /// Attribute used by a Pulumi Cloud Provider Package to declare one member of a discriminated
+    /// union interface marked with <see cref="DiscriminatedUnionTypeAttribute"/>. <see cref="Tag"/>
+    /// is the discriminator property value that selects this member, and <see cref="Type"/> is the
+    /// concrete <see cref="OutputTypeAttribute"/> class to instantiate; it must implement the
+    /// annotated interface.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Interface, AllowMultiple = true)]
+    public sealed class DiscriminatedUnionCaseAttribute : Attribute
+    {
+        public string Tag { get; }
+        public Type Type { get; }
+
+        public DiscriminatedUnionCaseAttribute(string tag, Type type)
+        {
+            Tag = tag;
+            Type = type;
+        }
     }
 
     [AttributeUsage(AttributeTargets.Class)]

--- a/sdk/Pulumi/Serialization/Converter.cs
+++ b/sdk/Pulumi/Serialization/Converter.cs
@@ -189,7 +189,7 @@ namespace Pulumi.Serialization
 
             if (targetType.IsInterface)
             {
-                var unionAttribute = targetType.GetCustomAttribute<DiscriminatedUnionTypeAttribute>();
+                var unionAttribute = targetType.GetCustomAttribute<DiscriminatedUnionDiscriminatorAttribute>();
                 if (unionAttribute != null)
                     return TryConvertDiscriminatedUnion(warn, context, val, targetType, unionAttribute);
             }
@@ -296,7 +296,7 @@ namespace Pulumi.Serialization
             => val is T t ? (t, null) : (default(T)!, $"Expected {typeof(T).FullName} but got {val.GetType().FullName} deserializing {context}");
 
         private static (object?, string?) TryConvertDiscriminatedUnion(
-            Action<string> warn, string context, object val, Type targetType, DiscriminatedUnionTypeAttribute unionAttribute)
+            Action<string> warn, string context, object val, Type targetType, DiscriminatedUnionDiscriminatorAttribute unionAttribute)
         {
             if (!(val is ImmutableDictionary<string, object> dictionary))
                 return (null,
@@ -536,7 +536,7 @@ namespace Pulumi.Serialization
 
             if (targetType.IsInterface)
             {
-                var unionAttribute = targetType.GetCustomAttribute<DiscriminatedUnionTypeAttribute>();
+                var unionAttribute = targetType.GetCustomAttribute<DiscriminatedUnionDiscriminatorAttribute>();
                 if (unionAttribute != null)
                 {
                     foreach (var unionCase in targetType.GetCustomAttributes<DiscriminatedUnionCaseAttribute>())

--- a/sdk/Pulumi/Serialization/Converter.cs
+++ b/sdk/Pulumi/Serialization/Converter.cs
@@ -187,6 +187,13 @@ namespace Pulumi.Serialization
                     $"Unexpected generic target type {targetType.FullName} when deserializing {context}");
             }
 
+            if (targetType.IsInterface)
+            {
+                var unionAttribute = targetType.GetCustomAttribute<DiscriminatedUnionTypeAttribute>();
+                if (unionAttribute != null)
+                    return TryConvertDiscriminatedUnion(warn, context, val, targetType, unionAttribute);
+            }
+
             if (targetType.GetCustomAttribute<OutputTypeAttribute>() == null)
                 return (null, $"Unexpected target type {targetType.FullName} when deserializing {context}");
 
@@ -287,6 +294,28 @@ namespace Pulumi.Serialization
 
         private static (T, string?) TryEnsureType<T>(string context, object val)
             => val is T t ? (t, null) : (default(T)!, $"Expected {typeof(T).FullName} but got {val.GetType().FullName} deserializing {context}");
+
+        private static (object?, string?) TryConvertDiscriminatedUnion(
+            Action<string> warn, string context, object val, Type targetType, DiscriminatedUnionTypeAttribute unionAttribute)
+        {
+            if (!(val is ImmutableDictionary<string, object> dictionary))
+                return (null,
+                    $"Expected {typeof(ImmutableDictionary<string, object>).FullName} with discriminator property \"{unionAttribute.PropertyName}\" but got {val.GetType().FullName} deserializing {context}");
+
+            var cases = targetType.GetCustomAttributes<DiscriminatedUnionCaseAttribute>().ToArray();
+            var expectedTags = string.Join(", ", cases.Select(c => c.Tag).OrderBy(t => t, StringComparer.Ordinal));
+
+            if (!dictionary.TryGetValue(unionAttribute.PropertyName, out var tagValue) || !(tagValue is string tag))
+                return (null,
+                    $"missing discriminator property \"{unionAttribute.PropertyName}\"; expected one of: {expectedTags} deserializing {context}");
+
+            var matchedCase = cases.FirstOrDefault(c => c.Tag == tag);
+            if (matchedCase == null)
+                return (null,
+                    $"unknown \"{unionAttribute.PropertyName}\" value \"{tag}\"; expected one of: {expectedTags} deserializing {context}");
+
+            return TryConvertObject(warn, context, val, matchedCase.Type);
+        }
 
         private static (object?, string?) TryConvertOneOf(Action<string> warn, string context, object val, Type oneOfType)
         {
@@ -503,6 +532,26 @@ namespace Pulumi.Serialization
                 }
                 throw new InvalidOperationException($@"{context} contains invalid type {targetType.FullName}:
     The only generic types allowed are ImmutableArray<...> and ImmutableDictionary<string, ...>");
+            }
+
+            if (targetType.IsInterface)
+            {
+                var unionAttribute = targetType.GetCustomAttribute<DiscriminatedUnionTypeAttribute>();
+                if (unionAttribute != null)
+                {
+                    foreach (var unionCase in targetType.GetCustomAttributes<DiscriminatedUnionCaseAttribute>())
+                    {
+                        if (!targetType.IsAssignableFrom(unionCase.Type))
+                        {
+                            throw new InvalidOperationException(
+                                $"{targetType.FullName} had [{nameof(DiscriminatedUnionCaseAttribute)}(\"{unionCase.Tag}\")] with type {unionCase.Type.FullName} that is not assignable to {targetType.FullName}.");
+                        }
+
+                        CheckTargetType($"{targetType.FullName}(\"{unionCase.Tag}\")", unionCase.Type, seenTypes);
+                    }
+
+                    return;
+                }
             }
 
             var propertyTypeAttribute = targetType.GetCustomAttribute<OutputTypeAttribute>();


### PR DESCRIPTION
Fixes #1104.

`Converter.TryConvertOneOf` converts against `T0` and returns on the first success; `TryConvertObject` tolerates missing keys, so for object unions the first member usually wins even when the discriminator names another. Two variants that differ only by tag cannot deserialize correctly today.

This adds a discriminator-driven path:

- `DiscriminatedUnionDiscriminatorAttribute(string propertyName)` and `DiscriminatedUnionCaseAttribute(string tag, Type type)` on a generated interface; concrete `[OutputType]` classes implement the interface.
- `Converter.TryConvertObject` resolves interface targets carrying the attribute by reading the discriminator property and delegating to the matching case type. `CheckTargetType` validates each case recursively and requires assignability to the interface.
- The same dispatch is added to `PropertyValueSerializer.DeserializeValue` for the component-provider path.
- `Union<T0,T1>` semantics are unchanged.

Unknown and missing tags produce errors naming the property and listing the valid tags.

Codegen that emits these attributes is stacked in the follow-up PR; this PR only adds runtime support, so it is inert until an SDK release carries the attributes.

## Test plan

New `DiscriminatedUnionConverterTests` covers tag dispatch where two cases have identical property shapes and differ only by tag (the case first-match cannot solve), all tags round-tripping, unknown-tag and missing-discriminator errors, nesting inside an `[OutputType]`, and secret-wrapped values. `PropertyValueTests` gains the same-shape and unknown-tag cases for the serializer path.

`dotnet test` for `Pulumi.Tests`: 413 passed, 0 failed. `dotnet format --verify-no-changes` clean.

Note for reviewers: the `Converter` fixtures use a plain discriminator name rather than a `__`-prefixed one because `Deserializer.DeserializeStruct` skips keys beginning with `__`, so such a key can never reach the converter on the output path (related: #1102).

