### PR TITLE
Avoid allocations when normalizing common Pulumi tokens

### DIFF
--- a/.changes/unreleased/improvements-1119.yaml
+++ b/.changes/unreleased/improvements-1119.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: Improve .NET program generation performance by avoiding allocations while normalizing common Pulumi tokens
+time: 2026-08-11T15:16:58-04:00
+custom:
+    PR: "1119"

--- a/pulumi-language-dotnet/codegen/gen_program.go
+++ b/pulumi-language-dotnet/codegen/gen_program.go
@@ -117,14 +117,19 @@ func (g *generator) packageForToken(token, fallback string) string {
 // "index" module and an elided module compare equal — schema tokens spell the
 // module "index" while PCL tokens omit it (e.g. "pkg::member").
 func canonicalToken(token string) string {
-	parts := strings.SplitN(token, ":", 3)
-	if len(parts) != 3 {
+	packageEnd := strings.IndexByte(token, ':')
+	if packageEnd == -1 {
 		return token
 	}
-	if parts[1] == "index" {
-		parts[1] = ""
+	moduleEnd := strings.IndexByte(token[packageEnd+1:], ':')
+	if moduleEnd == -1 {
+		return token
 	}
-	return parts[0] + ":" + parts[1] + ":" + parts[2]
+	moduleEnd += packageEnd + 1
+	if token[packageEnd+1:moduleEnd] != "index" {
+		return token
+	}
+	return token[:packageEnd+1] + token[moduleEnd:]
 }
 
 func (g *generator) resetListInitializer() {

--- a/pulumi-language-dotnet/codegen/gen_program_test.go
+++ b/pulumi-language-dotnet/codegen/gen_program_test.go
@@ -105,6 +105,7 @@ func TestCanonicalToken(t *testing.T) {
 		{token: "aws:index:Bucket", want: "aws::Bucket"},
 		{token: "aws::Bucket", want: "aws::Bucket"},
 		{token: "malformed", want: "malformed"},
+		{token: "aws:index", want: "aws:index"},
 		{token: "aws:index:Bucket:extra", want: "aws::Bucket:extra"},
 	}
 

--- a/pulumi-language-dotnet/codegen/gen_program_test.go
+++ b/pulumi-language-dotnet/codegen/gen_program_test.go
@@ -94,6 +94,28 @@ func TestGenerateProgramYAML(t *testing.T) {
 	})
 }
 
+func TestCanonicalToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		token string
+		want  string
+	}{
+		{token: "aws:s3/bucket:Bucket", want: "aws:s3/bucket:Bucket"},
+		{token: "aws:index:Bucket", want: "aws::Bucket"},
+		{token: "aws::Bucket", want: "aws::Bucket"},
+		{token: "malformed", want: "malformed"},
+		{token: "aws:index:Bucket:extra", want: "aws::Bucket:extra"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.token, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, canonicalToken(tt.token))
+		})
+	}
+}
+
 func parseAndBindProgram(t *testing.T,
 	text string,
 	name string,


### PR DESCRIPTION
.NET program generation normalizes package tokens while building schema lookup maps. Most tokens do not use the default `index` module, but `canonicalToken` currently splits and rebuilds every valid token.

This change returns the original string for the common case and allocates a new string only when it must convert `pkg:index:member` to `pkg::member`.

Measured across the complete AWS PCL corpus of 3,736 examples:

| Metric | Before | After | Change |
|---|---:|---:|---:|
| .NET generation | 15,555 ms | 8,584 ms | -44.8% |
| User CPU | 20,157 ms | 10,005 ms | -50.4% |
| System CPU | 312 ms | 141 ms | -54.8% |
| Allocated bytes | 19.97 GB | 6.30 GB | -68.5% |
| Allocations | 178,920,998 | 19,316,973 | -89.2% |
| GC cycles | 120 | 52 | -56.7% |
| GC pause | 10.064 ms | 3.726 ms | -63.0% |
| Peak RSS | 1.00 GB | 2.14 GB | +113.1% |
| Parse time | 2,828 ms | 2,752 ms | -2.7% |
| Bind time | 8,975 ms | 8,804 ms | -1.9% |

Peak RSS varied substantially between complete benchmark runs and increased in this individual run. The generated files, diagnostics, and workload counts remained unchanged.

Validation:

- `mise exec -- make format_language_host_check`
- `mise exec -- make lint_language_host`
- `mise exec -- make test_codegen`
