### PR TITLE
Generalize representation tracking for schema-less object literals

### DIFF
--- a/.changes/unreleased/bug-fixes-1147.yaml
+++ b/.changes/unreleased/bug-fixes-1147.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: bug-fixes
+body: Fix program codegen for schema-less object literals nested inside `secret(...)`
+time: 2026-08-27T12:00:00.000000+00:00
+custom:
+    PR: "1147"

--- a/pulumi-language-dotnet/codegen/gen_intrinsics.go
+++ b/pulumi-language-dotnet/codegen/gen_intrinsics.go
@@ -16,6 +16,7 @@ package dotnet
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	"github.com/zclconf/go-cty/cty"
 )
 
 const (
@@ -26,13 +27,33 @@ const (
 	// intrinsicUntypedObjectLiteral marks a schema-less object literal sitting in
 	// a typeless position; it renders as a Dictionary that carries its own type.
 	intrinsicUntypedObjectLiteral = "__untypedObjectLiteral"
+	// intrinsicAnonymousRecordLiteral marks a schema-less object literal whose
+	// value is wrapped in an Output; it renders as an anonymous record so member
+	// types survive Apply lambdas, which a Dictionary's object? values would not.
+	intrinsicAnonymousRecordLiteral = "__anonymousRecordLiteral"
 )
 
 // newUntypedObjectLiteralCall creates a new call to the untyped-object-literal
-// intrinsic.
-func newUntypedObjectLiteralCall(obj *model.ObjectConsExpression) model.Expression {
+// intrinsic. elementType is the C# value type of the emitted Dictionary.
+func newUntypedObjectLiteralCall(obj *model.ObjectConsExpression, elementType string) model.Expression {
 	return &model.FunctionCallExpression{
 		Name: intrinsicUntypedObjectLiteral,
+		Signature: model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "literal",
+				Type: obj.Type(),
+			}},
+			ReturnType: obj.Type(),
+		},
+		Args: []model.Expression{obj, &model.LiteralValueExpression{Value: cty.StringVal(elementType)}},
+	}
+}
+
+// newAnonymousRecordLiteralCall creates a new call to the
+// anonymous-record-literal intrinsic.
+func newAnonymousRecordLiteralCall(obj *model.ObjectConsExpression) model.Expression {
+	return &model.FunctionCallExpression{
+		Name: intrinsicAnonymousRecordLiteral,
 		Signature: model.StaticFunctionSignature{
 			Parameters: []model.Parameter{{
 				Name: "literal",

--- a/pulumi-language-dotnet/codegen/gen_program.go
+++ b/pulumi-language-dotnet/codegen/gen_program.go
@@ -87,10 +87,6 @@ type generator struct {
 	// from an array
 	listInitializer         string
 	deferredOutputVariables []*pcl.DeferredOutputVariable
-	// Local variables whose object literal was emitted as a typed Dictionary. Traversals into
-	// these locals must use string indexers rather than property access, so the decision made
-	// at declaration time is recorded here for the traversal sites.
-	typedDictionaryLocals map[*pcl.LocalVariable]bool
 	// Some of our names interfere with one another. For example, `Pulumi.Output` is a module, and `Output` exists in
 	// `Pulumi`, so programs that import `Pulumi` and `Pulumi.Output` hit name collisions. For this reason, we'll import
 	// the latter as `OutputProvider` rather than `Output`.
@@ -2252,10 +2248,6 @@ func (g *generator) genLocalVariable(w io.Writer, localVariable *pcl.LocalVariab
 		result := g.lowerExpression(value, value.Type())
 		g.Fgenf(w, "%svar %s = ", g.Indent, variableName)
 		if object, ok := result.(*model.ObjectConsExpression); ok && g.genTypedLocalObjectConsExpression(w, object) {
-			if g.typedDictionaryLocals == nil {
-				g.typedDictionaryLocals = map[*pcl.LocalVariable]bool{}
-			}
-			g.typedDictionaryLocals[localVariable] = true
 			g.Fgenf(w, ";\n\n")
 		} else {
 			g.Fgenf(w, "%v;\n\n", g.markUntypedObjectLiterals(result))
@@ -2317,14 +2309,7 @@ func (g *generator) genTypedLocalObjectConsExpression(w io.Writer, expr *model.O
 		return false
 	}
 
-	g.Fgenf(w, "new Dictionary<string, %s>\n", elementType)
-	g.Fgenf(w, "%s{\n", g.Indent)
-	g.Indented(func() {
-		for _, item := range expr.Items {
-			g.Fgenf(w, "%s[%.v] = %.v,\n", g.Indent, item.Key, item.Value)
-		}
-	})
-	g.Fgenf(w, "%s}", g.Indent)
+	g.genDictionary(w, expr, elementType)
 	return true
 }
 

--- a/pulumi-language-dotnet/codegen/gen_program.go
+++ b/pulumi-language-dotnet/codegen/gen_program.go
@@ -2246,12 +2246,14 @@ func (g *generator) genLocalVariable(w io.Writer, localVariable *pcl.LocalVariab
 		g.Fgenf(w, "%svar %s = %v;\n\n", g.Indent, variableName, result)
 	} else {
 		result := g.lowerExpression(value, value.Type())
-		g.Fgenf(w, "%svar %s = ", g.Indent, variableName)
-		if object, ok := result.(*model.ObjectConsExpression); ok && g.genTypedLocalObjectConsExpression(w, object) {
-			g.Fgenf(w, ";\n\n")
-		} else {
-			g.Fgenf(w, "%v;\n\n", g.markUntypedObjectLiterals(result))
+		// A homogeneous top-level literal gets a precise Dictionary value type;
+		// var-typed locals keep their members usable (e.g. Output<T> methods).
+		if obj, ok := result.(*model.ObjectConsExpression); ok {
+			if elementType, homogeneous := dictionaryValueType(obj); homogeneous {
+				result = newUntypedObjectLiteralCall(obj, elementType)
+			}
 		}
+		g.Fgenf(w, "%svar %s = %v;\n\n", g.Indent, variableName, g.markUntypedObjectLiterals(result))
 	}
 }
 
@@ -2301,16 +2303,6 @@ func dictionaryValueType(expr *model.ObjectConsExpression) (string, bool) {
 		}
 	}
 	return elementType, true
-}
-
-func (g *generator) genTypedLocalObjectConsExpression(w io.Writer, expr *model.ObjectConsExpression) bool {
-	elementType, ok := dictionaryValueType(expr)
-	if !ok {
-		return false
-	}
-
-	g.genDictionary(w, expr, elementType)
-	return true
 }
 
 func (g *generator) genNYI(w io.Writer, reason string, vs ...any) {

--- a/pulumi-language-dotnet/codegen/gen_program_expressions.go
+++ b/pulumi-language-dotnet/codegen/gen_program_expressions.go
@@ -54,8 +54,28 @@ func (g *generator) rewriteExpression(expr model.Expression, typ model.Type, rew
 	} else {
 		expr = g.outputInvokes(expr)
 	}
+	expr = g.markSecretObjectLiterals(expr)
 	g.diagnostics = g.diagnostics.Extend(diags)
 	return expr
+}
+
+// markSecretObjectLiterals wraps the schema-less object literal argument of
+// each secret(...) call in the anonymous-record intrinsic, so the literal
+// renders as a record wherever the call is emitted.
+func (g *generator) markSecretObjectLiterals(x model.Expression) model.Expression {
+	rewriter := func(x model.Expression) (model.Expression, hcl.Diagnostics) {
+		call, ok := x.(*model.FunctionCallExpression)
+		if !ok || call.Name != "secret" {
+			return x, nil
+		}
+		if obj, ok := call.Args[0].(*model.ObjectConsExpression); ok && g.exprContainerRepr(call) == reprAnonymousRecord {
+			call.Args[0] = newAnonymousRecordLiteralCall(obj)
+		}
+		return call, nil
+	}
+	x, diags := model.VisitExpression(x, model.IdentityVisitor, rewriter)
+	contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
+	return x
 }
 
 // lowerExpression amends the expression with intrinsics for C# generation.
@@ -628,7 +648,11 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		})
 
 	case intrinsicUntypedObjectLiteral:
-		g.genDictionaryOrTuple(w, expr.Args[0])
+		elementType := expr.Args[1].(*model.LiteralValueExpression).Value.AsString()
+		g.genDictionary(w, expr.Args[0].(*model.ObjectConsExpression), elementType)
+
+	case intrinsicAnonymousRecordLiteral:
+		g.genAnonymousRecord(w, expr.Args[0].(*model.ObjectConsExpression))
 
 	case intrinsicOutput:
 		// if we are calling Output.Create(FuncInvokeAsync())
@@ -840,12 +864,6 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case "readDir":
 		g.Fgenf(w, "Directory.GetFiles(%.v).Select(Path.GetFileName)", expr.Args[0])
 	case "secret":
-		if g.exprContainerRepr(expr) == reprAnonymousRecord {
-			g.Fgen(w, "Output.CreateSecret(")
-			g.genAnonymousRecord(w, expr.Args[0].(*model.ObjectConsExpression))
-			g.Fgen(w, ")")
-			return
-		}
 		g.Fgenf(w, "Output.CreateSecret(%v)", expr.Args[0])
 	case "unsecret":
 		g.Fgenf(w, "Output.Unsecret(%v)", expr.Args[0])
@@ -1154,14 +1172,26 @@ func (g *generator) schemalessObjectLiteral(expr model.Expression) *model.Object
 }
 
 // exprContainerRepr classifies how the value of a defining expression is
-// represented in C#. Producers of schema-less object literals and the
-// traversal codegen both consult this, so the container shape and the
-// accessor spelling cannot diverge.
+// represented in C#. The lowering pass that marks schema-less object literals
+// with their representation intrinsic and the traversal codegen both consult
+// this, so the container shape and the accessor spelling cannot diverge. It
+// accepts both unlowered and marked expressions: lowering mutates shared
+// trees in place, so a definition may carry marks when traversals resolve it.
 func (g *generator) exprContainerRepr(expr model.Expression) containerRepr {
 	expr = unwrapIntrinsicConvert(expr)
-	if call, ok := expr.(*model.FunctionCallExpression); ok && call.Name == "secret" {
-		if obj, ok := call.Args[0].(*model.ObjectConsExpression); ok && g.schemalessObjectLiteral(obj) != nil {
+	if call, ok := expr.(*model.FunctionCallExpression); ok {
+		switch call.Name {
+		case intrinsicUntypedObjectLiteral:
+			return reprDictionary
+		case intrinsicAnonymousRecordLiteral:
 			return reprAnonymousRecord
+		case "secret":
+			if inner, ok := call.Args[0].(*model.FunctionCallExpression); ok && inner.Name == intrinsicAnonymousRecordLiteral {
+				return reprAnonymousRecord
+			}
+			if obj, ok := call.Args[0].(*model.ObjectConsExpression); ok && g.schemalessObjectLiteral(obj) != nil {
+				return reprAnonymousRecord
+			}
 		}
 		return reprNone
 	}
@@ -1272,7 +1302,7 @@ func (g *generator) markUntypedObjectLiterals(expr model.Expression) model.Expre
 	switch expr := expr.(type) {
 	case *model.ObjectConsExpression:
 		if _, hasSchema := g.toSchemaType(expr.Type()); !hasSchema {
-			return newUntypedObjectLiteralCall(expr)
+			return newUntypedObjectLiteralCall(expr, "object?")
 		}
 	case *model.TupleConsExpression:
 		for i, element := range expr.Expressions {

--- a/pulumi-language-dotnet/codegen/gen_program_expressions.go
+++ b/pulumi-language-dotnet/codegen/gen_program_expressions.go
@@ -840,17 +840,11 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case "readDir":
 		g.Fgenf(w, "Directory.GetFiles(%.v).Select(Path.GetFileName)", expr.Args[0])
 	case "secret":
-		// A schema-less object literal would be emitted as a Dictionary (see
-		// genObjectConsExpression), but the value is traversed through Apply
-		// lambdas whose codegen emits property access. Emit an anonymous record
-		// instead: its PascalCased properties line up with traversal codegen.
-		if obj, ok := expr.Args[0].(*model.ObjectConsExpression); ok {
-			if _, hasSchema := g.toSchemaType(obj.Type()); !hasSchema {
-				g.Fgen(w, "Output.CreateSecret(")
-				g.genAnonymousRecord(w, obj)
-				g.Fgen(w, ")")
-				return
-			}
+		if g.exprContainerRepr(expr) == reprAnonymousRecord {
+			g.Fgen(w, "Output.CreateSecret(")
+			g.genAnonymousRecord(w, expr.Args[0].(*model.ObjectConsExpression))
+			g.Fgen(w, ")")
+			return
 		}
 		g.Fgenf(w, "Output.CreateSecret(%v)", expr.Args[0])
 	case "unsecret":
@@ -928,7 +922,15 @@ func (g *generator) genAnonymousRecord(w io.Writer, expr *model.ObjectConsExpres
 	g.Indented(func() {
 		for _, item := range expr.Items {
 			key := objectKey(item)
-			g.Fgenf(w, "%s%s = %.v,\n", g.Indent, propertyName(key), item.Value)
+			g.Fgenf(w, "%s%s = ", g.Indent, propertyName(key))
+			// A nested schema-less literal stays an anonymous record: the
+			// members must keep their static types along with the parent's.
+			if obj := g.schemalessObjectLiteral(item.Value); obj != nil {
+				g.genAnonymousRecord(w, obj)
+			} else {
+				g.Fgenf(w, "%.v", item.Value)
+			}
+			g.Fgen(w, ",\n")
 		}
 	})
 	g.Fgenf(w, "%s}", g.Indent)
@@ -1120,6 +1122,62 @@ func resolvePropertyName(property string, overrides map[string]string) string {
 	}
 
 	return propertyName(property)
+}
+
+// containerRepr describes the C# container emitted for a schema-less object
+// literal. Schema-backed literals render as their args classes and are not
+// tracked here.
+type containerRepr int
+
+const (
+	// reprNone: not a schema-less object literal; traversals use property
+	// access (or the map/JsonElement spellings genRelativeTraversal picks
+	// per hop).
+	reprNone containerRepr = iota
+	// reprDictionary: a Dictionary, traversed with string indexers.
+	reprDictionary
+	// reprAnonymousRecord: an anonymous record, traversed with PascalCase
+	// property access. Chosen for Output-wrapped literals so member types
+	// survive Apply lambdas, which a Dictionary's object? values would not.
+	reprAnonymousRecord
+)
+
+// schemalessObjectLiteral returns the object literal an expression is when the
+// literal has no schema-backed type, or nil.
+func (g *generator) schemalessObjectLiteral(expr model.Expression) *model.ObjectConsExpression {
+	if obj, ok := unwrapIntrinsicConvert(expr).(*model.ObjectConsExpression); ok {
+		if _, hasSchema := g.toSchemaType(obj.Type()); !hasSchema {
+			return obj
+		}
+	}
+	return nil
+}
+
+// exprContainerRepr classifies how the value of a defining expression is
+// represented in C#. Producers of schema-less object literals and the
+// traversal codegen both consult this, so the container shape and the
+// accessor spelling cannot diverge.
+func (g *generator) exprContainerRepr(expr model.Expression) containerRepr {
+	expr = unwrapIntrinsicConvert(expr)
+	if call, ok := expr.(*model.FunctionCallExpression); ok && call.Name == "secret" {
+		if obj, ok := call.Args[0].(*model.ObjectConsExpression); ok && g.schemalessObjectLiteral(obj) != nil {
+			return reprAnonymousRecord
+		}
+		return reprNone
+	}
+	if g.schemalessObjectLiteral(expr) != nil {
+		return reprDictionary
+	}
+	return reprNone
+}
+
+// rootContainerRepr resolves a traversal root to the representation of its
+// defining expression.
+func (g *generator) rootContainerRepr(root model.Traversable) containerRepr {
+	if local, ok := root.(*pcl.LocalVariable); ok {
+		return g.exprContainerRepr(local.Definition.Value)
+	}
+	return reprNone
 }
 
 // configBindsToJSONElement reports whether a config variable of this declared
@@ -1517,14 +1575,12 @@ func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTr
 	}
 
 	var objType *schema.ObjectType
-	rootIsDictionary := false
 	if resource, ok := expr.Parts[0].(*pcl.Resource); ok {
 		if schemaType, ok := pcl.GetSchemaForType(resource.InputType); ok {
 			objType, _ = schemaType.(*schema.ObjectType)
 		}
-	} else if local, ok := expr.Parts[0].(*pcl.LocalVariable); ok {
-		rootIsDictionary = g.typedDictionaryLocals[local]
 	}
+	rootIsDictionary := g.rootContainerRepr(expr.Parts[0]) == reprDictionary
 	g.genRelativeTraversal(w, expr.Traversal.SimpleSplit().Rel, expr.Parts, objType,
 		rootIsDictionary, g.isJSONElementRoot(expr.Parts[0]))
 

--- a/pulumi-language-dotnet/codegen/gen_program_test.go
+++ b/pulumi-language-dotnet/codegen/gen_program_test.go
@@ -491,6 +491,58 @@ output "out" {
 			"non-nullable JsonElement is ValueKind.Undefined, not null")
 }
 
+func TestGenerateProgramNestedSecretObjectLiteral(t *testing.T) {
+	t.Parallel()
+
+	source := `
+s = secret({
+    outer = {
+        inner = "value"
+    }
+})
+
+output "out" {
+    value = s.outer.inner
+}
+`
+
+	parser := syntax.NewParser()
+	err := parser.ParseFile(strings.NewReader(source), "main.pp")
+	require.NoError(t, err)
+	require.False(t, parser.Diagnostics.HasErrors(), "parse diagnostics: %v", parser.Diagnostics)
+
+	program, diags, err := pcl.BindProgram(parser.Files, &inlineLoader{})
+	require.NoError(t, err)
+	require.False(t, diags.HasErrors(), "bind diagnostics: %v", diags)
+	require.NotNil(t, program)
+
+	files, diags, err := GenerateProgram(program)
+	require.NoError(t, err)
+	require.False(t, diags.HasErrors(), "codegen diagnostics: %v", diags)
+
+	require.Equal(t, `using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+
+return await Deployment.RunAsync(() => 
+{
+    var s = Output.CreateSecret(new
+    {
+        Outer = new
+        {
+            Inner = "value",
+        },
+    });
+
+    return new Dictionary<string, object?>
+    {
+        ["out"] = s.Apply(s => s.Outer.Inner),
+    };
+});
+
+`, string(files["Program.cs"]))
+}
+
 type inlineLoader struct {
 	schemas map[string]schema.PackageSpec
 }


### PR DESCRIPTION
Follow-up to the discussion in https://github.com/pulumi/pulumi-dotnet/pull/1008#discussion_r3871577763: the dictionary-vs-record mismatch is not `secret`-specific, so this generalizes the tracking.

Producer sites and the traversal codegen previously decided the C# representation of a schema-less object literal independently, one mechanism per site: local variables recorded their typed-Dictionary choice in the generator-side `typedDictionaryLocals` map, and the `secret(...)` case embedded its own anonymous-record check, while traversal spelling relied on those decisions matching by construction.

Representation decisions now work in two coordinated halves:

- **One classifier.** `exprContainerRepr` maps a defining expression to its container representation (Dictionary or anonymous record), and `rootContainerRepr` resolves a traversal root through its definition to the same answer, so the container shape and the accessor spelling cannot diverge. The `typedDictionaryLocals` map is gone.
- **Decisions ride the tree as lowering-time marks.** Following the pattern `__untypedObjectLiteral` established, a rewrite during lowering wraps the schema-less object literal argument of each `secret(...)` call in a new `__anonymousRecordLiteral` intrinsic, so the `secret` emission is just `Output.CreateSecret(%v)` and any future Output-wrapping builtin gets record rendering by marking alone. The `__untypedObjectLiteral` intrinsic now carries the Dictionary value type, which lets `genLocalVariable` express its typed-Dictionary choice as a mark and deletes `genTypedLocalObjectConsExpression`.

The JsonElement tracking (`isJSONElementRoot` and friends) is deliberately left as a separate axis: whether Dynamic-typed hops hold a `JsonElement` is orthogonal to the container shape and can be true at the same time as either representation (e.g. `secret({a = anyObject.x})`), so folding it into the same enum would lose information.

The generalization also fixes a latent bug: a schema-less object literal nested inside `secret({...})` previously emitted a bare collection initializer, which neither compiled nor matched the property-access spelling of its traversals. `genAnonymousRecord` now recurses, and a new unit test asserts the full generated program for that case (verified to fail on the base branch).

No golden files change: all codegen golden tests and the conformance snapshots for the affected tests (`l1-proxy-index`, `l2-proxy-index`, `l1-output-map`, `l1-config-types-object`, `l1-builtin-list`, `l2-id-type`, `l1-output-secret`) are untouched.
