### PR TITLE
Drain all in-flight tasks before reporting exceptions

### DIFF
--- a/.changes/unreleased/bug-fixes-1156.yaml
+++ b/.changes/unreleased/bug-fixes-1156.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Drain all in-flight resource registrations before reporting exceptions, so failures with `ContinueOnError` (and independent resources registered concurrently with a failing one) are not lost to a race.
+time: 2026-09-07T00:00:00Z
+component: sdk
+custom:
+  PR: "1160"

--- a/sdk/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -1530,12 +1530,25 @@ namespace Pulumi.Automation.Tests
             });
 
             var previewTaskWithOutput = stackWithOutput.PreviewAsync();
-            await Assert.ThrowsAsync<FileNotFoundException>(
-                () => previewTaskWithOutput);
+            await AssertThrowsFileNotFoundAsync(() => previewTaskWithOutput);
 
             var upTaskWithOutput = stackWithOutput.UpAsync();
-            await Assert.ThrowsAsync<FileNotFoundException>(
-                () => upTaskWithOutput);
+            await AssertThrowsFileNotFoundAsync(() => upTaskWithOutput);
+        }
+
+        // The runner drains all in-flight tasks before reporting exceptions. When the failing task is
+        // an output the runner may collect more than one exception (the original fault plus a
+        // downstream "error serializing property" from RegisterResourceOutputs consuming the same
+        // output). Accept either the raw exception or an AggregateException containing it.
+        private static async Task AssertThrowsFileNotFoundAsync(Func<Task> action)
+        {
+            var ex = await Assert.ThrowsAnyAsync<Exception>(action);
+            if (ex is FileNotFoundException)
+            {
+                return;
+            }
+            var agg = Assert.IsType<AggregateException>(ex);
+            Assert.Contains(agg.Flatten().InnerExceptions, e => e is FileNotFoundException);
         }
 
         private class FileNotFoundStack : Stack
@@ -1595,12 +1608,10 @@ namespace Pulumi.Automation.Tests
             });
 
             var previewTaskWithOutput = stackWithOutput.PreviewAsync();
-            await Assert.ThrowsAsync<FileNotFoundException>(
-                () => previewTaskWithOutput);
+            await AssertThrowsFileNotFoundAsync(() => previewTaskWithOutput);
 
             var upTaskWithOutput = stackWithOutput.UpAsync();
-            await Assert.ThrowsAsync<FileNotFoundException>(
-                () => upTaskWithOutput);
+            await AssertThrowsFileNotFoundAsync(() => upTaskWithOutput);
         }
 
         // TODO[pulumi/pulumi#8228]: fix flakiness

--- a/sdk/Pulumi.Tests/Deployment/DeploymentRunnerTests.cs
+++ b/sdk/Pulumi.Tests/Deployment/DeploymentRunnerTests.cs
@@ -15,25 +15,29 @@ namespace Pulumi.Tests
     public class DeploymentRunnerTests
     {
         [Fact]
-        public async Task TerminatesEarlyOnException()
+        public async Task DrainsAllTasksBeforeReportingException()
         {
-            var deployResult = await Deployment.TryTestAsync<TerminatesEarlyOnExceptionStack>(new EmptyMocks());
+            // Even when one task faults, the runner should wait for all other in-flight
+            // tasks to complete before returning the exception. This matches the behavior
+            // of the Go, Node, and Python SDKs, and avoids losing resource registrations
+            // (e.g. under ContinueOnError) to a race with the faulting task.
+            var deployResult = await Deployment.TryTestAsync<DrainsAllTasksStack>(new EmptyMocks());
             Assert.NotNull(deployResult.Exception);
             Assert.IsType<RunException>(deployResult.Exception!);
             Assert.Contains("Deliberate test error", deployResult.Exception!.Message);
-            var stack = (TerminatesEarlyOnExceptionStack)deployResult.Resources[0];
-            Assert.False(stack.SlowOutput.GetValueAsync(whenUnknown: default!).IsCompleted);
+            var stack = (DrainsAllTasksStack)deployResult.Resources[0];
+            Assert.True(stack.OtherOutput.GetValueAsync(whenUnknown: default!).IsCompleted);
         }
 
-        class TerminatesEarlyOnExceptionStack : Stack
+        class DrainsAllTasksStack : Stack
         {
             [Output]
-            public Output<int> SlowOutput { get; private set; }
+            public Output<int> OtherOutput { get; private set; }
 
-            public TerminatesEarlyOnExceptionStack()
+            public DrainsAllTasksStack()
             {
                 Output.Create(Task.FromException<int>(new Exception("Deliberate test error")));
-                SlowOutput = Output.Create(Task.Delay(60000).ContinueWith(_ => 1));
+                OtherOutput = Output.Create(Task.Delay(100).ContinueWith(_ => 1));
             }
         }
 

--- a/sdk/Pulumi/Deployment/Deployment.Runner.cs
+++ b/sdk/Pulumi/Deployment/Deployment.Runner.cs
@@ -138,7 +138,7 @@ namespace Pulumi
 
             internal async Task<int> WhileRunningAsync()
             {
-                var errs = await _inFlightTasks.AwaitIdleOrFirstExceptionAsync().ConfigureAwait(false);
+                var errs = await _inFlightTasks.AwaitIdleAsync().ConfigureAwait(false);
                 if (errs.Any())
                 {
                     return await HandleExceptionsAsync(errs).ConfigureAwait(false);

--- a/sdk/Pulumi/Deployment/TaskMonitoringHelper.cs
+++ b/sdk/Pulumi/Deployment/TaskMonitoringHelper.cs
@@ -75,46 +75,34 @@ namespace Pulumi
                     _exceptions.AddRange(task.Exception.InnerExceptions);
                 }
 
-                if (_exceptions.Count > 0 && _promise != null)
+                if (_activeTasks == 0 && _promise != null)
                 {
                     _promise.SetResult(Flush());
-                    _promise = null;
-                }
-                else if (_activeTasks == 0 && _promise != null)
-                {
-                    _promise.SetResult(Enumerable.Empty<Exception>());
                     _promise = null;
                 }
             }
         }
 
         /// <summary>
