### PR TITLE
unpin .net 10.0

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJson(needs.setup_matrix.outputs.matrix).os }}
-        dotnet-version: ["8.0", "9.0", "10.0.103"]
+        dotnet-version: ["8.0", "9.0", "10.0"]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -161,7 +161,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        dotnet-version: ["8.0", "9.0", "10.0.103"]
+        dotnet-version: ["8.0", "9.0", "10.0"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Fetch secrets from ESC


### PR DESCRIPTION
We pinned this previously to fix issues in integration tests.  Unpin it to see if a new version of .net fixed the issues.