### PR TITLE
Fix codegen for `secret`/`unsecret` of object/tuple literals

### DIFF
--- a/pulumi-language-dotnet/codegen/gen_program_expressions.go
+++ b/pulumi-language-dotnet/codegen/gen_program_expressions.go
@@ -836,9 +836,13 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case "readDir":
 		g.Fgenf(w, "Directory.GetFiles(%.v).Select(Path.GetFileName)", expr.Args[0])
 	case "secret":
-		g.Fgenf(w, "Output.CreateSecret(%v)", expr.Args[0])
+		g.Fgen(w, "Output.CreateSecret(")
+		g.genDictionaryOrTuple(w, expr.Args[0])
+		g.Fgen(w, ")")
 	case "unsecret":
-		g.Fgenf(w, "Output.Unsecret(%v)", expr.Args[0])
+		g.Fgen(w, "Output.Unsecret(")
+		g.genDictionaryOrTuple(w, expr.Args[0])
+		g.Fgen(w, ")")
 	case "split":
 		g.Fgenf(w, "%.20v.Split(%v)", expr.Args[1], expr.Args[0])
 	case "toBase64":


### PR DESCRIPTION
Part of fixing l1-proxy-index.

`GenObjectConsExpression` emits a bare `{ ... }` collection initializer when the argument's type has no schema binding (e.g. the `dynamic` arg to `secret`). That's only valid C# when a parent supplies a `new Type` prefix, which resource-args callers do but intrinsic calls do not.

Route `secret`/`unsecret` args through `genDictionaryOrTuple` (same approach `toJSON` already uses) so object/tuple literals emit a self-contained `new Dictionary<string, object?> { ... }` or `new[] { ... }`.