### PR TITLE
Restore pre-extension RegisterPackageRequest constructor for binary compatibility

### DIFF
--- a/.changes/unreleased/Bug Fixes-1131.yaml
+++ b/.changes/unreleased/Bug Fixes-1131.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Restore the pre-`extension` `RegisterPackageRequest` constructor so SDKs compiled against Pulumi < 3.109.0 no longer fail with `MissingMethodException` at runtime
+time: 2026-08-18T11:45:00-07:00
+custom:
+    PR: "1131"

--- a/sdk/Pulumi.Tests/Resources/RegisterPackageRequestTests.cs
+++ b/sdk/Pulumi.Tests/Resources/RegisterPackageRequestTests.cs
@@ -1,0 +1,26 @@
+// Copyright 2016-2026, Pulumi Corporation
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace Pulumi.Tests.Resources
+{
+    public class RegisterPackageRequestTests
+    {
+        [Fact]
+        public void KeepsPreExtensionConstructorForBinaryCompatibility()
+        {
+            // SDKs generated before the `extension` parameter existed bind to this exact
+            // signature at runtime; if it disappears they fail with MissingMethodException.
+            var ctor = typeof(RegisterPackageRequest).GetConstructor(new[]
+            {
+                typeof(string),
+                typeof(string),
+                typeof(string),
+                typeof(Dictionary<string, byte[]>),
+                typeof(RegisterPackageRequest.PackageParameterization),
+            });
+            Assert.NotNull(ctor);
+        }
+    }
+}

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -2600,15 +2600,6 @@
             <see cref="P:Pulumi.RegisterPackageRequest.Extension"/>, never both.
             </summary>
         </member>
-        <member name="M:Pulumi.RegisterPackageRequest.#ctor(System.String,System.String,System.String,System.Collections.Generic.Dictionary{System.String,System.Byte[]},Pulumi.RegisterPackageRequest.PackageParameterization)">
-            <remarks>
-            This overload must be kept: SDKs generated before <see cref="P:Pulumi.RegisterPackageRequest.Extension"/> was
-            added bind to this exact constructor signature at runtime, and removing it
-            causes a <see cref="T:System.MissingMethodException"/> in already-built SDKs.
-            Its parameters are deliberately not optional so that source-level calls that omit
-            arguments still resolve unambiguously to the primary constructor below.
-            </remarks>
-        </member>
         <member name="T:Pulumi.Resource">
             <summary>
             Resource represents a class whose CRUD operations are implemented by a provider plugin.

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -2600,6 +2600,15 @@
             <see cref="P:Pulumi.RegisterPackageRequest.Extension"/>, never both.
             </summary>
         </member>
+        <member name="M:Pulumi.RegisterPackageRequest.#ctor(System.String,System.String,System.String,System.Collections.Generic.Dictionary{System.String,System.Byte[]},Pulumi.RegisterPackageRequest.PackageParameterization)">
+            <remarks>
+            This overload must be kept: SDKs generated before <see cref="P:Pulumi.RegisterPackageRequest.Extension"/> was
+            added bind to this exact constructor signature at runtime, and removing it
+            causes a <see cref="T:System.MissingMethodException"/> in already-built SDKs.
+            Its parameters are deliberately not optional so that source-level calls that omit
+            arguments still resolve unambiguously to the primary constructor below.
+            </remarks>
+        </member>
         <member name="T:Pulumi.Resource">
             <summary>
             Resource represents a class whose CRUD operations are implemented by a provider plugin.

--- a/sdk/Pulumi/Resources/RegisterPackageRequest.cs
+++ b/sdk/Pulumi/Resources/RegisterPackageRequest.cs
@@ -54,6 +54,23 @@ public sealed class RegisterPackageRequest
     /// </summary>
     public PackageParameterization? Extension { get; }
 
+    /// <remarks>
+    /// This overload must be kept: SDKs generated before <see cref="Extension"/> was
+    /// added bind to this exact constructor signature at runtime, and removing it
+    /// causes a <see cref="System.MissingMethodException"/> in already-built SDKs.
+    /// Its parameters are deliberately not optional so that source-level calls that omit
+    /// arguments still resolve unambiguously to the primary constructor below.
+    /// </remarks>
+    public RegisterPackageRequest(
+        string name,
+        string version,
+        string? downloadUrl,
+        Dictionary<string, byte[]>? checksums,
+        PackageParameterization? parameterization)
+        : this(name, version, downloadUrl, checksums, parameterization, extension: null)
+    {
+    }
+
     public RegisterPackageRequest(
         string name,
         string version,

--- a/sdk/Pulumi/Resources/RegisterPackageRequest.cs
+++ b/sdk/Pulumi/Resources/RegisterPackageRequest.cs
@@ -54,13 +54,6 @@ public sealed class RegisterPackageRequest
     /// </summary>
     public PackageParameterization? Extension { get; }
 
-    /// <remarks>
-    /// This overload must be kept: SDKs generated before <see cref="Extension"/> was
-    /// added bind to this exact constructor signature at runtime, and removing it
-    /// causes a <see cref="System.MissingMethodException"/> in already-built SDKs.
-    /// Its parameters are deliberately not optional so that source-level calls that omit
-    /// arguments still resolve unambiguously to the primary constructor below.
-    /// </remarks>
     public RegisterPackageRequest(
         string name,
         string version,


### PR DESCRIPTION
Alternative to #1130 — merge one or the other.

v3.109.0 (#1068) added an `extension` parameter to the `RegisterPackageRequest` constructor. Because it is optional this looked source-compatible, but SDKs compiled against an older Pulumi bind to the exact five-argument signature and fail at runtime against 3.109+:

```
System.MissingMethodException: Method not found: 'Void Pulumi.RegisterPackageRequest..ctor(System.String, System.String, System.String, System.Collections.Generic.Dictionary`2<System.String,Byte[]>, PackageParameterization)'.
   at RegisterPackageRequest Pulumi.Dashed.Utilities.PackageParameterization()
```

Generated SDKs reference `Pulumi [3.76.1.0,4)`, so any SDK produced by `pulumi package add` for a parameterized provider (`terraform-module`, `terraform-provider`, …) compiles against 3.76.1 and hits this whenever the consuming program floats to a newer Pulumi (`pulumi new csharp` uses `3.*`). This has broken pulumi-terraform-module's dotnet e2e tests on every PR since 3.109.0 shipped (pulumi/pulumi-terraform-module#968). Same class of bug as #317, fixed the same way as #318.

This PR brings the five-argument constructor back, delegating to the primary one. Its parameters are non-optional on purpose: with defaults on both overloads, a call like `new RegisterPackageRequest(name: .., version: .., downloadUrl: .., parameterization: ..)` (exactly what codegen emits) is ambiguous (CS0121).

Verified: a library compiled against `Pulumi 3.108.0` calling the codegen-shaped constructor throws the `MissingMethodException` above when run against `main`, and runs cleanly against this branch. Added a reflection test pinning the signature.

Unlike #1130 this fixes already-generated SDKs without regeneration, but #1130's codegen bump would still be reasonable on top eventually.

Closes #1132
Closes #1130
