### PR TITLE
Cache package-derived maps during .NET program generation

### DIFF
--- a/.changes/unreleased/improvements-1120.yaml
+++ b/.changes/unreleased/improvements-1120.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: Improve repeated .NET program generation performance by caching package-derived lookup maps
+time: 2026-08-11T15:17:25-04:00
+custom:
+    PR: "1120"

--- a/pulumi-language-dotnet/codegen/gen_program.go
+++ b/pulumi-language-dotnet/codegen/gen_program.go
@@ -25,6 +25,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/hashicorp/hcl/v2"
@@ -41,6 +42,33 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/zclconf/go-cty/cty"
 )
+
+// packageContext contains package-derived data that is immutable after construction.
+type packageContext struct {
+	namespaces      map[string]map[string]string
+	compatibilities map[string]string
+	tokenToModules  map[string]func(x string) string
+	functionArgs    map[string]string
+	tokenPackages   map[string]string
+}
+
+// packageContextCacheEntry records package shape because partial package snapshots
+// can grow as binding loads additional schema entries.
+type packageContextCacheEntry struct {
+	packages      []*schema.Package
+	resourceSizes []int
+	functionSizes []int
+	typeSizes     []int
+	context       *packageContext
+}
+
+var packageContexts = struct {
+	sync.Mutex
+	entries []*packageContextCacheEntry
+}{}
+
+// packageContextCacheSize limits the package schemas retained by a long-running language host.
+const packageContextCacheSize = 16
 
 type GenerateProgramOptions struct {
 	// Determines whether ResourceArg types have an implicit name
@@ -132,6 +160,95 @@ func canonicalToken(token string) string {
 	return token[:packageEnd+1] + token[moduleEnd:]
 }
 
+// packageContextFor reuses schema-derived maps across GenerateProgram calls. Bulk generators such as tfgen bind each
+// documentation example as a separate program with a shared pcl.PackageCache, so the programs use the same package
+// objects. Partial package objects can grow between calls, which is why cache hits also require a matching shape.
+func packageContextFor(packages []*schema.Package) (*packageContext, error) {
+	packageContexts.Lock()
+	for i, entry := range packageContexts.entries {
+		if entry.matches(packages) {
+			packageContexts.entries[0], packageContexts.entries[i] = packageContexts.entries[i], packageContexts.entries[0]
+			context := entry.context
+			packageContexts.Unlock()
+			return context, nil
+		}
+	}
+	packageContexts.Unlock()
+
+	context := &packageContext{
+		namespaces:      make(map[string]map[string]string, len(packages)),
+		compatibilities: make(map[string]string, len(packages)),
+		tokenToModules:  make(map[string]func(x string) string, len(packages)),
+		functionArgs:    make(map[string]string),
+		tokenPackages:   make(map[string]string),
+	}
+	entry := &packageContextCacheEntry{
+		packages:      slices.Clone(packages),
+		resourceSizes: make([]int, len(packages)),
+		functionSizes: make([]int, len(packages)),
+		typeSizes:     make([]int, len(packages)),
+		context:       context,
+	}
+	for i, p := range packages {
+		entry.resourceSizes[i] = len(p.Resources)
+		entry.functionSizes[i] = len(p.Functions)
+		entry.typeSizes[i] = len(p.Types)
+		if err := p.ImportLanguages(map[string]schema.Language{"csharp": Importer}); err != nil {
+			return nil, err
+		}
+
+		csharpInfo, hasInfo := p.Language["csharp"].(CSharpPackageInfo)
+		if !hasInfo {
+			csharpInfo = CSharpPackageInfo{}
+		}
+		normalizePackageInfo(&csharpInfo, p.Name, p.Namespace)
+		context.namespaces[p.Name] = csharpInfo.Namespaces
+		context.compatibilities[p.Name] = csharpInfo.Compatibility
+		context.tokenToModules[p.Name] = p.TokenToModule
+
+		for _, resource := range p.Resources {
+			context.tokenPackages[canonicalToken(resource.Token)] = p.Name
+		}
+		for _, function := range p.Functions {
+			context.tokenPackages[canonicalToken(function.Token)] = p.Name
+			if function.Inputs != nil {
+				context.functionArgs[function.Inputs.Token] = function.Token
+			}
+		}
+		for _, typ := range p.Types {
+			switch typ := typ.(type) {
+			case *schema.ObjectType:
+				context.tokenPackages[canonicalToken(typ.Token)] = p.Name
+			case *schema.EnumType:
+				context.tokenPackages[canonicalToken(typ.Token)] = p.Name
+			}
+		}
+	}
+
+	packageContexts.Lock()
+	packageContexts.entries = append([]*packageContextCacheEntry{entry}, packageContexts.entries...)
+	if len(packageContexts.entries) > packageContextCacheSize {
+		packageContexts.entries = packageContexts.entries[:packageContextCacheSize]
+	}
+	packageContexts.Unlock()
+	return context, nil
+}
+
+func (entry *packageContextCacheEntry) matches(packages []*schema.Package) bool {
+	if len(entry.packages) != len(packages) {
+		return false
+	}
+	for i, p := range packages {
+		if entry.packages[i] != p ||
+			entry.resourceSizes[i] != len(p.Resources) ||
+			entry.functionSizes[i] != len(p.Functions) ||
+			entry.typeSizes[i] != len(p.Types) {
+			return false
+		}
+	}
+	return true
+}
+
 func (g *generator) resetListInitializer() {
 	g.listInitializer = "new[]"
 }
@@ -153,52 +270,22 @@ func GenerateProgramWithOptions(
 	// Linearize the nodes into an order appropriate for procedural code generation.
 	nodes := pcl.Linearize(program)
 
-	// Import C#-specific schema info.
-	namespaces := make(map[string]map[string]string)
-	compatibilities := make(map[string]string)
-	tokenToModules := make(map[string]func(x string) string)
-	functionArgs := make(map[string]string)
-	tokenPackages := make(map[string]string)
+	// Import and retain C#-specific schema info. Programs bound through the same
+	// package cache share package objects, which can grow between calls as a
+	// partial package loads more schema entries.
 	packages, err := program.PackageSnapshots()
 	if err != nil {
 		return nil, nil, err
 	}
-	for _, p := range packages {
-		if err := p.ImportLanguages(map[string]schema.Language{"csharp": Importer}); err != nil {
-			return make(map[string][]byte), nil, err
-		}
-
-		csharpInfo, hasInfo := p.Language["csharp"].(CSharpPackageInfo)
-		if !hasInfo {
-			csharpInfo = CSharpPackageInfo{}
-		}
-		normalizePackageInfo(&csharpInfo, p.Name, p.Namespace)
-		packageNamespaces := csharpInfo.Namespaces
-		namespaces[p.Name] = packageNamespaces
-		compatibilities[p.Name] = csharpInfo.Compatibility
-		tokenToModules[p.Name] = p.TokenToModule
-
-		for _, r := range p.Resources {
-			tokenPackages[canonicalToken(r.Token)] = p.Name
-		}
-		for _, fn := range p.Functions {
-			tokenPackages[canonicalToken(fn.Token)] = p.Name
-		}
-		for _, t := range p.Types {
-			switch typ := t.(type) {
-			case *schema.ObjectType:
-				tokenPackages[canonicalToken(typ.Token)] = p.Name
-			case *schema.EnumType:
-				tokenPackages[canonicalToken(typ.Token)] = p.Name
-			}
-		}
-
-		for _, f := range p.Functions {
-			if f.Inputs != nil {
-				functionArgs[f.Inputs.Token] = f.Token
-			}
-		}
+	packageContext, err := packageContextFor(packages)
+	if err != nil {
+		return make(map[string][]byte), nil, err
 	}
+	namespaces := maps.Clone(packageContext.namespaces)
+	compatibilities := packageContext.compatibilities
+	tokenToModules := packageContext.tokenToModules
+	functionArgs := packageContext.functionArgs
+	tokenPackages := packageContext.tokenPackages
 
 	g := &generator{
 		program:          program,

--- a/pulumi-language-dotnet/codegen/gen_program_test.go
+++ b/pulumi-language-dotnet/codegen/gen_program_test.go
@@ -117,6 +117,27 @@ func TestCanonicalToken(t *testing.T) {
 	}
 }
 
+func TestPackageContextCacheTracksPackageShape(t *testing.T) {
+	t.Parallel()
+
+	pkg := &schema.Package{Name: "test"}
+	packages := []*schema.Package{pkg}
+
+	first, err := packageContextFor(packages)
+	require.NoError(t, err)
+	second, err := packageContextFor(packages)
+	require.NoError(t, err)
+	require.Same(t, first, second)
+
+	pkg.Types = append(pkg.Types, &schema.ObjectType{Token: "test:index:Added"})
+	third, err := packageContextFor(packages)
+	require.NoError(t, err)
+	require.NotSame(t, first, third)
+	fourth, err := packageContextFor(packages)
+	require.NoError(t, err)
+	require.Same(t, third, fourth)
+}
+
 func parseAndBindProgram(t *testing.T,
 	text string,
 	name string,


### PR DESCRIPTION
Provider documentation generation binds each example separately but reuses one `pcl.PackageCache`. This means thousands of programs can use the same package objects. `GenerateProgram` currently scans those packages and rebuilds the same C# lookup maps for every example.

This change caches the namespace, compatibility, module, function argument, and token ownership maps. Cache entries use package identity and resource, function, and type counts, so the maps are rebuilt when a partial package grows. The cache is bounded, and each generator receives its own mutable top-level namespace map.

Measured across the complete AWS PCL corpus with the first PR applied:

| Metric | Before | After | Change |
|---|---:|---:|---:|
| .NET generation | 8,584 ms | 1,726 ms | -79.9% |
| User CPU | 10,005 ms | 1,991 ms | -80.1% |
| System CPU | 141 ms | 50 ms | -64.7% |
| Allocated bytes | 6.30 GB | 1.15 GB | -81.7% |
| Allocations | 19,316,973 | 18,934,626 | -2.0% |
| GC cycles | 52 | 8 | -84.6% |
| GC pause | 3.726 ms | 0.461 ms | -87.6% |
| Peak RSS | 2.14 GB | 764 MB | -64.3% |
| Parse time | 2,752 ms | 2,708 ms | -1.6% |
| Bind time | 8,804 ms | 8,793 ms | -0.1% |

Together, the two PRs change the primary and resource metrics from the original baseline as follows:

| Metric | Original baseline | Both PRs | Change |
|---|---:|---:|---:|
| .NET generation | 15,555 ms | 1,726 ms | -88.9% |
| User CPU | 20,157 ms | 1,991 ms | -90.1% |
| System CPU | 312 ms | 50 ms | -84.1% |
| Allocated bytes | 19.97 GB | 1.15 GB | -94.2% |
| Allocations | 178,920,998 | 18,934,626 | -89.4% |
| GC cycles | 120 | 8 | -93.3% |
| GC pause | 10.064 ms | 0.461 ms | -95.4% |
| Peak RSS | 1.00 GB | 764 MB | -23.9% |

The generated files, diagnostics, and workload counts remained unchanged.

Validation:

- `mise exec -- make format_language_host_check`
- `mise exec -- make lint_language_host`
- `mise exec -- make test_codegen`
