### PR TITLE
Bump generated SDK minimum Pulumi version to 3.109.0

### DIFF
--- a/.changes/unreleased/Bug Fixes-1130.yaml
+++ b/.changes/unreleased/Bug Fixes-1130.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Bump the minimum Pulumi version referenced by generated SDKs to 3.109.0, so SDKs generated locally (e.g. via `pulumi package add`) bind to the current `RegisterPackageRequest` constructor and no longer fail with `MissingMethodException` at runtime
+time: 2026-08-18T11:20:00-07:00
+custom:
+    PR: "1130"

--- a/pulumi-language-dotnet/codegen/gen.go
+++ b/pulumi-language-dotnet/codegen/gen.go
@@ -2405,7 +2405,7 @@ func genProjectFile(pkg *schema.Package,
 		// only add a package reference to Pulumi if we're not referencing a local Pulumi project
 		// which we usually do when testing schemas locally
 		if !referencedLocalPulumiProject {
-			packageReferences["Pulumi"] = "[3.76.1.0,4)"
+			packageReferences["Pulumi"] = "[3.109.0,4)"
 		}
 	}
 

--- a/pulumi-language-dotnet/codegen/testdata/assets-and-archives/Pulumi.Example.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/assets-and-archives/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/azure-native-nested-types/Pulumi.AzureNative.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/azure-native-nested-types/Pulumi.AzureNative.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 

--- a/pulumi-language-dotnet/codegen/testdata/cyclic-types/Pulumi.Example.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/cyclic-types/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/dash-named-schema/Pulumi.FooBar.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/dash-named-schema/Pulumi.FooBar.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
     <PackageReference Include="Pulumi.Aws" Version="4.20" ExcludeAssets="contentFiles" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.7" ExcludeAssets="contentFiles" />
     <PackageReference Include="Pulumi.Random" Version="4.2" ExcludeAssets="contentFiles" />

--- a/pulumi-language-dotnet/codegen/testdata/dashed-import-schema/Pulumi.Plant.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/dashed-import-schema/Pulumi.Plant.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/hyphen-url/Pulumi.Registrygeoreplication.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/hyphen-url/Pulumi.Registrygeoreplication.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
     <PackageReference Include="Pulumi.UsingDashes" Version="1.0.*" ExcludeAssets="contentFiles" />
   </ItemGroup>
 

--- a/pulumi-language-dotnet/codegen/testdata/legacy-names/Pulumi.Legacy_names.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/legacy-names/Pulumi.Legacy_names.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/naming-collisions/Pulumi.Example.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/naming-collisions/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/nested-module-thirdparty/Pulumi.FooBar.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/nested-module-thirdparty/Pulumi.FooBar.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/output-funcs-edgeorder/Pulumi.Myedgeorder.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/output-funcs-edgeorder/Pulumi.Myedgeorder.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/output-funcs-tfbridge20/Pulumi.Mypkg.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/output-funcs-tfbridge20/Pulumi.Mypkg.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/output-funcs/Pulumi.Mypkg.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/output-funcs/Pulumi.Mypkg.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/plain-and-default/Pulumi.FooBar.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/plain-and-default/Pulumi.FooBar.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/plain-object-defaults/Pulumi.Example.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/plain-object-defaults/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/plain-object-disable-defaults/Pulumi.Example.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/plain-object-disable-defaults/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/provider-type-schema/Pulumi.ProviderType.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/provider-type-schema/Pulumi.ProviderType.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/regress-8403/Pulumi.Mongodbatlas.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/regress-8403/Pulumi.Mongodbatlas.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/regress-node-8110/Pulumi.My8110.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/regress-node-8110/Pulumi.My8110.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/resource-args-python-case-insensitive/Pulumi.Example.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/resource-args-python-case-insensitive/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/resource-args-python/Pulumi.Example.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/resource-args-python/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/resource-property-overlap/Pulumi.Example.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/resource-property-overlap/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/simple-methods-schema-single-value-returns/Pulumi.Example.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/simple-methods-schema-single-value-returns/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/simple-methods-schema/Pulumi.Example.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/simple-methods-schema/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
     <PackageReference Include="Pulumi.Random" Version="4.11.2" ExcludeAssets="contentFiles" />
   </ItemGroup>
 

--- a/pulumi-language-dotnet/codegen/testdata/simple-plain-schema-with-root-package/Pulumi.Example.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/simple-plain-schema-with-root-package/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/simple-resource-schema/Pulumi.Example.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/simple-resource-schema/Pulumi.Example.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/simple-resource-with-aliases/Pulumi.Example.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/simple-resource-with-aliases/Pulumi.Example.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/urn-id-properties/Pulumi.Urnid.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/urn-id-properties/Pulumi.Urnid.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pulumi-language-dotnet/codegen/testdata/using-shared-types-in-config/Pulumi.Credentials.csproj
+++ b/pulumi-language-dotnet/codegen/testdata/using-shared-types-in-config/Pulumi.Credentials.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.76.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="[3.109.0,4)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
v3.109.0 (#1068) added an `extension` parameter to the `RegisterPackageRequest` constructor without keeping the previous overload — a binary-breaking change for code compiled against older versions.

Generated SDKs reference `Pulumi [3.76.1.0,4)`, so a locally generated SDK (e.g. `pulumi package add` for a parameterized provider such as `terraform-module` or `terraform-provider`) restores and compiles against 3.76.1 and binds to the five-argument constructor. The consuming program (`pulumi new csharp` template uses `Pulumi 3.*`) floats to 3.109+, whose runtime no longer has that constructor:

```
System.MissingMethodException: Method not found: 'Void Pulumi.RegisterPackageRequest..ctor(System.String, System.String, System.String, System.Collections.Generic.Dictionary`2<System.String,Byte[]>, PackageParameterization)'.
   at RegisterPackageRequest Pulumi.Dashed.Utilities.PackageParameterization()
```

This has broken pulumi-terraform-module's dotnet e2e tests on every PR since 3.109.0 shipped (see pulumi/pulumi-terraform-module#968 for the diagnosis). Same class of bug as #317 / #318.

Extension-parameterized SDKs already need 3.109.0, so raise the default lower bound to `[3.109.0,4)`. Golden testdata regenerated with `PULUMI_ACCEPT=true`.

An alternative/additional fix is to restore the five-argument overload in `RegisterPackageRequest` for binary compatibility with already-generated SDKs; happy to do that too if preferred.

Closes #1132
Closes #1131