-        /// Awaits next IDLE state or an exception, whichever comes
-        /// first. Several exceptions may be returned if they have
-        /// been observed prior to this call.
-        ///
-        /// IDLE state is represented as an empty sequence in the result.
+        /// Awaits the next IDLE state (all monitored tasks completed) and
+        /// returns every exception observed across all of them. Faulting
+        /// tasks do not short-circuit the wait; outstanding tasks are
+        /// always allowed to finish so callers see every fault.
         /// </summary>
-        public Task<IEnumerable<Exception>> AwaitIdleOrFirstExceptionAsync()
+        public Task<IEnumerable<Exception>> AwaitIdleAsync()
         {
             lock (_lockObject)
             {
-                if (_exceptions.Count > 0)
+                if (_activeTasks == 0)
                 {
                     return Task.FromResult(Flush());
                 }
-                else if (_activeTasks == 0)
+
+                if (_promise == null)
                 {
-                    return Task.FromResult(Enumerable.Empty<Exception>());
+                    _promise = new TaskCompletionSource<IEnumerable<Exception>>();
                 }
-                else
-                {
-                    if (_promise == null)
-                    {
-                        _promise = new TaskCompletionSource<IEnumerable<Exception>>();
-                    }
-                    return _promise.Task;
-                }
+                return _promise.Task;
             }
         }
     }

--- a/sdk/Pulumi/Pulumi.xml
+++ b/sdk/Pulumi/Pulumi.xml
@@ -2079,14 +2079,13 @@
             Starts monitoring the given task.
             </summary>
         </member>
-        <member name="M:Pulumi.TaskMonitoringHelper.AwaitIdleOrFirstExceptionAsync">
-             <summary>
-             Awaits next IDLE state or an exception, whichever comes
-             first. Several exceptions may be returned if they have
-             been observed prior to this call.
-            
-             IDLE state is represented as an empty sequence in the result.
-             </summary>
+        <member name="M:Pulumi.TaskMonitoringHelper.AwaitIdleAsync">
+            <summary>
+            Awaits the next IDLE state (all monitored tasks completed) and
+            returns every exception observed across all of them. Faulting
+            tasks do not short-circuit the wait; outstanding tasks are
+            always allowed to finish so callers see every fault.
+            </summary>
         </member>
         <member name="T:Pulumi.LogException">
             <summary>


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-dotnet/issues/1037

The runner previously used `AwaitIdleOrFirstExceptionAsync`, which returned as soon as any monitored task threw. Resource registrations in the .NET SDK are fire-and-forget, so a failure on one resource would tear the program down before independent resources registered concurrently had a chance to dispatch their RegisterResource RPCs to the engine.

That made `l2-failed-create-continue-on-error` flaky: whether the `independent` resource's RPC reached the engine before the `failing` resource's exception surfaced depended on task scheduling, so the engine saw either 1 or 2 Creates.

The other Pulumi SDKs (Go, Node, Python) always drain outstanding registrations and only report errors once the work queue empties; this change brings .NET in line. `AwaitIdleAsync` now waits for `_activeTasks == 0` and returns every collected exception, rather than short-circuiting on the first fault.

Also updates `TerminatesEarlyOnException` (renamed to `DrainsAllTasksBeforeReportingException`), which explicitly encoded the old fail-fast behaviour.