### PR TITLE
Require Pulumi 3.109.0 in generated extension-parameterized SDKs

### DIFF
--- a/.changes/unreleased/Bug Fixes-1133.yaml
+++ b/.changes/unreleased/Bug Fixes-1133.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Generated extension-parameterized SDKs now declare a minimum Pulumi version of 3.109.0, matching the `RegisterPackageRequest` constructor they use
+time: 2026-08-18T12:30:00-07:00
+custom:
+    PR: "1133"

--- a/pulumi-language-dotnet/codegen/gen.go
+++ b/pulumi-language-dotnet/codegen/gen.go
@@ -2405,7 +2405,13 @@ func genProjectFile(pkg *schema.Package,
 		// only add a package reference to Pulumi if we're not referencing a local Pulumi project
 		// which we usually do when testing schemas locally
 		if !referencedLocalPulumiProject {
-			packageReferences["Pulumi"] = "[3.76.1.0,4)"
+			// Extension-parameterized SDKs pass `extension:` to RegisterPackageRequest,
+			// which only exists in Pulumi 3.109.0 and later.
+			if pkg.ExtensionParameterization != nil {
+				packageReferences["Pulumi"] = "[3.109.0,4)"
+			} else {
+				packageReferences["Pulumi"] = "[3.76.1.0,4)"
+			}
 		}
 	}
 

--- a/pulumi-language-dotnet/codegen/gen_test.go
+++ b/pulumi-language-dotnet/codegen/gen_test.go
@@ -17,6 +17,7 @@ package dotnet
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"sync"
 	"testing"
@@ -169,4 +170,26 @@ func TestGenerateTypeNames(t *testing.T) {
 			return root.typeString(t, "", false, false, false)
 		}
 	}, filepath.FromSlash("../../pulumi/tests/testdata/codegen"))
+}
+
+func TestGenProjectFilePulumiVersion(t *testing.T) {
+	t.Parallel()
+
+	pulumiReference := func(pkg *schema.Package) string {
+		csproj, err := genProjectFile(pkg, "Pulumi.Test", nil, nil, "0.0.1", nil)
+		require.NoError(t, err)
+		re := regexp.MustCompile(`<PackageReference Include="Pulumi" Version="([^"]+)" />`)
+		match := re.FindStringSubmatch(string(csproj))
+		require.Len(t, match, 2, "expected a Pulumi package reference in:\n%s", csproj)
+		return match[1]
+	}
+
+	assert.Equal(t, "[3.76.1.0,4)", pulumiReference(&schema.Package{Name: "test"}))
+	assert.Equal(t, "[3.109.0,4)", pulumiReference(&schema.Package{
+		Name: "test",
+		ExtensionParameterization: &schema.ExtensionParameterization{
+			BaseProvider: schema.BaseProvider{Name: "base"},
+			Parameter:    []byte("param"),
+		},
+	}))
 }


### PR DESCRIPTION
Follow-up to #1131 (which restores binary compatibility for everything already generated); this narrows what #1130 tried to do to the one case where it is actually needed. Closes #1130.

Extension-parameterized SDKs call `RegisterPackageRequest(..., extension: ...)`, which only exists in Pulumi 3.109.0+, but the generated `.csproj` declared `Pulumi [3.76.1.0,4)`. If NuGet resolves the lower bound (as it does when the SDK is a standalone project) the SDK does not compile. Declare `[3.109.0,4)` when `pkg.ExtensionParameterization != nil`; all other packages keep `[3.76.1.0,4)`.

No golden files change (there is no extension-parameterized case in the SDK codegen corpus; the conformance tests reference a local `Pulumi.csproj`, which skips the package reference). Added a unit test on `genProjectFile` covering both branches.